### PR TITLE
Fixed issue with MultiRef Arrays

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -805,7 +805,6 @@ WSDL.prototype.xmlToObject = function(xml) {
 
     // merge obj with href
     var merge = function(href, obj) {
-      console.log('merging');
       for (var j in obj) {
         if (obj.hasOwnProperty(j)) {
           href.obj[j] = obj[j];


### PR DESCRIPTION
Fixed an issue with the latest implementation of MultiRef responses. (WSDL.xmlToObject)
The parsing of the following block was not returning an array as expected.

&lt;entryList soapenc:arrayType="ns2:TableEntry[49]" xsi:type="soapenc:Array">
    &lt;entryList href="#id1"/>
    &lt;entryList href="#id2"/>
    &lt;entryList href="#id3"/>
    ...

Arnaud
