### PR TITLE
Fixed problem with parameter namespaces

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -856,14 +856,14 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns) {
                 parts.push(['</',ns,name,'>'].join(''));
                 parts.push(['<',ns,name,xmlnsAttrib,'>'].join(''));
             }
-            parts.push(self.objectToXML(item, name));
+            parts.push(self.objectToXML(item, name, namespace, xmlns));
         }
     }
     else if (typeof obj === 'object') {
         for (var name in obj) {
             var child = obj[name];
             parts.push(['<',ns,name,xmlnsAttrib,'>'].join(''));
-            parts.push(self.objectToXML(child, name));
+            parts.push(self.objectToXML(child, name, namespace, xmlns));
             parts.push(['</',ns,name,'>'].join(''));
         }
     }


### PR DESCRIPTION
For a call to a server using:

client.GetWeighInData({
  "group": "groupID"
} ... );

the resulting request did not include a namespace for parameters- only methods. e.g. for the namespace 'tns', tns:GetWeighInData/tns:GetWeighInData worked as it should, however the group parameter was <group></group>, not tns:group/tns:group.

The namespace was not being passed to WSDL.prototype.objectToXML() for nested objects.
