### PR TITLE
Allow relative files paths for local includes

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -632,7 +632,7 @@ WSDL.prototype._processNextInclude = function(includes, callback) {
     if (!include) return callback()
 
     var includePath;
-    if (!/^http/.test(self.uri)) {
+    if (!/^http/.test(self.uri) && !/^http/.test(include.location)) {
         includePath = path.resolve(path.dirname(self.uri), include.location);
     } else {
         includePath = url.resolve(self.uri, include.location);


### PR DESCRIPTION
This change was necessary to get local file includes working on Windows.
