### PR TITLE
Adding namespaces to Envelope

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -67,6 +67,24 @@ Client.prototype._defineMethod = function(method, location) {
     }
 }
 
+Client.prototype._getxmlns = function(params, nstrack) {
+	var xmlnsAttrib = [];
+	nstrack = nstrack || [];
+	
+	for (var name in params) {
+		var n = name.match(/(^\w+):/);
+		if (n && !nstrack[n[1]]) {
+			xmlnsAttrib.push('xmlns:' + n[1] + '="' + this.wsdl.definitions.xmlns[n[1]] + '"');
+			nstrack[n[1]] = true;
+		}
+		
+		if (typeof(params[name]) != 'string') {
+			xmlnsAttrib.concat(this._getxmlns(params[name],nstrack));
+		}
+	}
+	return xmlnsAttrib;
+}
+
 Client.prototype._invoke = function(method, arguments, location, callback) {
     var self = this,
         name = method.$name,
@@ -99,10 +117,12 @@ Client.prototype._invoke = function(method, arguments, location, callback) {
         assert.ok(!style || style == 'document', 'invalid message definition for rpc style binding');
         message = self.wsdl.objectToDocumentXML(input.$name, arguments);
     }
+
     xml = "<soap:Envelope " + 
             "xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" " +
             encoding +
-            "xmlns:ns0=\""+ns+"\">" +
+			self._getxmlns(arguments).join(' ') +
+            " xmlns:ns0=\""+ns+"\">" +
             "<soap:Header>" +
                 (self.security ? self.security.toXML() : "") +
             "</soap:Header>" +


### PR DESCRIPTION
Hi,

I made this change as I am using node-soap to access Exchange web services. In my case each element in the message needs to be namespaced and there is no overall wrapping element. ie this is for setting the out of office message by calling SetUserOofSettings:

{
        "t:Mailbox": {
            "t:Address": "me@example.com"
        },
        "t:UserOofSettings": {
            "t:OofState": "Disabled",
            "t:ExternalAudience": "All",
            "t:InternalReply": {
                "t:Message": "I have left the building"
            },
            "t:ExternalReply": {
                "t:Message": "How may I help you?"
            }
        }
}

As you can see I have added support for indicating the namespace in the element name which is then pulled from the wsdl into the Envelope. I'm not sure if this is the right way to do this, I'm no expert on SOAP, but you or others might find this useful.

-Mark
