### PR TITLE
Support of inerhitance and fix for issue #57

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -156,6 +156,16 @@ An instance of Client is passed to the soap.createClient callback.  It is used t
 
 ### Client.*lastRequest* - the property that contains last full soap request for client logging
 
+### Client: allow using custom attributes, for instance for inheritance
+
+A complex type that inherits from another complex type can be declared like this:
+
+``` javascript
+  {productId:{
+       '@':{'xmlns:xsi':'http://www.w3.org/2001/XMLSchema-instance','xsi:type':'{namespace}SubscriptionIdS'},
+       subscriptionId:12345
+  }
+```
 ## WSSecurity
 
 WSSecurity implements WS-Security.  UsernameToken and PasswordText/PasswordDigest is supported. An instance of WSSecurity is passed to Client.setSecurity.

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -150,6 +150,7 @@ var BindingElement = Element.createSubClass();
 var PortElement = Element.createSubClass();
 var ServiceElement = Element.createSubClass();
 var DefinitionsElement = Element.createSubClass();
+var DocumentationElement = Element.createSubClass();
 
 var ElementTypeMap = {
     types: [TypesElement, 'schema'],
@@ -171,7 +172,8 @@ var ElementTypeMap = {
     input : [InputElement, 'body SecuritySpecRef documentation header'],
     output : [OutputElement, 'body SecuritySpecRef documentation header'],
     fault : [Element, '_fault'],
-    definitions: [DefinitionsElement, 'types message portType binding service']
+    definitions: [DefinitionsElement, 'types message portType binding service'],
+    documentation: [DocumentationElement, '']
 };
 
 function mapElementTypes(types) {
@@ -315,7 +317,7 @@ DefinitionsElement.prototype.addChild = function(child) {
     else if (child instanceof ServiceElement) {
         self.services[child.$name] = child;
     }
-    else {
+    else if (! child instanceof DocumentationElement) {
         assert(false, "Invalid child type");
     }
     this.children.pop();
@@ -862,8 +864,17 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first) {
     }
     else if (typeof obj === 'object') {
         for (var name in obj) {
-            var child = obj[name];
-            parts.push(['<',ns,name,xmlnsAttrib,'>'].join(''));
+            var tag=['<',ns,name,xmlnsAttrib];
+            var child = obj[name], attr=child['@'];
+            if(attr){
+                for (var a in attr) {
+                    attr[a] = attr[a].replace("{namespace}",ns);
+                    tag.push(' ',a,'="',attr[a],'"');
+                }
+                delete child['@'];
+            }
+            tag.push('>');
+            parts.push(tag.join(''));
             parts.push(self.objectToXML(child, name, namespace, xmlns));
             parts.push(['</',ns,name,'>'].join(''));
         }
@@ -996,5 +1007,3 @@ function open_wsdl(uri, options, callback) {
 
 exports.open_wsdl = open_wsdl;
 exports.WSDL = WSDL;
-
-


### PR DESCRIPTION
I changed wsdl.js. This allows me now to use soap-node for a specific service.


Changes are:

Enabling complex types that inherit from / extend other complex types. For example: http://www.ibm.com/developerworks/websphere/techjournal/0401_brown/brown.html

Such attributes can be defined in request this way:
{productId:{
       '@':{'xmlns:xsi':'http://www.w3.org/2001/XMLSchema-instance','xsi:type':'{namespace}SubscriptionIdS'},
       subscriptionId:12345
 }

Also fixed "AssertionError: Invalid child type" on documentation node as described in 
https://github.com/milewise/node-soap/issues/57


modifications partially copied from this fork https://github.com/MauriceSchoenmakers/node-soap

