### PR TITLE
Ignore unknown elements in definition

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -408,9 +408,6 @@ DefinitionsElement.prototype.addChild = function(child) {
   }
   else if (child instanceof DocumentationElement) {
   }
-  else {
-    assert(false, "Invalid child type");
-  }
   this.children.pop();
 };
 

--- a/test/wsdl/ws-policy.wsdl
+++ b/test/wsdl/ws-policy.wsdl
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" 
+xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" 
+xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+xmlns:tns="http://www.Dummy.com"  xmlns:n="http://www.Dummy.com/Name/Types"  xmlns:ns="http://schemas.xmlsoap.org/soap/encoding/" targetNamespace="http://www.Dummy.com">
+    <wsp:Policy wsu:Id="Dummy_policy">
+        <wsp:ExactlyOne>
+            <wsp:All>
+                <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+                    <wsp:Policy>
+                        <sp:TransportToken>
+                            <wsp:Policy>
+                                <sp:HttpsToken RequireClientCertificate="false"/>
+                            </wsp:Policy>
+                        </sp:TransportToken>
+                        <sp:AlgorithmSuite>
+                            <wsp:Policy>
+                                <sp:Basic256/>
+                            </wsp:Policy>
+                        </sp:AlgorithmSuite>
+                        <sp:Layout>
+                            <wsp:Policy>
+                                <sp:Strict/>
+                            </wsp:Policy>
+                        </sp:Layout>
+                    </wsp:Policy>
+                </sp:TransportBinding>
+            </wsp:All>
+        </wsp:ExactlyOne>
+    </wsp:Policy>
+	<wsdl:types>
+		<xs:schema>
+			<xs:import namespace="http://www.Dummy.com/Common/Types" schemaLocation="./Common.xsd"/>
+			<xs:import namespace="http://www.Dummy.com/Name/Types" schemaLocation="./Name.xsd"/>
+		</xs:schema>
+	</wsdl:types>
+	<wsdl:message name="DummyRequest">
+		<wsdl:part name="DummyRequest" element="n:DummyRequest"/>
+	</wsdl:message>
+	<wsdl:message name="DummyResponse">
+		<wsdl:part name="DummyResponse" element="n:DummyResponse"/>
+	</wsdl:message>
+	<wsdl:portType name="DummyPortType">
+		<wsdl:operation name="Dummy">
+			<wsdl:input message="tns:DummyRequest"/>
+			<wsdl:output message="tns:DummyResponse"/>
+		</wsdl:operation>
+	</wsdl:portType>
+	<wsdl:binding name="DummyBinding" type="tns:DummyPortType">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+		<wsdl:operation name="Dummy">
+			<soap:operation soapAction="http://www.Dummy.com#Dummy" style="document"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:service name="DummyService">
+		<wsdl:port name="DummyPortType" binding="tns:DummyBinding">
+			<soap:address location="http://www.Dummy.com/"/>
+		</wsdl:port>
+	</wsdl:service>
+</wsdl:definitions>
+


### PR DESCRIPTION
I'm trying to use node-soap against a wsdl that contains a ws-policy (http://www.w3.org/Submission/WS-Policy/) definition. Is there a reason to error if there is an unknown element in the definition?
