### PR TITLE
Update soap.js WSSecurity to use toISOString method on dates

### DIFF
--- a/lib/soap.js
+++ b/lib/soap.js
@@ -76,8 +76,8 @@ BasicAuthSecurity.prototype.toXML = function() {
 }
 
 function ClientSSLSecurity(keyPath, certPath) {
-    this.key  =  fs.readFileSync(keyPath);
-    this.cert =  fs.readFileSync(certPath);
+    this.key  =  keyPath instanceof Buffer ? keyPath : fs.readFileSync(keyPath);
+    this.cert =  certPath instanceof Buffer ? fs.readFileSync(certPath);
 }
 
 ClientSSLSecurity.prototype.toXML = function (headers) {

--- a/lib/soap.js
+++ b/lib/soap.js
@@ -106,19 +106,9 @@ var passwordDigest = function(nonce, created, password) {
 }
 
 WSSecurity.prototype.toXML = function() {
-    // avoid dependency on date formatting libraries
-    function getDate(d) {
-        function pad(n){return n<10 ? '0'+n : n}
-        return d.getUTCFullYear()+'-'
-            + pad(d.getUTCMonth()+1)+'-'
-            + pad(d.getUTCDate())+'T'
-            + pad(d.getUTCHours())+':'
-            + pad(d.getUTCMinutes())+':'
-            + pad(d.getUTCSeconds())+'Z';
-    }
     var now = new Date();
-    var created = getDate( now );
-    var expires = getDate( new Date(now.getTime() + (1000 * 600)) );
+    var created = now.toISOString();
+    var expires = new Date(now.getTime() + (1000 * 600)).toISOString();
 
     // nonce = base64 ( sha1 ( created + random ) )
     var nHash = crypto.createHash('sha1');


### PR DESCRIPTION
Date.prototype.toISOString() is available in the node.js execution environment and should be used in favor of the formatting method that was used.