### PR TITLE
Fix for Issue #63

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -291,7 +291,7 @@ BindingElement.prototype.addChild = function(child) {
     }
 }
 PortElement.prototype.addChild = function(child) {
-    if (child.name === 'address') {
+    if (child.name === 'address' && typeof(child.$location) !== 'undefined') {
        this.location = child.$location;
     }
 }


### PR DESCRIPTION
A fix for issue #63, namespace parsing for RPC encoded WSDLs.

Tested with node v0.6.15 on Ubuntu 12.04
