### PR TITLE
Default namespace elements

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -21,7 +21,7 @@ exports.request = function(rurl, data, callback, exheaders, exoptions) {
         "Accept-Encoding": "none",
         "Accept-Charset": "utf-8",
         "Connection": "close",
-        "Host" : host
+        "Host" : host+':'+port
     };
 
     if (typeof data == 'string') {

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -22,7 +22,7 @@ var Primitives = {
 
 function splitNSName(nsName) {
     var i = (nsName != null) ? nsName.indexOf(':') : -1;
-    return i < 0 ? {namespace:null,name:nsName} : {namespace:nsName.substring(0, i), name:nsName.substring(i+1)};
+    return i < 0 ? {namespace:'xmlns',name:nsName} : {namespace:nsName.substring(0, i), name:nsName.substring(i+1)};
 }
 
 function xmlEscape(obj) {
@@ -69,7 +69,7 @@ var Element = function(nsName, attrs) {
     for (var key in attrs) {
         var match = /^xmlns:?(.*)$/.exec(key);
         if (match) {
-            this.xmlns[match[1]] = attrs[key];
+            this.xmlns[match[1]?match[1]:'xmlns'] = attrs[key];
         }
         else {
             this['$'+key] = attrs[key];        
@@ -845,8 +845,9 @@ WSDL.prototype.objectToRpcXML = function(name, params, namespace, xmlns) {
         defs = this.definitions,
         namespace = namespace || findKey(defs.xmlns, xmlns),
         xmlns = xmlns || defs.xmlns[namespace],
+        namespace = namespace == 'xmlns'?'':namespace+':',
         nsAttrName = '_xmlns';
-    parts.push(['<',namespace,':',name,'>'].join(''));
+    parts.push(['<',namespace,name,'>'].join(''));
     for (var key in params) {
         if (key != nsAttrName) {
             var value = params[key];
@@ -855,7 +856,7 @@ WSDL.prototype.objectToRpcXML = function(name, params, namespace, xmlns) {
             parts.push(['</',key,'>'].join(''));
         }
     }
-    parts.push(['</',namespace,':',name,'>'].join(''));
+    parts.push(['</',namespace,name,'>'].join(''));
 
     return parts.join('');
 }
@@ -863,8 +864,8 @@ WSDL.prototype.objectToRpcXML = function(name, params, namespace, xmlns) {
 WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first) {
     var self = this,
         parts = [],
-        xmlnsAttrib = first ? ' xmlns:'+namespace+'="'+xmlns+'"'+' xmlns="'+xmlns+'"' : '',
-        ns = namespace ? namespace + ':' : '';
+        xmlnsAttrib = first ? ((namespace!='xmlns'?' xmlns:'+namespace+'="'+xmlns+'"':'')+' xmlns="'+xmlns+'"') : '',
+        ns = namespace && namespace!='xmlns'? namespace + ':' : '';
     
     if (Array.isArray(obj)) {
         for (var i=0, item; item=obj[i]; i++) {
@@ -955,7 +956,7 @@ WSDL.prototype._xmlnsMap = function() {
     var xmlns = this.definitions.xmlns;
     var str = '';
     for (var alias in xmlns) {
-        if (alias === '') continue;
+        if (alias === '' || alias == 'xmlns') continue;
         var ns = xmlns[alias];
         switch(ns) {
             case "http://xml.apache.org/xml-soap" : // apachesoap


### PR DESCRIPTION
Modified http.js to add port number to host header. WSDL made on the fly, depends on this to correctly define port address location.

Modified wsdl.js to be able to call elements defined in default namespace (xmlns="http://default.namespace") that have no namespace alias, and are in targetNameSpace (targetNameSpace == default namespace)

for example

<pre>
&lt;wsdl:definitions targetNameSpace="http://my.namespace.com" xmlns="http://my.namespace.com"&gt;
    &lt;wsdl:types&gt;
        &lt;xs:schema targetNameSpace="http://my.namespace.com"&gt;
            &lt;xs:element name="myelement"/&gt;
        &lt;/xs:schema&gt;
    &lt;/wsdl:types&gt;
    &lt;wsdl:message name="message1"&gt;
        &lt;wsdl:part name="msg1" element="myelement"/&gt;
    &lt;/wsdl:message&gt;
&lt;/wsdl:definitions&gt;
</pre>


When wsdl.js post processed part tag it threw an exception, because it expected an element name of the kind "tns:myelement"
