### PR TITLE
WSDL port location parsing issue fixed

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -291,7 +291,7 @@ BindingElement.prototype.addChild = function(child) {
     }
 }
 PortElement.prototype.addChild = function(child) {
-    if (child.name === 'address' && typeof(child.$location) != 'undefined') {
+    if (child.name === 'address' && typeof(child.$location) !== 'undefined') {
        this.location = child.$location;
     }
 }


### PR DESCRIPTION
Consider the following part of a WSDL port section:

``` xml
<port binding="binding" name="service">
    <soap:address location="http://serviceaddress"/>
    <other:address random="service"/>
</port>
```

Before, location was at first set to "http://serviceaddress", which is correct, but later reset to "undefined".
This fix checks if address tag has location or not. In case of two address locations, the latter one is chosen.
