### PR TITLE
Fixing the documentation tag, which can happen under definitions (as well as other places)

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -141,6 +141,7 @@ var ComplexTypeElement = Element.createSubClass();
 var SequenceElement = Element.createSubClass();
 var AllElement = Element.createSubClass();
 var MessageElement = Element.createSubClass();
+var DocumentationElement = Element.createSubClass();
 
 var SchemaElement = Element.createSubClass();
 var TypesElement = Element.createSubClass();
@@ -152,7 +153,7 @@ var ServiceElement = Element.createSubClass();
 var DefinitionsElement = Element.createSubClass();
 
 var ElementTypeMap = {
-    types: [TypesElement, 'schema'],
+    types: [TypesElement, 'schema documentation'],
     schema: [SchemaElement, 'element complexType simpleType include import'],
     element: [ElementElement, 'annotation complexType'],
     simpleType: [SimpleTypeElement, 'restriction'],
@@ -163,15 +164,16 @@ var ElementTypeMap = {
     all: [AllElement, 'element'],
     
     service: [ServiceElement, 'port documentation'],
-    port: [PortElement, 'address'],
-    binding: [BindingElement, '_binding SecuritySpec operation'],
-    portType: [PortTypeElement, 'operation'],
+    port: [PortElement, 'address documentation'],
+    binding: [BindingElement, '_binding SecuritySpec operation documentation'],
+    portType: [PortTypeElement, 'operation documentation'],
     message: [MessageElement, 'part documentation'],
     operation: [OperationElement, 'documentation input output fault _operation'],
     input : [InputElement, 'body SecuritySpecRef documentation header'],
     output : [OutputElement, 'body SecuritySpecRef documentation header'],
-    fault : [Element, '_fault'],
-    definitions: [DefinitionsElement, 'types message portType binding service']
+    fault : [Element, '_fault documentation'],
+    definitions: [DefinitionsElement, 'types message portType binding service documentation'],
+    documentation: [DocumentationElement, '']
 };
 
 function mapElementTypes(types) {
@@ -231,6 +233,7 @@ DefinitionsElement.prototype.init = function() {
     this.services = {};
     this.schemas = {};
 }
+DocumentationElement.prototype.init = function(){}
 
 SchemaElement.prototype.addChild = function(child) {
     if (child.$name in Primitives) return;
@@ -314,6 +317,8 @@ DefinitionsElement.prototype.addChild = function(child) {
     }
     else if (child instanceof ServiceElement) {
         self.services[child.$name] = child;
+    }
+    else if (child instanceof DocumentationElement) {
     }
     else {
         assert(false, "Invalid child type");


### PR DESCRIPTION
The current code does not support that, thus asserting on valid wsdl file.

http://stackoverflow.com/questions/10042652/which-wsdl-tags-can-have-documentation-tag
