### PR TITLE
Fix default document binding style (supersede #208 PR).

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -730,6 +730,9 @@ var WSDL = function(definition, uri, options) {
       var bindings = self.definitions.bindings;
       for (var bindingName in bindings) {
         var binding = bindings[bindingName];
+        if (typeof binding.style == 'undefined') { 
+          binding.style = 'document'; 
+        }
         if (binding.style !== 'document')
           continue;
         var methods = binding.methods;

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -41,6 +41,16 @@ describe('SOAP Client', function() {
     });
     assert(!called);
   });
+
+  it('should set binding style to "document" by default if not explicitly set in WSDL, per SOAP spec', function (done) {
+    soap.createClient(__dirname+'/wsdl/binding_document.wsdl', function(err, client) {
+      assert.ok(client);
+      assert.ok(!err);
+      
+      assert.ok(client.wsdl.definitions.bindings.mySoapBinding.style === 'document');
+      done();
+    });
+  });
   
   describe('Extra headers in request and last response', function() {
     var server = null;

--- a/test/wsdl/binding_document.wsdl
+++ b/test/wsdl/binding_document.wsdl
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="myAPI">
+   <portType name="mySoapPort" />
+   <binding name="mySoapBinding" type="wsdlns:mySoapPort">
+      <soap:binding transport="http://schemas.xmlsoap.org/soap/http" />
+   </binding>
+   <service name="myAPI">
+      <port name="mySoapPort" binding="wsdlns:mySoapBinding">
+         <soap:address location="http://test" />
+      </port>
+   </service>
+</definitions>


### PR DESCRIPTION
This PR is a consolidated, functioning attempt at correcting the binding style (per SOAP spec) if not explicitly defined in the WSDL. It includes a test, and is intended to supersede the existing PR for Issue #208.
