### PR TITLE
include only valu in result body when found in SOAP response

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -798,8 +798,8 @@ WSDL.prototype.xmlToObject = function(xml) {
 				href.par[href.key] = obj;
 			});
 		}
-		
-    var body = root.Envelope.Body;
+
+    var body = root.Envelope.Body || (root.Envelope.Body = {});
     if (body.Fault) {
         throw new Error(body.Fault.faultcode+': '+body.Fault.faultstring+(body.Fault.detail ? ': ' + body.Fault.detail : ''));
     }


### PR DESCRIPTION
This patch only includes values in the result body when it has been found in SOAP response.
