### PR TITLE
Added lastResponseHeaders

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -140,6 +140,7 @@ Client.prototype._invoke = function(method, arguments, location, callback, optio
 	
     http.request(location, xml, function(err, response, body) {
         self.lastResponse = body;
+        self.lastResponseHeaders = response.headers;
         if (err) {
             callback(err);
         }


### PR DESCRIPTION
There is often need to extract cookies from a successful SOAP invocaton. Now I have to patch node-soap to do it. This pull request fixes (or at least much eleviates) issue 137 also, it is not only me who need access to HTTP headers of the last request.
