### PR TITLE
Optionally use funcback pattern if callback is omitted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+/.project

--- a/lib/client.js
+++ b/lib/client.js
@@ -77,12 +77,27 @@ Client.prototype._defineMethod = function(method, location) {
     var self = this;
     return function(args, callback, options) {
         if (typeof args === 'function') {
+        	// No "args" supplied - shift arguments right
+            options = callback ;
             callback = args;
             args = {};
         }
-        self._invoke(method, args, location, function(error, result, raw) {
-            callback(error, result, raw);
-        }, options)
+        if (typeof callback !== 'function') {
+        	// No callback supplied (might have args alone, or args,options)
+        	options = callback ;
+        	// Return "funcback" signature
+        	return function($return,$error) {
+    	        self._invoke(method, args, location, function(error, result, raw) {
+    	            if (error)
+    	            	return $error(error) ;
+    	            return $return(result,raw) ;
+    	        }, options) ;
+        	}
+        } else {
+	        self._invoke(method, args, location, function(error, result, raw) {
+	            callback(error, result, raw);
+	        }, options)
+        }
     }
 }
 


### PR DESCRIPTION
Create remote methods with "funcbank" pattern to reduce code complexity and make available for use with NoDent.

The pattern is optional (only used if "callback" is omitted) and used only if the callback is NOT specified to the rmeote method.

Note: This also fixes a bug which lost the "options" if the "args" were omitted.