### PR TITLE
Improper namespacing of attributes results in not being able to properly handle certain WebServices.

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -882,7 +882,7 @@ WSDL.prototype.xmlToObject = function(xml) {
       elementAttributes[attributeName] = attrs[attributeName];
     }
 
-    if(hasNonXmlnsAttribute)obj.attributes = elementAttributes;
+    if(hasNonXmlnsAttribute)obj.$attributes = elementAttributes;
 
     if (topSchema && topSchema[name + '[]'])
       name = name + '[]';
@@ -1053,13 +1053,13 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsA
   } else if (typeof obj === 'object') {
     for (name in obj) {
       //don't process attributes as element
-      if (name === 'attributes') {
+      if (name === '$attributes') {
         continue;
       }
       
       var child = obj[name];
-      if (child.attributes && child.attributes.xsi_type) {
-        var xsiType = child.attributes.xsi_type;
+      if (child.$attributes && child.$attributes.xsi_type) {
+        var xsiType = child.$attributes.xsi_type;
         
         // Generate a new namespace for complex extension if one not provided
         if (!xsiType.namespace) {
@@ -1104,12 +1104,12 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsA
               
               var completeChildParameterTypeObject = self.findChildParameterObjectFromSchema(childName, childXmlns) || childParameterTypeObject;
               value = self.objectToXML(child, name, childNamespace, childXmlns, false, childXmlnsAttrib, completeChildParameterTypeObject, ancXmlns);
-            } else if (obj.attributes && obj.attributes.xsi_type) { //if parent object has complex type defined and child not found in parent
-              var completeChildParamTypeObject = self.findChildParameterObjectFromSchema(obj.attributes.xsi_type.type, obj.attributes.xsi_type.xmlns);
+            } else if (obj.$attributes && obj.$attributes.xsi_type) { //if parent object has complex type defined and child not found in parent
+              var completeChildParamTypeObject = self.findChildParameterObjectFromSchema(obj.$attributes.xsi_type.type, obj.$attributes.xsi_type.xmlns);
               
-              ns = obj.attributes.xsi_type.namespace + ':';
-              ancXmlns.push(obj.attributes.xsi_type.xmlns);
-              value = self.objectToXML(child, name, obj.attributes.xsi_type.namespace, obj.attributes.xsi_type.xmlns, false, null, null, ancXmlns);
+              ns = obj.$attributes.xsi_type.namespace + ':';
+              ancXmlns.push(obj.$attributes.xsi_type.xmlns);
+              value = self.objectToXML(child, name, obj.$attributes.xsi_type.namespace, obj.$attributes.xsi_type.xmlns, false, null, null, ancXmlns);
             } else {
               value = self.objectToXML(child, name, namespace, xmlns, false, null, null, ancXmlns);
             }
@@ -1136,17 +1136,17 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsA
 
 WSDL.prototype.processAttributes = function(child) {
   var attr = '';
-  if (child.attributes) {
-    for (var attrKey in child.attributes) {
+  if (child.$attributes) {
+    for (var attrKey in child.$attributes) {
       //handle complex extension separately
       if (attrKey === 'xsi_type') {
-        var attrValue = child.attributes[attrKey];
+        var attrValue = child.$attributes[attrKey];
         attr += ' xsi:type="' + attrValue.namespace + ':' + attrValue.type + '"';
         attr += ' xmlns:' + attrValue.namespace + '="' + attrValue.xmlns + '"';
         
         continue;
       } else {
-        attr += ' ' + attrKey + '="' + xmlEscape(child.attributes[attrKey]) + '"';
+        attr += ' ' + attrKey + '="' + xmlEscape(child.$attributes[attrKey]) + '"';
       }
     }
   }

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -158,7 +158,7 @@ describe('SOAP Client', function() {
         assert.ok(client);
         
         var data = {
-          attributes: {
+          $attributes: {
             xsi_type: {
               type: 'Ty',
               xmlns: 'xmlnsTy'
@@ -172,7 +172,7 @@ describe('SOAP Client', function() {
           assert.ok(client.lastMessage);
           assert.equal(client.lastMessage, message);
           
-          delete data.attributes.xsi_type.namespace;
+          delete data.$attributes.xsi_type.namespace;
           client.MyOperation(data, function(err, result) {
             assert.ok(client.lastRequest);
             assert.ok(client.lastMessage);

--- a/test/request-response-samples/GetAccountXml__non_xmlns_attributes_should_be_returned/response.json
+++ b/test/request-response-samples/GetAccountXml__non_xmlns_attributes_should_be_returned/response.json
@@ -3,7 +3,7 @@
   "AccountXml": {
     "Foo": {
       "Foo": {
-        "attributes": {
+        "$attributes": {
           "PrivateLabelID": "1",
           "ResourceID": "034b7ea5-8a04-11e3-9710-0050569575d8",
           "IsPastDue": "False",
@@ -12,7 +12,7 @@
           "CurrentUnifiedProductID": "70761"
         },
         "Tree": {
-          "attributes": {
+          "$attributes": {
             "TreeID": "1091",
             "NodeID": "1091",
             "UnifiedProductID": "70761",

--- a/test/request-response-samples/get__complex_extension_with_explicit_namespace/request.json
+++ b/test/request-response-samples/get__complex_extension_with_explicit_namespace/request.json
@@ -1,6 +1,6 @@
 {
   "baseRef":{
-    "attributes":{
+    "$attributes":{
       "type":"contact",
       "internalId":"42",
       "xsi_type":{

--- a/test/request-response-samples/get__complex_extension_with_explicit_namespace/response.json
+++ b/test/request-response-samples/get__complex_extension_with_explicit_namespace/response.json
@@ -1,24 +1,24 @@
 {
   "readResponse":{
     "status":{
-      "attributes":{
+      "$attributes":{
         "isSuccess":"true"
       }
     },"record":{
-      "attributes":{
+      "$attributes":{
         "internalId":"42",
         "externalId":"Alex Dniprovskyy",
         "xsi:type":"listRel:Contact"
       },
       "customForm":{
-        "attributes":{
+        "$attributes":{
           "internalId":"-40"
         },
         "name":"Standard Contact Form"
       },
       "entityId":"Allister Sullivan",
       "company":{
-        "attributes":{
+        "$attributes":{
           "internalId":"43"
         },
         "name":"Sullivan Distributors, Inc."

--- a/test/request-response-samples/get__complex_extension_without_explicit_namespace/request.json
+++ b/test/request-response-samples/get__complex_extension_without_explicit_namespace/request.json
@@ -1,6 +1,6 @@
 {
   "baseRef":{
-    "attributes":{
+    "$attributes":{
       "type":"contact",
       "internalId":"42",
       "xsi_type":{

--- a/test/request-response-samples/get__complex_extension_without_explicit_namespace/response.json
+++ b/test/request-response-samples/get__complex_extension_without_explicit_namespace/response.json
@@ -1,24 +1,24 @@
 {
   "readResponse":{
     "status":{
-      "attributes":{
+      "$attributes":{
         "isSuccess":"true"
       }
     },"record":{
-      "attributes":{
+      "$attributes":{
         "internalId":"42",
         "externalId":"Alex Dniprovskyy",
         "xsi:type":"listRel:Contact"
       },
       "customForm":{
-        "attributes":{
+        "$attributes":{
           "internalId":"-40"
         },
         "name":"Standard Contact Form"
       },
       "entityId":"Allister Sullivan",
       "company":{
-        "attributes":{
+        "$attributes":{
           "internalId":"43"
         },
         "name":"Sullivan Distributors, Inc."

--- a/test/request-response-samples/login__attributes_in_request_should_be_handled/request.json
+++ b/test/request-response-samples/login__attributes_in_request_should_be_handled/request.json
@@ -4,7 +4,7 @@
     "password":"pwd",
     "account":"acc",
     "role": {
-      "attributes": {            
+      "$attributes": {            
         "internalId": "3",
         "externalId": "2"
       }

--- a/test/request-response-samples/login__attributes_in_request_should_be_handled/response.json
+++ b/test/request-response-samples/login__attributes_in_request_should_be_handled/response.json
@@ -1,12 +1,12 @@
 {
   "sessionResponse":{
     "status":{
-      "attributes":{
+      "$attributes":{
         "isSuccess":"true"
        }
     },
     "userId":{
-      "attributes":{
+      "$attributes":{
         "internalId":"1645"
        },
        "name":"SCPlus Dev"
@@ -14,7 +14,7 @@
     "wsRoleList":{
       "wsRole":{
         "role":{
-          "attributes":{
+          "$attributes":{
             "internalId":"3"
            },
            "name":"Administrator"

--- a/test/request-response-samples/login__complex_schema_xmlns_should_be_handled/response.json
+++ b/test/request-response-samples/login__complex_schema_xmlns_should_be_handled/response.json
@@ -1,12 +1,12 @@
 {
   "sessionResponse":{
     "status":{
-      "attributes":{
+      "$attributes":{
         "isSuccess":"true"
        }
     },
     "userId":{
-      "attributes":{
+      "$attributes":{
         "internalId":"1645"
        },
        "name":"SCPlus Dev"
@@ -14,7 +14,7 @@
     "wsRoleList":{
       "wsRole":{
         "role":{
-          "attributes":{
+          "$attributes":{
             "internalId":"3"
            },
            "name":"Administrator"

--- a/test/request-response-samples/update__complex_extension_fields_in_parent_without_explicit_namespace/request.json
+++ b/test/request-response-samples/update__complex_extension_fields_in_parent_without_explicit_namespace/request.json
@@ -1,6 +1,6 @@
 {
   "record":{
-    "attributes":{
+    "$attributes":{
       "internalId":"42",
       "externalId":"Alex Dniprovskyy",
       "xsi_type":{

--- a/test/request-response-samples/update__complex_extension_fields_in_parent_without_explicit_namespace/response.json
+++ b/test/request-response-samples/update__complex_extension_fields_in_parent_without_explicit_namespace/response.json
@@ -1,12 +1,12 @@
 {
   "writeResponse":{
     "status":{
-      "attributes":{
+      "$attributes":{
         "isSuccess":"true"
       }
     },
     "baseRef":{
-      "attributes":{
+      "$attributes":{
         "internalId":"42",
         "externalId":"Alex Dniprovskyy",
         "type":"contact",

--- a/test/request-response-samples/update__complex_extension_with_array_attributes/request.json
+++ b/test/request-response-samples/update__complex_extension_with_array_attributes/request.json
@@ -1,6 +1,6 @@
 {
   "record": {
-    "attributes": {
+    "$attributes": {
       "internalId": "42",
       "externalId": "Alex Dniprovskyy",
       "xsi_type": {
@@ -22,11 +22,11 @@
       "subscriptions": [
         {
           "subscribed": "true",
-          "attributes": {
+          "$attributes": {
             "tempId": "34"
           },
           "subscription": {
-            "attributes": {
+            "$attributes": {
               "internalId": "2",
               "xsi_type": {
                 "type": "RecordRef",
@@ -39,7 +39,7 @@
         {
           "subscribed": "true",
           "subscription": {
-            "attributes": {
+            "$attributes": {
               "internalId": "1",
               "xsi_type": {
                 "type": "RecordRef",

--- a/test/request-response-samples/update__complex_extension_with_array_attributes/response.json
+++ b/test/request-response-samples/update__complex_extension_with_array_attributes/response.json
@@ -1,12 +1,12 @@
 {
   "writeResponse":{
     "status":{
-      "attributes":{
+      "$attributes":{
         "isSuccess":"true"
       }
     },
     "baseRef":{
-      "attributes":{
+      "$attributes":{
         "internalId":"42",
         "externalId":"Alex Dniprovskyy",
         "type":"contact",


### PR DESCRIPTION
Certain webservices have actual elements named "attributes" 

``` xml
<tns:attributes>
   <tns:entry>
```
#272 Added in attributes, however it did not namespace the attributes.

In order to be soap compliant we should be namespacing the attributes tag, with this commit, i use $ to namespace.

Tests Passing.
