### PR TITLE
compensation for poorly constructed wsdl schema

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -749,6 +749,8 @@ WSDL.prototype.xmlToObject = function(xml) {
 					if(!refs[id]) refs[id] = {hrefs:[],obj:null};
 				}
 
+		obj.attrs = attrs;
+		
         if (topSchema && topSchema[name+'[]']) name = name + '[]';
         stack.push({name: originalName, object: obj, schema: topSchema && topSchema[name], id:attrs.id});
     })


### PR DESCRIPTION
There are additional attributes that are returned in the raw response but are not documented in the wsdl.
