### PR TITLE
use soapAction from WSDL

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -88,7 +88,7 @@ Client.prototype._invoke = function(method, arguments, location, callback) {
         message = '',
         xml = null,
         headers = {
-            SOAPAction: this.SOAPAction ? this.SOAPAction(ns, name) : (((ns.lastIndexOf("/") != ns.length - 1) ? ns + "/" : ns) + name),
+            SOAPAction: '"' + method.soapAction + '"',
             'Content-Type': "text/xml; charset=utf-8"
         },
         options = {},


### PR DESCRIPTION
I think it's better to use soapAction defined in WSDL, rather than client assumption of its value. Especially since we have it in _method.soapAction_. And double quote it.
