### PR TITLE
Added additional XML mime type.

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -17,7 +17,7 @@ exports.request = function(rurl, data, callback, exheaders, exoptions) {
     var method = data ? "POST" : "GET";
     var headers = {
         "User-Agent": "node-soap/" + VERSION,
-        "Accept" : "text/html,application/xhtml+xml,application/xml",
+        "Accept" : "text/html,application/xhtml+xml,application/xml,text/xml",
         "Accept-Encoding": "none",
         "Accept-Charset": "utf-8",
         "Connection": "close",

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -986,7 +986,7 @@ function open_wsdl(uri, options, callback) {
                 wsdl.onReady(callback);
             }
             else {
-                callback(new Error('Invalid WSDL URL: '+uri))
+                callback(new Error('Invalid WSDL URL: '+uri + "\n\n\r Code: "+ response.statusCode + "\n\n\r Response Body: " + response.body));
             }
         });   
     }    


### PR DESCRIPTION
Missing "text/xml" mime type, which this particular soap service I'm currently working with is sending back.  

I also Included server response code and response body in the returned error, as the "Invalid WSDL URL..." response in open_wsdl was sort of lacking useful information from the actual response.

Thanks for the great module! 
