### PR TITLE
remove assert for unexpected element

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -321,7 +321,7 @@ DefinitionsElement.prototype.addChild = function(child) {
     else if (child instanceof DocumentationElement) {
     }
     else {
-        assert(false, "Invalid child type");
+        console.warn("Warning: Invalid child type - '" + child.nsName + "' identified as UNKNOWN!\n");
     }
     this.children.pop();
 }


### PR DESCRIPTION
This a `assert` prevents any code to read and parse a XML little different from expected, for example: with elements like `wsdl:documentation` or `plnk:partnerLinks`,...

Theres a dedicated issued for that: #57

A *warning* should be a more well suited solution...