### PR TITLE
WSDL only maps to array when maxOccurs is greater than one.

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -483,8 +483,8 @@ ElementElement.prototype.description = function(definitions) {
     var element = {},
         name = this.$name,
         schema;
-    var isMany = !this.$maxOccurs ? false : (isNaN(this.$maxOccurs) ? (this.$maxOccurs == 'unbounded') : (this.$maxOccurs > 1));
-    if (this.$minOccurs !== this.$maxOccurs && isMany) {
+    var maxOccurs = this.$maxOccurs || 1;
+    if ((isNaN(maxOccurs) && maxOccurs == 'unbounded') || maxOccurs > 1) {
         name += '[]';
     }
     


### PR DESCRIPTION
Only when attribute maxOccurs is greater than one the object must be mapped to array.
