### PR TITLE
Unspecified binding style defaults to 'document'

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -608,6 +608,7 @@ var WSDL = function(definition, uri, options) {
             var bindings = self.definitions.bindings;
             for(var bindingName in bindings) {
                 var binding = bindings[bindingName];
+                if (typeof binding.style == 'undefined') { binding.style = 'document'; }
                 if(binding.style !== 'document') continue;
                 var methods = binding.methods;
                 var topEls = binding.topElements = {};


### PR DESCRIPTION
> If the style attribute is omitted, the value is assumed to be "document"
> --[The SOAP spec](http://docs.oracle.com/cd/E19182-01/820-0595/6ncatc2mj/index.html)

The current implementation leaves it unspecified, and bindings are being skipped from processing by the “continue” statement on the next line
