### PR TITLE
Fix for adding an undefined XML namespace to the generated XML's child x...

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1119,11 +1119,12 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsA
                 childName = childParameterType.substring(childParameterType.indexOf(':') + 1);
               }
               var childXmlns = schema.xmlns[childNamespace];
-              var childXmlnsAttrib = ' xmlns:' + childNamespace + '="' + childXmlns+ '"';
-              if (ancXmlns.indexOf(childXmlns) !== -1) {
-                childXmlnsAttrib = '';
-              } else {
-                ancXmlns.push(childXmlns);
+              var childXmlnsAttrib = '';
+              if ((ancXmlns.indexOf(childXmlns) === -1) && (childXmlns)) {
+                childXmlnsAttrib = ' xmlns:' + childNamespace + '="' + childXmlns+ '"';
+                if ((childXmlns)) {
+                  ancXmlns.push(childXmlns);
+                }
               }
 
               var completeChildParameterTypeObject = self.findChildParameterObjectFromSchema(childName, childXmlns) || childParameterTypeObject;


### PR DESCRIPTION
...mlns attribute.

Converting a JSON object into XML was adding an undefined XML namespace attribute to a child element.    This change checks if the childXmlns is defined before allowing the childXmlnsAttribute to be created.  If the chidlXmlns is not defined then no xmlns is added to the child.

For example the following JSON object would generate this XML:

```
    var args = "Operation": {
                "CreateUser": {
                    "User": {
                        "A": aVar,
                        "B": bVar,
                        "C": cVar,
                        "D": dVar,
                        "E": eVar,
                        "F": fVar
                    },
                    "G":""
                }
            }
     client.admin(args, function(err, result) {};
```

  Created XML with undefined xmlns in child XML Attribute:

```
<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:typens="http://schemas.abc.com/abc11" xmlns:wsdlns="http://schemas.abc.com/abc11/wsdl" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <soap:Header/>
    <soap:Body>
        <typens:Admin xmlns="http://schemas.abc.com/abc11" xmlns:typens="http://schemas.abc.com/abc">
            <typens:Operation>
                <typens:CreateUser xmlns:typens="undefined">
                    <typens:User>
                        <typens:A>aVal</typens:Name>
                        <typens:B>bVal</typens:Password>
                        <typens:C>cVal</typens:Description>
                        <typens:D>dVal</typens:IsLoginDisabled>
                        <typens:E>eVal</typens:HomeFolder>
                        <typens:F>fVal</typens:HomeFolder>
                    </typens:User>
                    <typens:G/>
                </typens:CreateUser>
            </typens:Operation>
        </typens:Admin>
    </soap:Body>
</soap:Envelope>
```

Expected XML / XML generated with this change:

```
<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:typens="http://schemas.abc.com/abc11" xmlns:wsdlns="http://schemas.abc.com/abc11/wsdl" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <soap:Header/>
    <soap:Body>
        <typens:Admin xmlns="http://schemas.abc.com/abc11" xmlns:typens="http://schemas.abc.com/abc">
            <typens:Operation>
                <typens:CreateUser>
                    <typens:User>
                        <typens:A>aVal</typens:Name>
                        <typens:B>bVal</typens:Password>
                        <typens:C>cVal</typens:Description>
                        <typens:D>dVal</typens:IsLoginDisabled>
                        <typens:E>eVal</typens:HomeFolder>
                        <typens:F>fVal</typens:HomeFolder>
                    </typens:User>
                    <typens:G/>
                </typens:CreateUser>
            </typens:Operation>
        </typens:Admin>
    </soap:Body>
</soap:Envelope>
```
