### PR TITLE
Fix describe on single operations

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -627,8 +627,8 @@ PortTypeElement.prototype.description = function(definitions) {
 };
 
 OperationElement.prototype.description = function(definitions) {
-  var inputDesc = this.input.description(definitions);
-  var outputDesc = this.output.description(definitions);
+  var inputDesc = this.input ? this.input.description(definitions) : null;
+  var outputDesc = this.output ? this.output.description(definitions) : null;
   return {
     input: inputDesc && inputDesc[Object.keys(inputDesc)[0]],
     output: outputDesc && outputDesc[Object.keys(outputDesc)[0]]

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -34,9 +34,10 @@ fs.readdirSync(__dirname+'/wsdl/strict').forEach(function(file) {
 
 fs.readdirSync(__dirname+'/wsdl').forEach(function(file) {
     if (!/.wsdl$/.exec(file)) return;
-    wsdlNonStrictTests['should parse '+file] = function(done) {
+    wsdlNonStrictTests['should parse and describe '+file] = function(done) {
         soap.createClient(__dirname+'/wsdl/'+file, function(err, client) {
             assert.ok(!err);
+            client.describe();
             done();
         });
     };

--- a/test/wsdl/rpcexample.wsdl
+++ b/test/wsdl/rpcexample.wsdl
@@ -1,0 +1,357 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:tns="urn:RpcExample" xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope" xmlns:SOAP-ENC="http://www.w3.org/2003/05/soap-encoding" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:RpcExample="urn:RpcExample" xmlns:SOAP="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:MIME="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:DIME="http://schemas.xmlsoap.org/ws/2002/04/dime/wsdl/" xmlns:WSDL="http://schemas.xmlsoap.org/wsdl/" xmlns="http://schemas.xmlsoap.org/wsdl/" name="urn:RpcExample" targetNamespace="urn:RpcExample">
+	<types>
+		<schema xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope" xmlns:SOAP-ENC="http://www.w3.org/2003/05/soap-encoding" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:RpcExample="urn:RpcExample" xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:RpcExample" elementFormDefault="unqualified" attributeFormDefault="unqualified">
+			<import namespace="http://www.w3.org/2003/05/soap-encoding"/>
+			<complexType name="pullFileParams">
+				<sequence>
+					<element name="url" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="fileName" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="fileMode" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+					<element name="forceOverwrite" type="xsd:boolean" minOccurs="1" maxOccurs="1"/>
+					<element name="username" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="password" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="base64EncodedCallback" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+				</sequence>
+			</complexType>
+			<complexType name="putFileParams">
+				<sequence>
+					<element name="fileName" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="base64EncodedBlob" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="fileMode" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+					<element name="forceOverwrite" type="xsd:boolean" minOccurs="1" maxOccurs="1"/>
+				</sequence>
+			</complexType>
+			<complexType name="getFileParams">
+				<sequence>
+					<element name="fileName" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+				</sequence>
+			</complexType>
+			<complexType name="execFileParams">
+				<sequence>
+					<element name="fileName" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="arguments" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+					<element name="base64EncodedStdIn" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="startDetached" type="xsd:boolean" minOccurs="1" maxOccurs="1"/>
+				</sequence>
+			</complexType>
+			<complexType name="listFilesResult">
+				<complexContent>
+					<restriction base="SOAP-ENC:Array">
+						<sequence>
+							<element name="files" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+						</sequence>
+						<attribute ref="SOAP-ENC:arrayType" WSDL:arrayType="xsd:string[]"/>
+					</restriction>
+				</complexContent>
+			</complexType>
+			<complexType name="execFileResult">
+				<sequence>
+					<element name="base64EncodedStdOut" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="base64EncodedStdError" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="exitCode" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+				</sequence>
+			</complexType>
+			<complexType name="setKeyParams">
+				<sequence>
+					<element name="module" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="key" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="base64EncodedVariant" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+				</sequence>
+			</complexType>
+			<complexType name="getKeyParams">
+				<sequence>
+					<element name="module" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="key" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+				</sequence>
+			</complexType>
+			<complexType name="clearKeyParams">
+				<sequence>
+					<element name="module" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="key" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+				</sequence>
+			</complexType>
+			<complexType name="listKeysResult">
+				<complexContent>
+					<restriction base="SOAP-ENC:Array">
+						<sequence>
+							<element name="keys" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+						</sequence>
+						<attribute ref="SOAP-ENC:arrayType" WSDL:arrayType="xsd:string[]"/>
+					</restriction>
+				</complexContent>
+			</complexType>
+			<complexType name="listKeysParams">
+				<sequence>
+					<element name="module" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="base" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+				</sequence>
+			</complexType>
+			<complexType name="execActionParams">
+				<sequence>
+					<element name="module" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="action" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="arguments" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+				</sequence>
+			</complexType>
+			<complexType name="heartbeatParams">
+				<sequence>
+					<element name="deviceUuid" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="updatedKeys" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="options" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+				</sequence>
+			</complexType>
+			<complexType name="legacyHeartbeatParams">
+				<sequence>
+					<element name="deviceUuid" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="agentVersion" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="macAddress" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="ipAddress" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="deviceOS" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+				</sequence>
+			</complexType>
+			<complexType name="messageParams">
+				<sequence>
+					<element name="deviceUuid" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="type" type="xsd:int" minOccurs="1" maxOccurs="1"/>
+					<element name="message" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+				</sequence>
+			</complexType>
+		</schema>
+	</types>
+	<message name="pullFileRequest">
+		<part name="params" type="RpcExample:pullFileParams"/>
+	</message>
+	<message name="pullFileResponse">
+		<part name="result" type="xsd:boolean"/>
+	</message>
+	<message name="putFileRequest">
+		<part name="params" type="RpcExample:putFileParams"/>
+	</message>
+	<message name="putFileResponse">
+		<part name="result" type="xsd:boolean"/>
+	</message>
+	<message name="getFileRequest">
+		<part name="params" type="RpcExample:getFileParams"/>
+	</message>
+	<message name="getFileResponse">
+		<part name="base64EncodedBlobResult" type="xsd:string"/>
+	</message>
+	<message name="execFile">
+		<part name="params" type="RpcExample:execFileParams"/>
+	</message>
+	<message name="execFileResponse">
+		<part name="result" type="RpcExample:execFileResult"/>
+	</message>
+	<message name="listFilesRequest">
+	</message>
+	<message name="listFilesResponse">
+		<part name="result" type="RpcExample:listFilesResult"/>
+	</message>
+	<message name="setKeyRequest">
+		<part name="params" type="RpcExample:setKeyParams"/>
+	</message>
+	<message name="setKeyResponse">
+		<part name="result" type="xsd:boolean"/>
+	</message>
+	<message name="getKeyRequest">
+		<part name="params" type="RpcExample:getKeyParams"/>
+	</message>
+	<message name="getKeyResponse">
+		<part name="base64EncodedVariantResult" type="xsd:string"/>
+	</message>
+	<message name="clearKeyRequest">
+		<part name="params" type="RpcExample:clearKeyParams"/>
+	</message>
+	<message name="clearKeyResponse">
+		<part name="result" type="xsd:boolean"/>
+	</message>
+	<message name="listKeysRequest">
+		<part name="params" type="RpcExample:listKeysParams"/>
+	</message>
+	<message name="listKeysResponse">
+		<part name="result" type="RpcExample:listKeysResult"/>
+	</message>
+	<message name="execActionRequest">
+		<part name="params" type="RpcExample:execActionParams"/>
+	</message>
+	<message name="execActionResponse">
+		<part name="base64EncodedVariantResult" type="xsd:string"/>
+	</message>
+	<message name="heartbeat">
+		<part name="params" type="RpcExample:heartbeatParams"/>
+	</message>
+	<message name="legacyHeartbeat">
+		<part name="params" type="RpcExample:legacyHeartbeatParams"/>
+	</message>
+	<message name="message">
+		<part name="params" type="RpcExample:messageParams"/>
+	</message>
+	<portType name="RpcExamplePortType">
+		<operation name="pullFile">
+			<input message="tns:pullFileRequest"/>
+			<output message="tns:pullFileResponse"/>
+		</operation>
+		<operation name="putFile">
+			<input message="tns:putFileRequest"/>
+			<output message="tns:putFileResponse"/>
+		</operation>
+		<operation name="getFile">
+			<input message="tns:getFileRequest"/>
+			<output message="tns:getFileResponse"/>
+		</operation>
+		<operation name="execFile">
+			<input message="tns:execFile"/>
+			<output message="tns:execFileResponse"/>
+		</operation>
+		<operation name="listFiles">
+			<input message="tns:listFilesRequest"/>
+			<output message="tns:listFilesResponse"/>
+		</operation>
+		<operation name="setKey">
+			<input message="tns:setKeyRequest"/>
+			<output message="tns:setKeyResponse"/>
+		</operation>
+		<operation name="getKey">
+			<input message="tns:getKeyRequest"/>
+			<output message="tns:getKeyResponse"/>
+		</operation>
+		<operation name="clearKey">
+			<input message="tns:clearKeyRequest"/>
+			<output message="tns:clearKeyResponse"/>
+		</operation>
+		<operation name="listKeys">
+			<input message="tns:listKeysRequest"/>
+			<output message="tns:listKeysResponse"/>
+		</operation>
+		<operation name="execAction">
+			<input message="tns:execActionRequest"/>
+			<output message="tns:execActionResponse"/>
+		</operation>
+		<operation name="heartbeat">
+			<input message="tns:heartbeat"/>
+		</operation>
+		<operation name="legacyHeartbeat">
+			<input message="tns:legacyHeartbeat"/>
+		</operation>
+		<operation name="message">
+			<input message="tns:message"/>
+		</operation>
+	</portType>
+	<binding name="RpcExample" type="tns:RpcExamplePortType">
+		<SOAP:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/>
+		<operation name="pullFile">
+			<SOAP:operation style="rpc"/>
+			<input>
+				<SOAP:body use="encoded" namespace="urn:RpcExample" encodingStyle="http://www.w3.org/2003/05/soap-encoding"/>
+			</input>
+			<output>
+				<SOAP:body use="encoded" namespace="urn:RpcExample" encodingStyle="http://www.w3.org/2003/05/soap-encoding"/>
+			</output>
+		</operation>
+		<operation name="putFile">
+			<SOAP:operation style="rpc"/>
+			<input>
+				<SOAP:body use="encoded" namespace="urn:RpcExample" encodingStyle="http://www.w3.org/2003/05/soap-encoding"/>
+			</input>
+			<output>
+				<SOAP:body use="encoded" namespace="urn:RpcExample" encodingStyle="http://www.w3.org/2003/05/soap-encoding"/>
+			</output>
+		</operation>
+		<operation name="getFile">
+			<SOAP:operation style="rpc"/>
+			<input>
+				<SOAP:body use="encoded" namespace="urn:RpcExample" encodingStyle="http://www.w3.org/2003/05/soap-encoding"/>
+			</input>
+			<output>
+				<SOAP:body use="encoded" namespace="urn:RpcExample" encodingStyle="http://www.w3.org/2003/05/soap-encoding"/>
+			</output>
+		</operation>
+		<operation name="execFile">
+			<SOAP:operation style="rpc"/>
+			<input>
+				<SOAP:body use="encoded" namespace="urn:RpcExample" encodingStyle="http://www.w3.org/2003/05/soap-encoding"/>
+			</input>
+			<output>
+				<SOAP:body use="encoded" namespace="urn:RpcExample" encodingStyle="http://www.w3.org/2003/05/soap-encoding"/>
+			</output>
+		</operation>
+		<operation name="listFiles">
+			<SOAP:operation style="rpc"/>
+			<input>
+				<SOAP:body use="encoded" namespace="urn:RpcExample" encodingStyle="http://www.w3.org/2003/05/soap-encoding"/>
+			</input>
+			<output>
+				<SOAP:body use="encoded" namespace="urn:RpcExample" encodingStyle="http://www.w3.org/2003/05/soap-encoding"/>
+			</output>
+		</operation>
+		<operation name="setKey">
+			<SOAP:operation style="rpc"/>
+			<input>
+				<SOAP:body use="encoded" namespace="urn:RpcExample" encodingStyle="http://www.w3.org/2003/05/soap-encoding"/>
+			</input>
+			<output>
+				<SOAP:body use="encoded" namespace="urn:RpcExample" encodingStyle="http://www.w3.org/2003/05/soap-encoding"/>
+			</output>
+		</operation>
+		<operation name="getKey">
+			<SOAP:operation style="rpc"/>
+			<input>
+				<SOAP:body use="encoded" namespace="urn:RpcExample" encodingStyle="http://www.w3.org/2003/05/soap-encoding"/>
+			</input>
+			<output>
+				<SOAP:body use="encoded" namespace="urn:RpcExample" encodingStyle="http://www.w3.org/2003/05/soap-encoding"/>
+			</output>
+		</operation>
+        <operation name="clearKey">
+                <SOAP:operation style="rpc"/>
+                <input>
+                        <SOAP:body use="encoded" namespace="urn:RpcExample" encodingStyle="http://www.w3.org/2003/05/soap-encoding"/>
+                </input>
+                <output>
+                        <SOAP:body use="encoded" namespace="urn:RpcExample" encodingStyle="http://www.w3.org/2003/05/soap-encoding"/>
+                </output>
+        </operation>
+		<operation name="listKeys">
+			<SOAP:operation style="rpc"/>
+			<input>
+				<SOAP:body use="encoded" namespace="urn:RpcExample" encodingStyle="http://www.w3.org/2003/05/soap-encoding"/>
+			</input>
+			<output>
+				<SOAP:body use="encoded" namespace="urn:RpcExample" encodingStyle="http://www.w3.org/2003/05/soap-encoding"/>
+			</output>
+		</operation>
+		<operation name="execAction">
+			<SOAP:operation style="rpc"/>
+			<input>
+				<SOAP:body use="encoded" namespace="urn:RpcExample" encodingStyle="http://www.w3.org/2003/05/soap-encoding"/>
+			</input>
+			<output>
+				<SOAP:body use="encoded" namespace="urn:RpcExample" encodingStyle="http://www.w3.org/2003/05/soap-encoding"/>
+			</output>
+		</operation>
+		<operation name="heartbeat">
+			<SOAP:operation style="rpc"/>
+			<input>
+				<SOAP:body use="encoded" namespace="urn:RpcExample" encodingStyle="http://www.w3.org/2003/05/soap-encoding"/>
+			</input>
+		</operation>
+		<operation name="legacyHeartbeat">
+			<SOAP:operation style="rpc"/>
+			<input>
+				<SOAP:body use="encoded" namespace="urn:RpcExample" encodingStyle="http://www.w3.org/2003/05/soap-encoding"/>
+			</input>
+		</operation>
+		<operation name="message">
+			<SOAP:operation style="rpc"/>
+			<input>
+				<SOAP:body use="encoded" namespace="urn:RpcExample" encodingStyle="http://www.w3.org/2003/05/soap-encoding"/>
+			</input>
+		</operation>
+	</binding>
+	<service name="RpcExample">
+		<port name="RpcExample" binding="tns:RpcExample">
+			<SOAP:address location="http://127.0.0.1/"/>
+		</port>
+	</service>
+</definitions>


### PR DESCRIPTION
it's possible that an operation could only have an input or output, but not both. This patches wsdl.js to accommodate this situation, and adds a test for it
