### PR TITLE
fixed; handle connection errors

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -590,6 +590,10 @@ var WSDL = function(definition, uri, options) {
         fromFunc.call(self, definition);
 
         self.processIncludes(function(err) {
+            if (err) {
+                return self.callback(err);
+            }
+
             self.definitions.deleteFixedAttrs();
             var services = self.services = self.definitions.services ;
             if (services) {

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -41,6 +41,13 @@ fs.readdirSync(__dirname+'/wsdl').forEach(function(file) {
     };
 })
 
+wsdlNonStrictTests['should not parse connection error'] = function(done) {
+    soap.createClient(__dirname+'/wsdl/connection/econnrefused.wsdl', function(err, client) {
+        assert.ok(/EADDRNOTAVAIL/.test(err));
+        done();
+    });
+};
+
 module.exports = {
     'SOAP Server': {
 


### PR DESCRIPTION
Includes often require making requests to other servers which may be down. This change handles this error and properly passes it back through to the callback instead of trying to parse a non-existant response.

also fixes #129
