### PR TITLE
[#159] Pass custom options and headers for WSDL requests

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -964,6 +964,11 @@ function open_wsdl(uri, options, callback) {
         options = {};
     }
 
+    request_headers = options.wsdl_headers;
+    delete options.wsdl_headers;
+    request_options = options.wsdl_options;
+    delete options.wsdl_options;
+
     var wsdl;
     if (!/^http/.test(uri)) {
         fs.readFile(uri, 'utf8',  function (err, definition) {
@@ -988,7 +993,7 @@ function open_wsdl(uri, options, callback) {
             else {
                 callback(new Error('Invalid WSDL URL: '+uri))
             }
-        });   
+        }, request_headers, request_options);
     }    
 
     return wsdl;


### PR DESCRIPTION
Greetings,
This allows custom headers and options to be passed as part of the `createClient` call.  For example:

``` coffeescript
soap.createClient wsdl_url, { 'endpoint': endpoint, wsdl_options: { strictSSL: false } }, cb
```

This passes `wsdl_options` and `wsdl_headers` down to the `open_wsdl` call, which removes them before passing them on, to be safe.

--  Morgan
