### PR TITLE
better implementation of request headers customization via header decorators

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -16,6 +16,11 @@ var Client = function(wsdl, endpoint) {
     this._initializeServices(endpoint);
 }
 
+Client.prototype.addHeaderDecorator = function(decorator) {
+    this.decorators = this.decorators || [];
+    this.decorators.push(decorator);
+}
+
 Client.prototype.addSoapHeader = function(soapHeader, name, namespace, xmlns) {
 	if(!this.soapHeaders){
 		this.soapHeaders = [];
@@ -103,8 +108,14 @@ Client.prototype._invoke = function(method, arguments, location, callback) {
             'Content-Type': "text/xml; charset=utf-8"
         },
         options = {},
-        alias = findKey(defs.xmlns, ns);
-    
+        alias = findKey(defs.xmlns, ns),
+        decors = this.decorators || [];
+
+    // update headers
+    for (var i=0; i<decors.length; i++) {
+        decors[i](headers, method, arguments, location);
+    }    
+
     // Allow the security object to add headers
     if (self.security && self.security.addHeaders)
         self.security.addHeaders(headers);


### PR DESCRIPTION
Example:

soap.createClient(url, {}, function(err, client) {

```
    // tune the client to allow adding more headers, since the original doesn't support it

    client.addHeaderDecorator(function(headers, method, args, location) {
        headers['heade-key'] = 'header value;
    });
```
