### PR TITLE
Wrap the default SOAPAction header in quotes.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -88,7 +88,7 @@ Client.prototype._invoke = function(method, arguments, location, callback) {
         message = '',
         xml = null,
         headers = {
-            SOAPAction: this.SOAPAction ? this.SOAPAction(ns, name) : (((ns.lastIndexOf("/") != ns.length - 1) ? ns + "/" : ns) + name),
+            SOAPAction: this.SOAPAction ? this.SOAPAction(ns, name) : '"' + (((ns.lastIndexOf("/") != ns.length - 1) ? ns + "/" : ns) + name) + '"',
             'Content-Type': "text/xml; charset=utf-8"
         },
         options = {},


### PR DESCRIPTION
I don't know much about soap... but I've been using your excellent library as a client working against glassfish/metro. It works great except that the glassfish log is spammed with something in the lines of "Received non-conformant unquoted header SOAPAction". I had a quick look in the specs and it seems SOAPAction should always be quoted.
