### PR TITLE
Fix handle nested elements lacking namespace declarations..

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -318,6 +318,12 @@ DefinitionsElement.prototype.addChild = function(child) {
     else if (child instanceof ServiceElement) {
         self.services[child.$name] = child;
     }
+     /*
+     * Hack fix for issue https://github.com/milewise/node-soap/issues/57
+     */
+    else if (child.nsName === 'wsdl:documentation') {
+        // Do nothing.
+    }
     else {
         assert(false, "Invalid child type");
     }


### PR DESCRIPTION
When consuming this service (http://gepir.gs1.org/V31/router.asmx?WSDL) i ran into a undefined_method error that appeared to be linked to a missing namespace prefix. This quick-fix solved it for me but may not be the the best solution. 
