### PR TITLE
Fix Issue #42, support default rpc/literal response naming

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -123,7 +123,13 @@ Client.prototype._invoke = function(method, arguments, location, callback) {
                 callback(error, null, body);
                 return;
             }
-            callback(null, obj[output.$name], body);
+            var result = obj[output.$name];
+            // RPC/literal response body may contain element named after the method + 'Response'
+            // This doesn't necessarily equal the ouput message name. See WSDL 1.1 Section 2.4.5
+            if(!result) {
+               result = obj[name + 'Response'];
+            }
+            callback(null, result, body);
         }
     }, headers, options);
 }

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -557,15 +557,44 @@ WSDL.prototype.xmlToObject = function(xml) {
             top = stack[stack.length-1],
             topSchema = top.schema,
             obj = {};
+        var originalName = name;
 
         if (!objectName && top.name === 'Body' && name !== 'Fault') {
             var message = self.definitions.messages[name];
+            // Support RPC/literal messages where response body contains one element named
+            // after the operation + 'Response'. See http://www.w3.org/TR/wsdl#_names
+            if (!message) {
+               // Determine if this is request or response
+               var isInput = false;
+               var isOutput = false;
+               if ((/Response$/).test(name)) {
+                 isOutput = true;
+                 name = name.replace(/Response$/, '');
+               } else if ((/Request$/).test(name)) {
+                 isInput = true;
+                 name = name.replace(/Request$/, '');
+               } else if ((/Solicit$/).test(name)) {
+                 isInput = true;
+                 name = name.replace(/Solicit$/, '');
+               }
+               // Look up the appropriate message as given in the portType's operations
+               var portTypes = self.definitions.portTypes;
+               var portTypeNames = Object.keys(portTypes);
+               // Currently this supports only one portType definition.
+               var portType = portTypes[portTypeNames[0]];
+               if (isInput) name = portType.methods[name].input.$name;
+               else name = portType.methods[name].output.$name;
+               message = self.definitions.messages[name];
+               // 'cache' this alias to speed future lookups
+               self.definitions.messages[originalName] = self.definitions.messages[name];
+            }
+
             topSchema = message.description(self.definitions);
-            objectName = name;
+            objectName = originalName;
         }
 
         if (topSchema && topSchema[name+'[]']) name = name + '[]';
-        stack.push({name: name, object: obj, schema: topSchema && topSchema[name]});
+        stack.push({name: originalName, object: obj, schema: topSchema && topSchema[name]});
     })
     
     p.on('endElement', function(nsName) {
@@ -574,7 +603,7 @@ WSDL.prototype.xmlToObject = function(xml) {
             topObject = top.object,
             topSchema = top.schema,
             name = splitNSName(nsName).name;
-            
+          
         if (topSchema && topSchema[name+'[]']) {
             if (!topObject[name]) topObject[name] = [];
             topObject[name].push(obj);
@@ -583,7 +612,6 @@ WSDL.prototype.xmlToObject = function(xml) {
             if (!Array.isArray(topObject[name])) {
                 topObject[name] = [topObject[name]];
             }
-            
             topObject[name].push(obj);
         }
         else {


### PR DESCRIPTION
See issue #42. This change supports WSDL definitions where the message names don't necessarily match the default naming convention given in the WSDL 1.1 specification (section 2.4.5) 
