### PR TITLE
namespace with one name and different path

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -137,7 +137,6 @@ Element.prototype.endElement = function(stack, nsName) {
       return;
     var parent = stack[stack.length - 2];
     if (this !== stack[0]) {
-      extend(stack[0].xmlns, this.xmlns);
       // delete this.xmlns;
       parent.children.push(this);
       parent.addChild(this);


### PR DESCRIPTION
fix bug witch break possibility use different namespace paths with one name in different part of wsdl document.
