### PR TITLE
Added null check for portType and methods[methodname].output

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 This module lets you connect to web services using SOAP.  It also provides a server that allows you to run your own SOAP services.
 
-[![Build Status](https://travis-ci.org/gabhi/node-soap.png?branch=master)](https://travis-ci.org/gabhi/node-soap)
+[![Build Status](https://travis-ci.org/milewise/node-soap.png?branch=master)](https://travis-ci.org/milewise/node-soap)
 
 Features:
 


### PR DESCRIPTION
Fixed issue when node-soap was not working when porttype or methods[methodName].output was null/undefined or 
