### PR TITLE
Fix for "TargetNamespace not loaded when import in schema"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+
+.idea
+*.iml

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -310,10 +310,23 @@ SchemaElement.prototype.addChild = function(child) {
   this.children.pop();
   // child.deleteFixedAttrs();
 };
-
-TypesElement.prototype.addChild = function(child) {
+//fix#325
+TypesElement.prototype.addChild = function (child) {
   assert(child instanceof SchemaElement);
-  this.schemas[child.$targetNamespace] = child;
+
+  var targetNamespace = child.$targetNamespace;
+
+  if(!targetNamespace) {
+    if(child.includes && (child.includes instanceof Array) && child.includes.length > 0) {
+      targetNamespace = child.includes[0].namespace;
+    }
+  }
+
+  if(!this.schemas.hasOwnProperty(targetNamespace)) {
+    this.schemas[targetNamespace] = child;
+  } else {
+    console.error('Target-Namespace "'+ targetNamespace +'" already in use by another Schema!');
+  }
 };
 
 InputElement.prototype.addChild = function(child) {

--- a/test/wsdl/Common.xsd
+++ b/test/wsdl/Common.xsd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:tns="http://www.Dummy.com/Common/Types" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.Dummy.com/Common/Types" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:complexType name="DummyResult">
+		<xs:sequence>
+			<xs:element name="DummyList" type="tns:DummyList" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="code" type="xs:string" use="optional"/>
+	</xs:complexType>
+	<xs:complexType name="Dummy">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="language" type="xs:language" use="optional"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="DummyList">
+		<xs:sequence>
+			<xs:element name="DummyElement" type="tns:Dummy" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>	
+</xs:schema>
+

--- a/test/wsdl/Dummy.wsdl
+++ b/test/wsdl/Dummy.wsdl
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" 
+xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" 
+xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+xmlns:tns="http://www.Dummy.com"  xmlns:n="http://www.Dummy.com/Name/Types"  xmlns:ns="http://schemas.xmlsoap.org/soap/encoding/" targetNamespace="http://www.Dummy.com">
+	<wsdl:types>
+		<xs:schema>
+			<xs:import namespace="http://www.Dummy.com/Common/Types" schemaLocation="./Common.xsd"/>
+			<xs:import namespace="http://www.Dummy.com/Name/Types" schemaLocation="./Name.xsd"/>
+		</xs:schema>
+	</wsdl:types>
+	<wsdl:message name="DummyRequest">
+		<wsdl:part name="DummyRequest" element="n:DummyRequest"/>
+	</wsdl:message>
+	<wsdl:message name="DummyResponse">
+		<wsdl:part name="DummyResponse" element="n:DummyResponse"/>
+	</wsdl:message>
+	<wsdl:portType name="DummyPortType">
+		<wsdl:operation name="Dummy">
+			<wsdl:input message="tns:DummyRequest"/>
+			<wsdl:output message="tns:DummyResponse"/>
+		</wsdl:operation>
+	</wsdl:portType>
+	<wsdl:binding name="DummyBinding" type="tns:DummyPortType">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+		<wsdl:operation name="Dummy">
+			<soap:operation soapAction="http://www.Dummy.com#Dummy" style="document"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:service name="DummyService">
+		<wsdl:port name="DummyPortType" binding="tns:DummyBinding">
+			<soap:address location="http://www.Dummy.com/"/>
+		</wsdl:port>
+	</wsdl:service>
+</wsdl:definitions>
+

--- a/test/wsdl/Name.xsd
+++ b/test/wsdl/Name.xsd
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:c="http://www.Dummy.com/Common/Types" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.Dummy.com/Name/Types" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:import namespace="http://www.Dummy.com/Common/Types" schemaLocation="Common.xsd"/>
+	<xs:element name="DummyRequest">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="DummyField1" type="xs:string" minOccurs="0"/>
+				<xs:element name="DummyField2" type="xs:string" minOccurs="0"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="DummyResponse">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="DummyResult" type="c:DummyResult"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>


### PR DESCRIPTION
Modified `wsdl.js` and added `Dummy.wsdl` which containes two schemas (`Commin.xsd` and `Name.xsd`) to test
