### PR TITLE
convert xsd:integer to int

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -768,7 +768,7 @@ WSDL.prototype.xmlToObject = function(xml) {
         var top = stack[stack.length-1];
         var name = splitNSName(top.schema).name,
             value;
-        if (name === 'int') {
+        if (name === 'int' || name === 'integer') {
             value = parseInt(text, 10);
         } else if (name === 'dateTime') {
             value = new Date(text);


### PR DESCRIPTION
This patch coverts xsd:integer to int as it's already done for `int`.
