### PR TITLE
Add an option to disable time stamp element generation in WSSecurity

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -158,9 +158,10 @@ An instance of Client is passed to the soap.createClient callback.  It is used t
 
 ## WSSecurity
 
-WSSecurity implements WS-Security.  UsernameToken and PasswordText/PasswordDigest is supported. An instance of WSSecurity is passed to Client.setSecurity.
+WSSecurity implements WS-Security.  UsernameToken and PasswordText/PasswordDigest is supported. Option disableTimeStamp will turn of timeStamp xml element generation. An instance of WSSecurity is passed to Client.setSecurity.
 
 ``` javascript
-  new WSSecurity(username, password, passwordType)
+  var options = { passwordType: 'PasswordDigest', disableTimeStamp: true }
     //'PasswordDigest' or 'PasswordText' default is PasswordText
+  new WSSecurity(username, password, options)
 ```

--- a/lib/soap.js
+++ b/lib/soap.js
@@ -90,10 +90,22 @@ ClientSSLSecurity.prototype.addOptions = function (options) {
     options.agent = new https.Agent(options);
 }
 
-function WSSecurity(username, password, passwordType) {
+/**
+ * WSSecurity
+ *
+ * @param username
+ * @param password
+ * @param options {object} {
+ *   passwordType: <the password type>,
+ *   disableTimeStamp: <a boolean to disable security time stamp>
+ * }
+ * @return
+ */
+function WSSecurity(username, password, options) {
     this._username = username;
     this._password = password;
-    this._passwordType = passwordType || 'PasswordText';
+    this._passwordType = options && options.passwordType;
+    this._disableTimeStamp = options && options.disableTimeStamp;
 }
 
 var passwordDigest = function(nonce, created, password) {
@@ -117,8 +129,15 @@ WSSecurity.prototype.toXML = function() {
             + pad(d.getUTCSeconds())+'Z';
     }
     var now = new Date();
-    var created = getDate( now );
-    var expires = getDate( new Date(now.getTime() + (1000 * 600)) );
+    var created = getDate(now);
+    var timeStampXml = '';
+    if (!this._disableTimeStamp) {
+        var expires = getDate( new Date(now.getTime() + (1000 * 600)) );
+        timeStampXml = "<wsu:Timestamp wsu:Id=\"Timestamp-"+created+"\">" +
+            "<wsu:Created>"+created+"</wsu:Created>" +
+            "<wsu:Expires>"+expires+"</wsu:Expires>" +
+            "</wsu:Timestamp>";
+    }
 
     // nonce = base64 ( sha1 ( created + random ) )
     var nHash = crypto.createHash('sha1');
@@ -126,10 +145,7 @@ WSSecurity.prototype.toXML = function() {
     var nonce = nHash.digest('base64');
 
     return  "<wsse:Security xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\" xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\">" +
-            "<wsu:Timestamp wsu:Id=\"Timestamp-"+created+"\">" +
-            "<wsu:Created>"+created+"</wsu:Created>" +
-            "<wsu:Expires>"+expires+"</wsu:Expires>" +
-            "</wsu:Timestamp>" +
+            timeStampXml +
             "<wsse:UsernameToken xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\" wsu:Id=\"SecurityToken-"+created+"\">" +
             "<wsse:Username>"+this._username+"</wsse:Username>" +
             (this._passwordType === 'PasswordText' ?
@@ -140,7 +156,7 @@ WSSecurity.prototype.toXML = function() {
             "<wsse:Nonce EncodingType=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary\">"+nonce+"</wsse:Nonce>" +
             "<wsu:Created>"+created+"</wsu:Created>" +
             "</wsse:UsernameToken>" +
-            "</wsse:Security>"
+            "</wsse:Security>";
 }
 
 exports.BasicAuthSecurity = BasicAuthSecurity;


### PR DESCRIPTION
The module works great, until I use it to access charge point web services.

I'd like to add an option to disable the timestamp generation in WSSecurity XML. 

When I use this module to access charge point web service, their service is not able to process the timestamp. 

The service wsdl is here, https://webservices.chargepoint.com/cp_api_4.1.wsdl