### PR TITLE
Fix "AssertionError: Invalid child type" for WSDLs containing imports and includes

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -379,6 +379,10 @@ DefinitionsElement.prototype.addChild = function(child) {
   }
   else if (child instanceof DocumentationElement) {
   }
+  else if (child.name === 'import' || child.name === 'include') {
+    // Ignore imports & includes until there is some logic to handle them...
+    // Fix for: AssertionError: Invalid child type (https://github.com/vpulim/node-soap/issues/125)
+  }
   else {
     assert(false, "Invalid child type");
   }


### PR DESCRIPTION
Any WSDL containing imports or includes will cause an "AssertionError: Invalid child type" Example:

``` xml
...
<wsdl:import location="https://192.168.2.2:8080/soap/Konto?wsdl=KontoService.wsdl"
namespace="http://service.soap.hbci.jameica.willuhn.de/"></wsdl:import>
...
```

This issue has been waiting for a year => https://github.com/vpulim/node-soap/issues/125

I suggest those types of elements are ignored temporary until node-soap has some logic to handle them.
