### PR TITLE
Element form default

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -904,9 +904,9 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first) {
               ) {
                  prefix = '';
               }
-            parts.push(['<',ns,name,xmlnsAttrib,'>'].join(''));
+            parts.push(['<',prefix,name,xmlnsAttrib,'>'].join(''));
             parts.push(self.objectToXML(child, name, namespace, xmlns));
-            parts.push(['</',ns,name,'>'].join(''));
+            parts.push(['</',prefix,name,'>'].join(''));
         }
     }
     else if (obj !== undefined) {


### PR DESCRIPTION
Quite right, @dhyanchand,

Updated PR to use 'prefix' when object is an Object, too.  (Was only using prefix when object was an Array.)
