### PR TITLE
Invoking operations to a Microsoft WCF services was failing when the request has a complex type.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -20,8 +20,10 @@ Client.prototype.addSoapHeader = function(soapHeader, name, namespace, xmlns) {
 	if(!this.soapHeaders){
 		this.soapHeaders = [];
 	}
+
+    var schema = self.wsdl.definitions.schemas[xmlns]; 
 	if(typeof soapHeader == 'object'){
-		soapHeader = this.wsdl.objectToXML(soapHeader, name, namespace, xmlns);
+		soapHeader = this.wsdl.objectToXML(soapHeader, name, schema);
 	}
 	this.soapHeaders.push(soapHeader);
 }
@@ -112,7 +114,7 @@ Client.prototype._invoke = function(method, arguments, location, callback, optio
         self.security.addOptions(options);
         
     if (input.parts) {
-        assert.ok(!style || style == 'rpc', 'invalid message definition for document style binding');
+        assert(!style || style == 'rpc', 'invalid message definition for document style binding');
         message = self.wsdl.objectToRpcXML(name, arguments, alias, ns);
         (method.inputSoap === 'encoded') && (encoding = 'soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" ');
     }
@@ -120,8 +122,9 @@ Client.prototype._invoke = function(method, arguments, location, callback, optio
       message = arguments;
     }
     else {
-        assert.ok(!style || style == 'document', 'invalid message definition for rpc style binding');
-        message = self.wsdl.objectToDocumentXML(input.$name, arguments, input.targetNSAlias, input.targetNamespace);
+        assert(!style || style == 'document', 'invalid message definition for rpc style binding');
+        var schema = self.wsdl.definitions.schemas[input.targetNamespace];
+        message = self.wsdl.objectToDocumentXML(input, arguments, schema);
     }
     xml = "<soap:Envelope " + 
             "xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" " +
@@ -135,10 +138,11 @@ Client.prototype._invoke = function(method, arguments, location, callback, optio
                 message +
             "</soap:Body>" +
         "</soap:Envelope>";
-    
-	self.lastRequest = xml;
-	
+
+    self.lastRequest = xml;	
+
     http.request(location, xml, function(err, response, body) {
+
         self.lastResponse = body;
         if (err) {
             callback(err);

--- a/lib/server.js
+++ b/lib/server.js
@@ -187,6 +187,7 @@ Server.prototype._process = function(input, URL, callback) {
 }
 
 Server.prototype._executeMethod = function(options, callback) {
+
     options = options || {};
     var self = this,
         method, body,
@@ -205,6 +206,7 @@ Server.prototype._executeMethod = function(options, callback) {
     }
 
     function handleResult(result) {
+
         if (handled) return;
         handled = true;
 
@@ -212,7 +214,9 @@ Server.prototype._executeMethod = function(options, callback) {
             body = self.wsdl.objectToRpcXML(outputName, result, '', self.wsdl.definitions.$targetNamespace);
         } else {
             var element = self.wsdl.definitions.services[serviceName].ports[portName].binding.methods[methodName].output;
-            body = self.wsdl.objectToDocumentXML(outputName, result, element.targetNSAlias, element.targetNamespace);
+            var ns = element.targetNamespace || self.wsdl.definitions.$targetNamespace;
+            var schema = self.wsdl.definitions.schemas[ns];
+            body = self.wsdl.objectToDocumentXML(element, result, schema);
         }
         callback(self._envelope(body));
     }

--- a/lib/soap.js
+++ b/lib/soap.js
@@ -11,7 +11,6 @@ var Client = require('./client').Client,
     https = require('https'),
     fs = require('fs');
 
-var WSDL = require('./wsdl').WSDL;
 var _wsdlCache = {};
 
 function _requestWSDL(url, options, callback) {

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -569,12 +569,14 @@ ServiceElement.prototype.description = function(definitions) {
 
 
 var WSDL = function(definition, uri, options) {
+
     var self = this,
         fromFunc;
 
     this.uri = uri;
     this.callback = function() {};
     this.options = options || {};
+    this._serializer = new Serializer(this);
 
     if (typeof definition === 'string') {
         fromFunc = this._fromXML;
@@ -635,7 +637,7 @@ WSDL.prototype._processNextInclude = function(includes, callback) {
     var self = this,
         include = includes.shift();
 
-    if (!include) return callback()
+    if (!include) return callback();
 
     var includePath;
     if (!/^http/.test(self.uri) && !/^http/.test(include.location)) {
@@ -643,6 +645,7 @@ WSDL.prototype._processNextInclude = function(includes, callback) {
     } else {
         includePath = url.resolve(self.uri, include.location);
     }
+
 
     open_wsdl(includePath, function(err, wsdl) {
         if (err) {
@@ -739,15 +742,15 @@ WSDL.prototype.xmlToObject = function(xml) {
             topSchema = message.description(self.definitions);
             objectName = originalName;
         }
-				
-				if(attrs.href) {
-					id = attrs.href.substr(1);
-					if(!refs[id]) refs[id] = {hrefs:[],obj:null};
-					refs[id].hrefs.push({par:top.object,key:name,obj:obj});
-				}
-				if(id=attrs.id) {
-					if(!refs[id]) refs[id] = {hrefs:[],obj:null};
-				}
+		
+		if(attrs.href) {
+			id = attrs.href.substr(1);
+			if(!refs[id]) refs[id] = {hrefs:[],obj:null};
+			refs[id].hrefs.push({par:top.object,key:name,obj:obj});
+		}
+		if(id=attrs.id) {
+			if(!refs[id]) refs[id] = {hrefs:[],obj:null};
+		}
 
         if (topSchema && topSchema[name+'[]']) name = name + '[]';
         stack.push({name: originalName, object: obj, schema: topSchema && topSchema[name], id:attrs.id});
@@ -833,10 +836,8 @@ WSDL.prototype.xmlToObject = function(xml) {
     return root.Envelope;
 }
 
-WSDL.prototype.objectToDocumentXML = function(name, params, ns, xmlns) {
-    var args = {};
-    args[name] = params;
-    return this.objectToXML(args, null, ns, xmlns, true);
+WSDL.prototype.objectToDocumentXML = function(element, params, schema) {
+    return this.objectToXML(element, params, schema);
 }
 
 WSDL.prototype.objectToRpcXML = function(name, params, namespace, xmlns) {
@@ -851,7 +852,7 @@ WSDL.prototype.objectToRpcXML = function(name, params, namespace, xmlns) {
         if (key != nsAttrName) {
             var value = params[key];
             parts.push(['<',key,'>'].join(''));
-            parts.push((typeof value==='object')?this.objectToXML(value):xmlEscape(value));            
+            parts.push((typeof value==='object')?this.objectToXML(value):xmlEscape(value));
             parts.push(['</',key,'>'].join(''));
         }
     }
@@ -860,34 +861,9 @@ WSDL.prototype.objectToRpcXML = function(name, params, namespace, xmlns) {
     return parts.join('');
 }
 
-WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first) {
-    var self = this,
-        parts = [],
-        xmlnsAttrib = first ? ' xmlns:'+namespace+'="'+xmlns+'"'+' xmlns="'+xmlns+'"' : '',
-        ns = namespace ? namespace + ':' : '';
-    
-    if (Array.isArray(obj)) {
-        for (var i=0, item; item=obj[i]; i++) {
-            if (i > 0) {
-                parts.push(['</',ns,name,'>'].join(''));
-                parts.push(['<',ns,name,xmlnsAttrib,'>'].join(''));
-            }
-            parts.push(self.objectToXML(item, name, namespace, xmlns));
-        }
-    }
-    else if (typeof obj === 'object') {
-        for (var name in obj) {
-            var child = obj[name];
-            parts.push(['<',ns,name,xmlnsAttrib,'>'].join(''));
-            parts.push(self.objectToXML(child, name, namespace, xmlns));
-            parts.push(['</',ns,name,'>'].join(''));
-        }
-    }
-    else if (obj !== undefined) {
-        parts.push(xmlEscape(obj));
-    }
-    return parts.join('');
-}
+WSDL.prototype.objectToXML = function(element, obj, schema) {
+    return this._serializer.serialize(element, obj, schema);
+};
 
 WSDL.prototype._parse = function(xml)
 {
@@ -934,6 +910,7 @@ WSDL.prototype._parse = function(xml)
     })
     
     if (!p.parse(xml, false)) {
+        
         throw new Error(p.getError());
     }
     
@@ -948,8 +925,6 @@ WSDL.prototype._fromXML = function(xml) {
 WSDL.prototype._fromServices = function(services) {
        
 }
-
-
 
 WSDL.prototype._xmlnsMap = function() {
     var xmlns = this.definitions.xmlns;
@@ -1013,6 +988,143 @@ function open_wsdl(uri, options, callback) {
 
     return wsdl;
 }
+
+// Serialize an object to an XML string
+var Serializer = function (wsdl) {
+
+    var self    = this; // Auto reference
+    var parts   = [];   // serialization's buffer 
+    var xmlns   = [];   // namespaces' stack
+    
+    // RegExp for all  XmlSchema versions
+    var xmlSchemas  = new RegExp('http://www.w3.org/.+/xmlschema', 'i');
+
+    // Main method
+    // element: target XML definition
+    // obj: Source data
+    // schema: element's schema
+    this.serialize = function(element, obj, schema) {
+        parts = [];
+        xmlns = [];
+        self[element.name](element, obj, element.targetNSAlias, schema);
+        return parts.join("");
+    };
+
+
+    // Serialize an element
+    // element: target XML definition
+    // obj: Source data
+    // alias: current namespace's alias
+    // schema: element's schema
+    this.element = function(element, obj, alias, schema) {
+
+        // does the namespace change?
+        var ns = xmlns[xmlns.length - 1] || { };
+        var attr = "";
+        if (schema["$targetNamespace"] !== ns.namespace) {
+            // sets new namespace
+            ns = {
+                alias: alias,
+                namespace: schema["$targetNamespace"]
+            };
+            attr = ' xmlns:' + alias + '="' + ns.namespace + '"';
+        }
+        // Adds namespace to the stack
+        xmlns.push(ns);
+
+        // Adds start element
+        var elemName = (ns.alias ? ns.alias + ":"  : "") + element["$name"];
+        parts.push("<" + elemName + attr + ">");
+
+        if (element.children && element.children.length>0) {
+    
+            // If the element is defined by its children, then process all children
+            element.children.forEach(function(child) { self[child.name](child, obj, alias, schema); });
+
+        } else if (element['$type']) {
+
+            // gets element's namespace alias and name,
+            var index = element['$type'].indexOf(":");
+            var typeAlias   = index===-1 ? (element.namespace || ns.alias) : element['$type'].substring(0, index);
+            var typeName    = index===-1 ? element['$type'] : element['$type'].substring(index + 1);
+            var namespace   = element.xmlns[typeAlias] || schema.xmlns[typeAlias] || wsdl.definitions.xmlns[typeAlias];
+
+            // Checks schema
+            if (xmlSchemas.test(namespace)) { 
+
+                // Plain serialization for XmlSchema's type
+                parts.push(xmlEscape(obj));
+            
+            } else if (typeAlias === 'tns') {
+            
+                // 'tns' means current schema. Searchs the type withing the current schema. 
+                var complexType = schema.complexTypes[typeName];
+                complexType.children.forEach(function(child) { self[child.name](child, obj, alias, schema); });
+            
+            } else {
+                
+                // Searchs for the new schema.
+                var newSchema = wsdl.definitions.schemas[namespace];
+                var complexType = newSchema.complexTypes[typeName];
+                complexType.children.forEach(function(child) { self[child.name](child, obj, typeAlias, newSchema); });
+            }
+
+        } else {
+
+            // Invalid element definition.
+            assert(false, "element not supported");
+        }
+
+        // Adds end element
+        parts.push("</" + elemName + ">");            
+        
+        // Removes namespace from the stack
+        xmlns.pop();
+    };
+
+    // Serialize a complexType
+    // element: target complexType
+    // obj: Source data
+    // alias: current namespace's alias
+    // schema: element's schema
+    this.complexType = function(element, obj, alias, schema) {
+        assert(element.children && element.children.length>0, "complexType wihtout children");
+        element.children.forEach(function(child) { self[child.name](child, obj, alias, schema); });
+    },
+
+    // Serialize a sequence
+    // element: target XML definition
+    // obj: Source data
+    // alias: current namespace's alias
+    // schema: element's schema
+    this.sequence = function(element, obj, alias, schema) {
+        var name = element["$name"];
+
+        if (obj instanceof Array) {
+            var child = element.children[0];
+            obj.forEach(function(item){ self[child.name](child, item, alias, schema); });
+        } else {
+            assert(obj && typeof obj === "object", "Unknown sequence type.");
+            element.children.forEach(function(child) {
+
+                var name = child["$name"];
+                var data = name ? obj[name] : obj;
+                if ((data===null || data===undefined)  && child["$nillable"] !== 'true') {
+                    throw new Error("'" + name + "' property is required");
+                }
+
+                self[child.name](child, data, alias, schema);
+            });
+        }
+    };
+
+    // Serialize an all (same as sequence)
+    // element: target XML definition
+    // obj: Source data
+    // alias: current namespace's alias
+    // schema: element's schema
+    this.all = this.sequence;
+};
 
 exports.open_wsdl = open_wsdl;
 exports.WSDL = WSDL;

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -989,6 +989,8 @@ function open_wsdl(uri, options, callback) {
     return wsdl;
 }
 
+var s = function(a) { return JSON.stringify(a, null, "  "); };
+
 // Serialize an object to an XML string
 var Serializer = function (wsdl) {
 
@@ -1009,7 +1011,6 @@ var Serializer = function (wsdl) {
         self[element.name](element, obj, element.targetNSAlias, schema);
         return parts.join("");
     };
-
 
     // Serialize an element
     // element: target XML definition
@@ -1088,8 +1089,8 @@ var Serializer = function (wsdl) {
     // alias: current namespace's alias
     // schema: element's schema
     this.complexType = function(element, obj, alias, schema) {
-        assert(element.children && element.children.length>0, "complexType wihtout children");
-        element.children.forEach(function(child) { self[child.name](child, obj, alias, schema); });
+        if(element.children && element.children.length>0)
+            element.children.forEach(function(child) { self[child.name](child, obj, alias, schema); });
     },
 
     // Serialize a sequence

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -3,7 +3,7 @@
  * MIT Licensed
  */
 
-var expat = require('node-expat'),
+var sax = require('sax'),
     inherits = require('util').inherits,
     http = require('./http'),
     fs = require('fs'),
@@ -686,7 +686,7 @@ WSDL.prototype.toXML = function() {
 
 WSDL.prototype.xmlToObject = function(xml) {
     var self = this,
-        p = new expat.Parser('UTF-8'),
+        p = new sax.parser(true, { trim: true }),
         objectName = null,
         root = {},
         schema = { 
@@ -702,8 +702,10 @@ WSDL.prototype.xmlToObject = function(xml) {
    
     var refs = {}, id; // {id:{hrefs:[],obj:}, ...}
 
-    p.on('startElement', function(nsName, attrs) {
-        var name = splitNSName(nsName).name,
+    p.onopentag = function(tag) {
+        var nsName = tag.name,
+            attrs = tag.attributes,
+            name = splitNSName(nsName).name,
             top = stack[stack.length-1],
             topSchema = top.schema,
             obj = {};
@@ -754,9 +756,9 @@ WSDL.prototype.xmlToObject = function(xml) {
 
         if (topSchema && topSchema[name+'[]']) name = name + '[]';
         stack.push({name: originalName, object: obj, schema: topSchema && topSchema[name], id:attrs.id});
-    })
+    };
     
-    p.on('endElement', function(nsName) {
+    p.onclosetag = function(nsName) {
         var cur = stack.pop(),
 						obj = cur.object,
             top = stack[stack.length-1],
@@ -781,10 +783,9 @@ WSDL.prototype.xmlToObject = function(xml) {
 				if(cur.id) {			
 					refs[cur.id].obj = obj;
 				}
-    })
+    };
     
-    p.on('text', function(text) {
-        text = trim(text);
+    p.ontext = function(text) {
         if (!text.length) return;
 
         var top = stack[stack.length-1];
@@ -805,11 +806,9 @@ WSDL.prototype.xmlToObject = function(xml) {
             }
         }
         top.object = value;
-    });
-        
-    if (!p.parse(xml, false)) {
-        throw new Error(p.getError());
-    }
+    };
+    
+    p.write(xml).close();
 
     // merge obj with href
     var merge = function(href, obj) {
@@ -868,12 +867,15 @@ WSDL.prototype.objectToXML = function(element, obj, schema) {
 WSDL.prototype._parse = function(xml)
 {
     var self = this,
-        p = new expat.Parser('UTF-8'),
+        p = sax.parser(true, { trim: true }),
         stack = [],
         root = null;
     
-    p.on('startElement', function(nsName, attrs) {
-        var top = stack[stack.length - 1];
+    p.onopentag = function(tag) {
+        var nsName = tag.name,
+            attrs = tag.attributes,
+            top = stack[stack.length - 1];
+        
         if (top) {
             try {
                 top.startElement(stack, nsName, attrs);
@@ -900,19 +902,16 @@ WSDL.prototype._parse = function(xml)
             }
             stack.push(root);
         }
-    })
+    };
     
-    p.on('endElement', function(name) {
+    p.onclosetag = function(name) {
         var top = stack[stack.length - 1];
         assert(top, 'Unmatched close tag: ' + name);
 
         top.endElement(stack, name);
-    })
+    };
     
-    if (!p.parse(xml, false)) {
-        
-        throw new Error(p.getError());
-    }
+    p.write(xml).close();
     
     return root;
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "engines": { "node": ">=0.8.0" },
     "author": "Vinay Pulim <v@pulim.com>",
     "dependencies": {
-        "node-expat": ">=1.6.1",
+        "sax": "0.5.5",
         "request": ">=2.9.0"
     },
     "repository" : { 


### PR DESCRIPTION
Requests to a WCF service fail if the request contains a complex type because the method "WSDL.objectToXml" serializes complex types incorrectly.
I modified the the method in order to fix this issue.
