### PR TITLE
Error handling in createClient

### DIFF
--- a/lib/soap.js
+++ b/lib/soap.js
@@ -24,8 +24,11 @@ function _requestWSDL(url, options, callback) {
     }
     else {
         open_wsdl(url, options, function(err, wsdl) {
-            if (!err) _wsdlCache[url] = wsdl;
-            callback(null, wsdl);                                
+            if (err) 
+                return callback(err);
+            else
+                _wsdlCache[url] = wsdl;
+            callback(null, wsdl);
         })
     }
 }


### PR DESCRIPTION
createClient calls _requestWSDL which didn't check if an error was
returned by the open_wsdl function.

To reproduce the issue try accessing a SOAP API that requires HTTPS using HTTP.
