### PR TITLE
Ability to add extra headers to the client request and tests

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -87,18 +87,18 @@ Client.prototype._definePort = function(port, endpoint) {
 
 Client.prototype._defineMethod = function(method, location) {
   var self = this;
-  return function(args, callback, options) {
+  return function(args, callback, options, extraHeaders) {
     if (typeof args === 'function') {
       callback = args;
       args = {};
     }
     self._invoke(method, args, location, function(error, result, raw) {
       callback(error, result, raw);
-    }, options);
+    }, options, extraHeaders);
   };
 };
 
-Client.prototype._invoke = function(method, args, location, callback, options) {
+Client.prototype._invoke = function(method, args, location, callback, options, extraHeaders) {
   var self = this,
     name = method.$name,
     input = method.input,
@@ -117,6 +117,9 @@ Client.prototype._invoke = function(method, args, location, callback, options) {
     alias = findKey(defs.xmlns, ns);
 
   options = options || {};
+
+  //Add extra headers
+  for (var attr in extraHeaders) { headers[attr] = extraHeaders[attr]; }
 
   // Allow the security object to add headers
   if (self.security && self.security.addHeaders)
@@ -155,6 +158,7 @@ Client.prototype._invoke = function(method, args, location, callback, options) {
     var obj;
     self.lastResponse = body;
     self.lastResponseHeaders = response && response.headers;
+    
     if (err) {
       callback(err);
     } else {


### PR DESCRIPTION
1) Ability to add extra headers to the client request. Two tests in client-tests.js for the same.
2) Test to ensure that client has lastResponse and lastResponseHeaders after it returns.

Please review and merge. Thanks!
