### PR TITLE
jshint is run on tests now, moved some tests over to mocha BDD format

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -16,5 +16,13 @@
   "node":true,
   "strict": true,
   "trailing":true,
-  "undef":true
+  "undef":true,
+  "predef": [
+    "describe",         // Used by mocha
+    "it",               // Used by mocha
+    "before",           // Used by mocha
+    "beforeEach",       // Used by mocha
+    "after",            // Used by mocha
+    "afterEach"         // Used by mocha
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "mocha": "mocha -R spec -u exports test/*-test.js",
-    "jshint": "jshint index.js lib/http.js lib/client.js lib/soap.js lib/server.js lib/wsdl.js",
+    "jshint": "jshint index.js lib test",
     "test": "npm run-script jshint && npm run-script mocha"
   },
   "keywords": [

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -1,14 +1,14 @@
+"use strict";
+
 var fs = require('fs'),
     soap = require('..'),
     assert = require('assert');
 
-module.exports = {
-    'SOAP Client': {
-        'should error on invalid host': function(done) {
-            soap.createClient('http://localhost:1', function(err, client) {
-                assert.ok(err);
-                done();
-            });
-        },
-    }
-}
+describe('SOAP Client', function() {
+  it('should error on invalid host', function(done) {
+    soap.createClient('http://localhost:1', function(err, client) {
+      assert.ok(err);
+      done();
+    });
+  });
+});

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -1,112 +1,131 @@
+"use strict";
+
 var fs = require('fs'),
     soap = require('..'),
     assert = require('assert'),
     request = require('request'),
     http = require('http');
 
-var service = {
-    StockQuoteService: {
-        StockQuotePort: {
-            GetLastTradePrice: function(args) {
-                if (args.tickerSymbol == 'trigger error') {
-                   throw new Error('triggered server error');
-                } else {
-                    return { price: 19.56 };
-                }
-            }
+var test = {};
+test.server = null;
+test.service = {
+  StockQuoteService: {
+    StockQuotePort: {
+      GetLastTradePrice: function(args) {
+        if (args.tickerSymbol === 'trigger error') {
+          throw new Error('triggered server error');
+        } else {
+          return { price: 19.56 };
         }
+      }
     }
-}
+  }
+};
 
-var server = null;
-module.exports = {
-    beforeEach: function() {
-        var wsdl = fs.readFileSync(__dirname+'/wsdl/strict/stockquote.wsdl', 'utf8');
-        server = http.createServer(function(req, res) {
-            res.statusCode = 404;
-            res.end();
-        });
-        server.listen(15099);
-        soap.listen(server, '/stockquote', service, wsdl);
-    },
-    afterEach: function(done) {
-        if (!server) return done()
-        server.close(function() {
-            server = null;
-            done();
-        });
-    },
+describe('SOAP Server', function() {
+  before(function(done) {
+    fs.readFile(__dirname + '/wsdl/strict/stockquote.wsdl', 'utf8', function(err, data) {
+      assert.ok(!err);
+      test.wsdl = data;
+      done();
+    });
+  });
 
-    'SOAP Server': {
+  beforeEach(function(done) {
+    test.server = http.createServer(function(req, res) {
+      res.statusCode = 404;
+      res.end();
+    });
 
-        'should be running': function(done) {
-            request('http://localhost:15099', function(err, res, body) {
-                assert.ok(!err);
-                done();
-            })
-        },
+    test.server.listen(15099, null, null, function() {
+      test.soapServer = soap.listen(test.server, '/stockquote', test.service, test.wsdl);
+      test.baseUrl =
+        'http://' + test.server.address().address + ":" + test.server.address().port;
+      done();
+    });
+  });
 
-        'should 404 on non-WSDL path': function(done) {
-            request('http://localhost:15099', function(err, res, body) {
-                assert.ok(!err);
-                assert.equal(res.statusCode, 404);
-                done();
-            })
-        },
+  afterEach(function(done) {
+    test.server.close(function() {
+      test.server = null;
+      delete test.soapServer;
+      test.soapServer = null;
+      done();
+    });
+  });
 
-        'should server up WSDL': function(done) {
-            request('http://localhost:15099/stockquote?wsdl', function(err, res, body) {
-                assert.ok(!err);
-                assert.equal(res.statusCode, 200);
-                assert.ok(body.length);
-                done();
-            })
-        },
 
-        'should return a valid error if the server stops responding': function(done) {
-            soap.createClient('http://localhost:15099/stockquote?wsdl', function(err, client) {
-                assert.ok(!err);
-                server.close(function() {
-                  server = null;
-                  client.GetLastTradePrice({ tickerSymbol: 'trigger error' }, function(err, response, body) {
-                      assert.ok(err);
-                      done();
-                  });
-                });
-            });
-        },
+  it('should be running', function(done) {
+    request(test.baseUrl, function(err, res, body) {
+      assert.ok(!err);
+      done();
+    });
+  });
 
-        'should return complete client description': function(done) {
-            soap.createClient('http://localhost:15099/stockquote?wsdl', function(err, client) {
-                assert.ok(!err);
-                var description = client.describe(),
-                    expected = { input: { tickerSymbol: "string" }, output:{ price: "float" } };
-                assert.deepEqual(expected , description.StockQuoteService.StockQuotePort.GetLastTradePrice );
-                done();
-            });
-        },
+  it('should 404 on non-WSDL path', function(done) {
+    request(test.baseUrl, function(err, res, body) {
+      assert.ok(!err);
+      assert.equal(res.statusCode, 404);
+      done();
+    });
+  });
 
-        'should return correct results': function(done) {
-            soap.createClient('http://localhost:15099/stockquote?wsdl', function(err, client) {
-                assert.ok(!err);
-                client.GetLastTradePrice({ tickerSymbol: 'AAPL'}, function(err, result) {
-                    assert.ok(!err);
-                    assert.equal(19.56, parseFloat(result.price));
-                    done();
-                });
-            });
-        },
+  it('should server up WSDL', function(done) {
+    request(test.baseUrl + '/stockquote?wsdl', function(err, res, body) {
+      assert.ok(!err);
+      assert.equal(res.statusCode, 200);
+      assert.ok(body.length);
+      done();
+    });
+  });
 
-        'should include response and body in error object': function(done) {
-            soap.createClient('http://localhost:15099/stockquote?wsdl', function(err, client) {
-                assert.ok(!err);
-                client.GetLastTradePrice({ tickerSymbol: 'trigger error' }, function(err, response, body) {
-                    assert.ok(err);
-                    assert.strictEqual(err.response, response);
-                    assert.strictEqual(err.body, body);
-                    done();
-                });
-            });
-        },
-    }
-}
+  it('should return complete client description', function(done) {
+    soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
+      assert.ok(!err);
+      var description = client.describe(),
+          expected = { input: { tickerSymbol: "string" }, output:{ price: "float" } };
+      assert.deepEqual(expected , description.StockQuoteService.StockQuotePort.GetLastTradePrice);
+      done();
+    });
+  });
+
+  it('should return correct results', function(done) {
+    soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
+      assert.ok(!err);
+      client.GetLastTradePrice({ tickerSymbol: 'AAPL'}, function(err, result) {
+        assert.ok(!err);
+        assert.equal(19.56, parseFloat(result.price));
+        done();
+      });
+    });
+  });
+
+  it('should include response and body in error object', function(done) {
+    soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
+      assert.ok(!err);
+      client.GetLastTradePrice({ tickerSymbol: 'trigger error' }, function(err, response, body) {
+        assert.ok(err);
+        assert.strictEqual(err.response, response);
+        assert.strictEqual(err.body, body);
+        done();
+      });
+    });
+  });
+
+// NOTE: this is actually a -client- test
+/*
+it('should return a valid error if the server stops responding': function(done) {
+  soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
+    assert.ok(!err);
+    server.close(function() {
+      server = null;
+      client.GetLastTradePrice({ tickerSymbol: 'trigger error' }, function(err, response, body) {
+        assert.ok(err);
+        done();
+      });
+    });
+  });
+});
+*/
+
+});

