### PR TITLE
move wsdl parsing tests to their own file

### DIFF
--- a/test/server-test.js
+++ b/test/server-test.js
@@ -18,39 +18,6 @@ var service = {
     }
 }
 
-var wsdlStrictTests = {},
-    wsdlNonStrictTests = {};
-
-fs.readdirSync(__dirname+'/wsdl/strict').forEach(function(file) {
-    if (!/.wsdl$/.exec(file)) return;
-    wsdlStrictTests['should parse and describe '+file] = function(done) {
-        soap.createClient(__dirname+'/wsdl/strict/'+file, {strict: true}, function(err, client) {
-            assert.ok(!err);
-            client.describe();
-            done();
-        });
-    };
-})
-
-fs.readdirSync(__dirname+'/wsdl').forEach(function(file) {
-    if (!/.wsdl$/.exec(file)) return;
-    wsdlNonStrictTests['should parse and describe '+file] = function(done) {
-        soap.createClient(__dirname+'/wsdl/'+file, function(err, client) {
-            assert.ok(!err);
-            client.describe();
-            done();
-        });
-    };
-})
-
-wsdlNonStrictTests['should not parse connection error'] = function(done) {
-    soap.createClient(__dirname+'/wsdl/connection/econnrefused.wsdl', function(err, client) {
-        assert.ok(/EADDRNOTAVAIL|ECONNREFUSED/.test(err), err);
-        done();
-    });
-};
-
-
 var server = null;
 module.exports = {
     beforeEach: function() {
@@ -141,7 +108,5 @@ module.exports = {
                 });
             });
         },
-    },
-    'WSDL Parser (strict)': wsdlStrictTests,
-    'WSDL Parser (non-strict)': wsdlNonStrictTests
+    }
 }

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -1,0 +1,40 @@
+var fs = require('fs'),
+    soap = require('..'),
+    assert = require('assert');
+
+var wsdlStrictTests = {},
+    wsdlNonStrictTests = {};
+
+fs.readdirSync(__dirname+'/wsdl/strict').forEach(function(file) {
+    if (!/.wsdl$/.exec(file)) return;
+    wsdlStrictTests['should parse and describe '+file] = function(done) {
+        soap.createClient(__dirname+'/wsdl/strict/'+file, {strict: true}, function(err, client) {
+            assert.ok(!err);
+            client.describe();
+            done();
+        });
+    };
+})
+
+fs.readdirSync(__dirname+'/wsdl').forEach(function(file) {
+    if (!/.wsdl$/.exec(file)) return;
+    wsdlNonStrictTests['should parse and describe '+file] = function(done) {
+        soap.createClient(__dirname+'/wsdl/'+file, function(err, client) {
+            assert.ok(!err);
+            client.describe();
+            done();
+        });
+    };
+})
+
+wsdlNonStrictTests['should not parse connection error'] = function(done) {
+    soap.createClient(__dirname+'/wsdl/connection/econnrefused.wsdl', function(err, client) {
+        assert.ok(/EADDRNOTAVAIL|ECONNREFUSED/.test(err), err);
+        done();
+    });
+};
+
+module.exports = {
+    'WSDL Parser (strict)': wsdlStrictTests,
+    'WSDL Parser (non-strict)': wsdlNonStrictTests
+}


### PR DESCRIPTION
This is a pretty simple patch to move the wsdl parsing tests to a wsdl-test.js file, in anticipation of actually testing the parsing without depending on creating a client and calling describe() on it
