### PR TITLE
Add support for setting xml attributes in JSON

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -865,8 +865,10 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first) {
         parts = [],
         xmlnsAttrib = first ? ' xmlns:'+namespace+'="'+xmlns+'"'+' xmlns="'+xmlns+'"' : '',
         ns = namespace ? namespace + ':' : '',
-        attributes = [];
+        attributes = [],
+        attrIdentifier = '$';
 
+    //This method parses all elements in the attributes array and returns a string with all the attributes
     var getAttributes = function(attribs, child){
         var result = '';
         attribs.forEach(function(element, index, array){
@@ -886,12 +888,15 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first) {
     }
     else if (typeof obj === 'object') {
         for (var name in obj) {
-            if (name[0] !== '_') {
+            //Ignore all elements that begin with the attrIdentifier
+            if (name[0] !== attrIdentifier){
                 var child = obj[name];
+                //If child is an object
                 if (typeof child === "object") {
+                    //parse all keys and search for attrIdentifier in the first char
                     for (var keyName in child) {
-                        if (keyName[0] === '_')
-                            attributes.push(keyName);
+                        if (keyName[0] === attrIdentifier)
+                            attributes.push(keyName); //add to the attributes array if it has the identifier
                     }
                 }
                 parts.push(['<', ns, name, xmlnsAttrib, getAttributes(attributes, child), '>'].join(''));


### PR DESCRIPTION
I implemented support for setting xml attributes within an object passed as args to a service. I could not find any way to do this currently. xml2js does this by using an attribute identifier ('$' by default). I implemented this in the ObjectToXML method of wsdl.js and thought other people might find it useful.
