### PR TITLE
Updated readme for undocumented feature

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -139,13 +139,22 @@ An instance of Client is passed to the soap.createClient callback.  It is used t
       // result is a javascript object
   })
 ```
-### Client.*service*.*port*.*method*(args, callback) - call a *method* using a specific *service* and *port*
+### Client.*service*.*port*.*method*(args, callback[, options]) - call a *method* using a specific *service* and *port*
 
 ``` javascript
   client.MyService.MyPort.MyFunction({name: 'value'}, function(err, result) {
       // result is a javascript object
   })
 ```
++#### Options (optional)
+ - Accepts any option that the request module accepts, see [here.](https://github.com/mikeal/request)
+ - For example, you could set a timeout of 5 seconds on the request like this:
+``` javascript
+  client.MyService.MyPort.MyFunction({name: 'value'}, function(err, result) {
+      // result is a javascript object
+  }, {timeout: 5000})
+```
+ 
 ### Client.*addSoapHeader*(soapHeader[, name, namespace, xmlns]) - add soapHeader to soap:Header node
 #### Options
 


### PR DESCRIPTION
Added documentation for passing options to a client request.  Client requests are able to use any options accepted by the request module.
