### PR TITLE
Namespace should propagate to child nodes and clean up of unused code

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -805,7 +805,7 @@ WSDL.prototype.xmlToObject = function(xml) {
 WSDL.prototype.objectToDocumentXML = function(name, params, ns, xmlns) {
     var args = {};
     args[name] = params;
-    return this.objectToXML(args, null, ns, xmlns);
+    return this.objectToXML(args, null, ns);
 }
 
 WSDL.prototype.objectToRpcXML = function(name, params, namespace, xmlns) {
@@ -829,17 +829,16 @@ WSDL.prototype.objectToRpcXML = function(name, params, namespace, xmlns) {
     return parts.join('');
 }
 
-WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns) {
+WSDL.prototype.objectToXML = function(obj, name, namespace) {
     var self = this,
         parts = [],
-        xmlnsAttrib = false ? ' xmlns:'+namespace+'="'+xmlns+'"'+' xmlns="'+xmlns+'"' : '',
         ns = namespace ? namespace + ':' : '';
     
     if (Array.isArray(obj)) {
         for (var i=0, item; item=obj[i]; i++) {
             if (i > 0) {
                 parts.push(['</',ns,name,'>'].join(''));
-                parts.push(['<',ns,name,xmlnsAttrib,'>'].join(''));
+                parts.push(['<',ns,name,'>'].join(''));
             }
             parts.push(self.objectToXML(item, name, namespace));
         }
@@ -847,7 +846,7 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns) {
     else if (typeof obj === 'object') {
         for (var name in obj) {
             var child = obj[name];
-            parts.push(['<',ns,name,xmlnsAttrib,'>'].join(''));
+            parts.push(['<',ns,name,'>'].join(''));
             parts.push(self.objectToXML(child, name, namespace));
             parts.push(['</',ns,name,'>'].join(''));
         }


### PR DESCRIPTION
I assume it's a bug (I'm unfortunately not that well versed with SOAP to know for sure but it caused my script to not work anyway) that the namespace didn't follow through to child nodes. This pull request fixes that issue. I also noticed some weird code that never gets triggered, which I removed (I assume there ain't no long term purpose of it?).
