### PR TITLE
exception catching during parse phase

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -700,7 +700,11 @@ var WSDL = function(definition, uri, options) {
   }
 
   process.nextTick(function() {
-    fromFunc.call(self, definition);
+    try {
+      fromFunc.call(self, definition);
+    } catch (e) {
+      return self.callback(e.message);
+    }
 
     self.processIncludes(function(err) {
       var name;

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -36,6 +36,20 @@ wsdlNonStrictTests['should not parse connection error'] = function(done) {
   });
 };
 
+wsdlNonStrictTests['should catch parse error'] = function(done) {
+  soap.createClient(__dirname+'/wsdl/bad.txt', function(err) {
+    assert.notEqual(err, null);
+    done();
+  });
+};
+
+wsdlStrictTests['should catch parse error'] = function(done) {
+  soap.createClient(__dirname+'/wsdl/bad.txt', function(err) {
+    assert.notEqual(err, null);
+    done();
+  });
+};
+
 module.exports = {
   'WSDL Parser (strict)': wsdlStrictTests,
   'WSDL Parser (non-strict)': wsdlNonStrictTests

--- a/test/wsdl/bad.txt
+++ b/test/wsdl/bad.txt
@@ -1,0 +1,1 @@
+I'm a jpeg.


### PR DESCRIPTION
An exception raised while parsing XML now hands off to callback of `createConnection()` instead of throwing it into the ether (+tests)
