### PR TITLE
bug: http request callback fires twice on error

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -45,9 +45,9 @@ exports.request = function(rurl, data, callback, exheaders, exoptions) {
         if (error) {
             callback(error);
         } else {
+            request.on('error', callback);
             callback(null, res, body);
         }
     });
-    request.on('error', callback);
     request.end(data);
 }

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -1,0 +1,14 @@
+var fs = require('fs'),
+    soap = require('..'),
+    assert = require('assert');
+
+module.exports = {
+    'SOAP Client': {
+        'should error on invalid host': function(done) {
+            soap.createClient('http://localhost:1', function(err, client) {
+                assert.ok(err);
+                done();
+            });
+        },        
+    }       
+}


### PR DESCRIPTION
Prevents http connection errors from executing the error
callback two times, and adds a test.
