### PR TITLE
Add support for xml attributes in requests and responses

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -736,9 +736,6 @@ WSDL.prototype.xmlToObject = function(xml) {
                self.definitions.messages[originalName] = self.definitions.messages[name];
             }
 
-            // since objects have no special attribute area, stick attributes straight into the obj
-            for (var n in attrs) obj[n] = attr[n];
-
             topSchema = message.description(self.definitions);
             objectName = originalName;
         }
@@ -751,6 +748,9 @@ WSDL.prototype.xmlToObject = function(xml) {
 				if(id=attrs.id) {
 					if(!refs[id]) refs[id] = {hrefs:[],obj:null};
 				}
+
+        // since objects have no special attribute area, stick attributes straight into the obj
+        for (var n in attrs) obj[n] = attrs[n];
 
         if (topSchema && topSchema[name+'[]']) name = name + '[]';
         stack.push({name: originalName, object: obj, schema: topSchema && topSchema[name], id:attrs.id});

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -873,7 +873,17 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, attrs)
     if (!!attrs) {
       if (typeof obj === 'object') {
         for (var n in obj) {
-          if (n[0] === '@') parts.push([' ', n.substring(1), '="', xmlEscape(obj[n]), '"'].join(''));
+          if (n[0] === '@') {
+            var attr = obj[n];
+            // for arrays, treat as ENTITIES attribute
+            if (Array.isArray(attr)) {
+              parts.push([' ', n.substring(1), '="'].join(''));
+              for (var i in attr) parts.push(xmlEscape(attr[i]));
+              parts.push('"');
+            } else {
+              parts.push([' ', n.substring(1), '="', xmlEscape(attr), '"'].join(''));
+            }
+          }
         }
         return parts.join('');
       }

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -736,6 +736,9 @@ WSDL.prototype.xmlToObject = function(xml) {
                self.definitions.messages[originalName] = self.definitions.messages[name];
             }
 
+            // since objects have no special attribute area, stick attributes straight into the obj
+            for (var n in attrs) obj[n] = attr[n];
+
             topSchema = message.description(self.definitions);
             objectName = originalName;
         }
@@ -860,12 +863,23 @@ WSDL.prototype.objectToRpcXML = function(name, params, namespace, xmlns) {
     return parts.join('');
 }
 
-WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first) {
+WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, attrs) {
     var self = this,
         parts = [],
         xmlnsAttrib = first ? ' xmlns:'+namespace+'="'+xmlns+'"'+' xmlns="'+xmlns+'"' : '',
         ns = namespace ? namespace + ':' : '';
     
+    // process keys starting with @ as attributes
+    if (!!attrs) {
+      if (typeof obj === 'object') {
+        for (var n in obj) {
+          if (n[0] === '@') parts.push([' ', n.substring(1), '="', xmlEscape(obj[n]), '"'].join(''));
+        }
+        return parts.join('');
+      }
+      return '';
+    }
+
     if (Array.isArray(obj)) {
         for (var i=0, item; item=obj[i]; i++) {
             if (i > 0) {
@@ -877,10 +891,14 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first) {
     }
     else if (typeof obj === 'object') {
         for (var name in obj) {
-            var child = obj[name];
-            parts.push(['<',ns,name,xmlnsAttrib,'>'].join(''));
-            parts.push(self.objectToXML(child, name, namespace, xmlns));
-            parts.push(['</',ns,name,'>'].join(''));
+            if (name[0] !== '@') {
+              var child = obj[name];
+              parts.push(['<',ns,name,xmlnsAttrib].join(''));
+              parts.push(self.objectToXML(child, name, namespace, xmlns, void(0), true));
+              parts.push('>');
+              parts.push(self.objectToXML(child, name, namespace, xmlns));
+              parts.push(['</',ns,name,'>'].join(''));
+            }
         }
     }
     else if (obj !== undefined) {


### PR DESCRIPTION
I have a few soap services that I access that require attributes instead of nested elements. This commit sets any field in an argument object that starts with '@' as an attribute on its parent element instead of as a nested element. It also makes any attributes that come back in response available in the response object.

I'm not positive that this is the best way to handle this, but it seemed much better than having a blessed name, like attrs, that may overlap with actual parameters.

In summary:
```javascript
client.someMethod({ name: 'value', '@attr': 'attrval' }, function(err, response) { });
```
has a body with
```xml
<urn:someMethod attr="attrval"><urn:name>value</urn:name></urn:someMethod>
```
instead of the current (sans @)
```xml
<urn:someMethod><urn:attr>attrval</urn:attr><urn:name>value</urn:name></urn:someMethod>
```