### PR TITLE
Don't fire the callback twice if it throws an error

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -118,11 +118,12 @@ Client.prototype._invoke = function(method, arguments, location, callback) {
         else {
             try {
                 var obj = self.wsdl.xmlToObject(body);
-                callback(null, obj[output.$name], body);
             }
             catch (error) {
                 callback(error, null, body);
+                return;
             }
+            callback(null, obj[output.$name], body);
         }
     }, headers, options);
 }


### PR DESCRIPTION
If the callback throws an error, that's the user's problem. The callback should never be fired twice for the same SOAP call.
