### PR TITLE
Ability to change the way the SOAPAction header is computed

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -25,6 +25,10 @@ Client.prototype.setSecurity = function(security) {
     this.security = security;
 }
 
+Client.prototype.setSOAPAction = function(SOAPAction) {
+    this.SOAPAction = SOAPAction;
+}
+
 Client.prototype._initializeServices = function(endpoint) {
     var definitions = this.wsdl.definitions,
         services = definitions.services;
@@ -79,7 +83,7 @@ Client.prototype._invoke = function(method, arguments, location, callback) {
         message = '',
         xml = null,
         headers = {
-            SOAPAction: ((ns.lastIndexOf("/") != ns.length - 1) ? ns + "/" : ns) + name,
+            SOAPAction: this.SOAPAction ? this.SOAPAction(ns, name) : (((ns.lastIndexOf("/") != ns.length - 1) ? ns + "/" : ns) + name),
             'Content-Type': "text/xml; charset=utf-8"
         },
         options = {};


### PR DESCRIPTION
Hi, I've been using node-soap, thanks for the module, it is very to use.

However, I had an issue due to the way the WebService I use handles the SOAPAction header. Basically, it requires a header of the form "namespace#name", using a # symbol instead of a /.

First, I used the following workaround: 

```
client.setSecurity({
    addHeaders: function(headers) {
        headers.SOAPAction = "My SOAPAction goes here";
    },
    toXML: function() {
        return "";
    }
});
```

but I did not think it was a good solution. So I modified the node-soap call to give the ability to change the way the SOAPAction is computed. Basically, and I can now use the following code, computing the SOAPAction header automatically once and for all.

```
client.setSOAPAction(function(ns, name) {
    return ns.substring(4) + '#' + name;
});
```

Here is a pull request for the corresponding change.

Regards, 

-Alex