--- a/test/ssl-test.js
+++ b/test/ssl-test.js
@@ -1,62 +1,83 @@
+"use strict";
+
 var fs = require('fs'),
     soap = require('..'),
     https = require('https'),
     constants = require('constants'),
     assert = require('assert');
 
-var service = {
-    StockQuoteService: {
-        StockQuotePort: {
-            GetLastTradePrice: function(args) {
-                if (args.tickerSymbol == 'trigger error') {
-                   throw new Error('triggered server error');
-                } else {
-                    return { price: 19.56 };
-                }
-            }
+var test = {};
+test.service = {
+  StockQuoteService: {
+    StockQuotePort: {
+      GetLastTradePrice: function(args) {
+        if (args.tickerSymbol === 'trigger error') {
+          throw new Error('triggered server error');
+        } else {
+          return { price: 19.56 };
         }
+      }
     }
-}
+  }
+};
 
-var sslOptions = {
+test.sslOptions = {
   key: fs.readFileSync(__dirname + '/certs/agent2-key.pem'),
   cert: fs.readFileSync(__dirname + '/certs/agent2-cert.pem')
 };
 
-module.exports = {
-  'SSL SOAP Client': {
-    'should connect to an SSL server': function(done) {
-      // setup server and listen
-      var server = https.createServer(sslOptions, function(req, res) {
-        res.statusCode = 404;
-        res.end();
-      }).listen(51515);
+describe('SOAP Client(SSL)', function() {
+  before(function(done) {
+    fs.readFile(__dirname + '/wsdl/strict/stockquote.wsdl', 'utf8', function(err, data) {
+      assert.ok(!err);
+      test.wsdl = data;
+      done();
+    });
+  });
 
-      var wsdl = fs.readFileSync(__dirname + '/wsdl/strict/stockquote.wsdl', 'utf8');
-      var soapServer = soap.listen(server, '/stockquote', service, wsdl);
+  beforeEach(function(done) {
+    test.server = https.createServer(test.sslOptions, function(req, res) {
+      res.statusCode = 404;
+      res.end();
+    }).listen(51515, function() {
+      test.soapServer = soap.listen(test.server, '/stockquote', test.service, test.wsdl);
+      test.baseUrl =
+        'https://' + test.server.address().address + ':' + test.server.address().port;
+      done();
+    });
+  });
 
-      // test client
-      soap.createClient(__dirname + '/wsdl/strict/stockquote.wsdl', function(err, client) {
-        assert.ok(!err);
-        client.setEndpoint('https://localhost:51515/stockquote');
-        client.setSecurity({
-          addOptions:function(options){
-            options.cert = sslOptions.cert,
-            options.key = sslOptions.key,
-            options.rejectUnauthorized = false;
-            options.secureOptions = constants.SSL_OP_NO_TLSv1_2;
-            options.strictSSL = false;
-            options.agent = new https.Agent(options);
-          },
-          toXML:function(){return '';}
-        });
+  afterEach(function(done) {
+    test.server.close(function() {
+      test.server = null;
+      delete test.soapServer;
+      test.soapServer = null;
+      done();
+    });
+  });
 
-        client.GetLastTradePrice({ tickerSymbol: 'AAPL'}, function(err, result) {
-          assert.ok(!err);
-          assert.equal(19.56, parseFloat(result.price));
-          done();
-        });
+  it('should connect to an SSL server', function(done) {
+    soap.createClient(__dirname + '/wsdl/strict/stockquote.wsdl', function(err, client) {
+      assert.ok(!err);
+      client.setEndpoint(test.baseUrl + '/stockquote');
+      client.setSecurity({
+        addOptions:function(options){
+          options.cert = test.sslOptions.cert,
+          options.key = test.sslOptions.key,
+          options.rejectUnauthorized = false;
+          options.secureOptions = constants.SSL_OP_NO_TLSv1_2;
+          options.strictSSL = false;
+          options.agent = new https.Agent(options);
+        },
+        toXML: function() { return ''; }
       });
-    }
-  }
-}
+
+      client.GetLastTradePrice({ tickerSymbol: 'AAPL'}, function(err, result) {
+        assert.ok(!err);
+        assert.equal(19.56, parseFloat(result.price));
+        done();
+      });
+    });
+  });
+
+});

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var fs = require('fs'),
     soap = require('..'),
     assert = require('assert');
@@ -6,35 +8,35 @@ var wsdlStrictTests = {},
     wsdlNonStrictTests = {};
 
 fs.readdirSync(__dirname+'/wsdl/strict').forEach(function(file) {
-    if (!/.wsdl$/.exec(file)) return;
-    wsdlStrictTests['should parse and describe '+file] = function(done) {
-        soap.createClient(__dirname+'/wsdl/strict/'+file, {strict: true}, function(err, client) {
-            assert.ok(!err);
-            client.describe();
-            done();
-        });
-    };
-})
+  if (!/.wsdl$/.exec(file)) return;
+  wsdlStrictTests['should parse and describe '+file] = function(done) {
+    soap.createClient(__dirname+'/wsdl/strict/'+file, {strict: true}, function(err, client) {
+      assert.ok(!err);
+      client.describe();
+      done();
+    });
+  };
+});
 
 fs.readdirSync(__dirname+'/wsdl').forEach(function(file) {
-    if (!/.wsdl$/.exec(file)) return;
-    wsdlNonStrictTests['should parse and describe '+file] = function(done) {
-        soap.createClient(__dirname+'/wsdl/'+file, function(err, client) {
-            assert.ok(!err);
-            client.describe();
-            done();
-        });
-    };
-})
+  if (!/.wsdl$/.exec(file)) return;
+  wsdlNonStrictTests['should parse and describe '+file] = function(done) {
+    soap.createClient(__dirname+'/wsdl/'+file, function(err, client) {
+      assert.ok(!err);
+      client.describe();
+      done();
+    });
+  };
+});
 
 wsdlNonStrictTests['should not parse connection error'] = function(done) {
-    soap.createClient(__dirname+'/wsdl/connection/econnrefused.wsdl', function(err, client) {
-        assert.ok(/EADDRNOTAVAIL|ECONNREFUSED/.test(err), err);
-        done();
-    });
+  soap.createClient(__dirname+'/wsdl/connection/econnrefused.wsdl', function(err, client) {
+    assert.ok(/EADDRNOTAVAIL|ECONNREFUSED/.test(err), err);
+    done();
+  });
 };
 
 module.exports = {
-    'WSDL Parser (strict)': wsdlStrictTests,
-    'WSDL Parser (non-strict)': wsdlNonStrictTests
-}
+  'WSDL Parser (strict)': wsdlStrictTests,
+  'WSDL Parser (non-strict)': wsdlNonStrictTests
+};


### PR DESCRIPTION
A few changes here:
- made 'npm test' run jshint on tests as well
- migrated a number of tests to mocha's BDD style
  - added some predefines to .jshintrc for this
- fixed a whole bunch of formatting issues in the tests (as per jshints demands)
- partially reworked server test to run more asynchronously

I know it's kind of a big commit, but its all in the tests and I think this sets us up for better testing in the future. 
