### PR TITLE
 Fixed: error while there is no connection to url, which may cause read  property "headers" of undefined variable "response".

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -140,7 +140,7 @@ Client.prototype._invoke = function(method, arguments, location, callback, optio
 	
     http.request(location, xml, function(err, response, body) {
         self.lastResponse = body;
-        self.lastResponseHeaders = response.headers;
+        self.lastResponseHeaders = response && response.headers;
         if (err) {
             callback(err);
         }


### PR DESCRIPTION
The error may be reproduced in the following way.
The client is created from the .wsdl file in local file system. Then the endpoint is specified (with functionality provided by the local wsdl) and the client function is called. If there is no connection to the url specified, the variable response is undefined, and instead of calling callback, the exception is thrown (cannot read property "headers" of undefined).