### PR TITLE
Make sure callback is done asynchronously for a cached wsdl

### DIFF
--- a/lib/soap.js
+++ b/lib/soap.js
@@ -24,7 +24,9 @@ function _requestWSDL(url, options, callback) {
 
   var wsdl = _wsdlCache[url];
   if (wsdl) {
-    callback(null, wsdl);
+    process.nextTick(function() {
+      callback(null, wsdl);
+    });
   }
   else {
     open_wsdl(url, options, function(err, wsdl) {

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -29,4 +29,15 @@ describe('SOAP Client', function() {
       done();
     });
   });
+
+  it('should issue async callback for cached wsdl', function(done) {
+    var called = false;
+    soap.createClient(__dirname+'/wsdl/default_namespace.wsdl', function(err, client) {
+      assert.ok(client);
+      assert.ok(!err);
+      called = true;
+      done();
+    });
+    assert(!called);
+  });
 });


### PR DESCRIPTION
The PR fixes the callback when the wsdl is found in the cache. The synchronous callback breaks the assumption that callback should only happen after the function is done.
