### PR TITLE
Fix for uncaught typeError (Issue 197)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -139,8 +139,15 @@ Client.prototype._invoke = function(method, arguments, location, callback, optio
 	self.lastRequest = xml;
 	
     http.request(location, xml, function(err, response, body) {
-        self.lastResponse = body;
-        self.lastResponseHeaders = response.headers;
+        if (!response) {
+            self.lastResponse = null;
+            self.lastResponseHeaders = null;
+            err = new Error("No response."); 
+        } else {
+            self.lastResponse = body;
+            self.lastResponseHeaders = response.headers;
+        }
+
         if (err) {
             callback(err);
         }

--- a/lib/http.js
+++ b/lib/http.js
@@ -45,6 +45,10 @@ exports.request = function(rurl, data, callback, exheaders, exoptions) {
         if (error) {
             callback(error);
         } else {
+            if (typeof(res) === 'undefined' && typeof(body) === 'undefined') {
+                res = null;
+                body = null;
+            }
             callback(null, res, body);
         }
     });


### PR DESCRIPTION
The request library will return an undefined response object if a request response has a 0 length (see mikeal/request#414). This causes node-soap to return an uncaught typeError exception, immediately killing the node process, since it doesn't check if the response object is undefined before trying to retrieve the headers from it.
