### PR TITLE
Add support for enumeration restrictions on <xsd:simpleType...>

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -134,6 +134,8 @@ var ElementElement = Element.createSubClass();
 var InputElement = Element.createSubClass();
 var OutputElement = Element.createSubClass();
 var SimpleTypeElement = Element.createSubClass();
+var RestrictionElement = Element.createSubClass();
+var EnumerationElement = Element.createSubClass();
 var ComplexTypeElement = Element.createSubClass();
 var SequenceElement = Element.createSubClass();
 var AllElement = Element.createSubClass();
@@ -152,7 +154,9 @@ var ElementTypeMap = {
     types: [TypesElement, 'schema'],
     schema: [SchemaElement, 'element complexType simpleType include import'],
     element: [ElementElement, 'annotation complexType'],
-    simpleType: [SimpleTypeElement, ''],
+    simpleType: [SimpleTypeElement, 'restriction'],
+    restriction: [RestrictionElement, 'enumeration'],
+    enumeration: [EnumerationElement, ''],
     complexType: [ComplexTypeElement,  'annotation sequence all'],
     sequence: [SequenceElement, 'element'],
     all: [AllElement, 'element'],
@@ -439,6 +443,25 @@ ServiceElement.prototype.postProcess = function(definitions) {
     this.deleteFixedAttrs();
 }
 
+SimpleTypeElement.prototype.description = function(definitions) {
+    var children = this.children;
+    for (var i=0, child; child=children[i]; i++) {
+        if (child instanceof RestrictionElement)
+           return this.$name+"|"+child.description();
+    }
+    return {};
+}
+
+RestrictionElement.prototype.description = function() {
+    var base = this.$base ? this.$base+"|" : "";
+    return base + this.children.map( function(child) {
+       return child.description();
+    } ).join(",");
+}
+
+EnumerationElement.prototype.description = function() {
+   return this.$value;
+}
 
 ComplexTypeElement.prototype.description = function(definitions) {
     var children = this.children;
@@ -953,3 +976,5 @@ function open_wsdl(uri, options, callback) {
 
 exports.open_wsdl = open_wsdl;
 exports.WSDL = WSDL;
+
+


### PR DESCRIPTION
For example, this simpleType:

``` xml
<xsd:simpleType name="FrequencyType">
  <xsd:restriction base="xsd:string">
    <xsd:enumeration value="PER_WEEK"/>
    <xsd:enumeration value="PER_MONTH"/>
    <xsd:enumeration value="PER_YEAR"/>
  </xsd:restriction>
</xsd:simpleType>
```

would show up in service description as: `FrequencyType|xsd:string|PER_WEEK,PER_MONTH,PER_YEAR`
