### PR TITLE
Fix error occurs when parsing WSDL where operation does not have definitions

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -215,7 +215,7 @@ var ElementTypeMap = {
   simpleContent: [SimpleContentElement,  'extension'],
   sequence: [SequenceElement, 'element choice any'],
   all: [AllElement, 'element choice'],
-    
+
   service: [ServiceElement, 'port documentation'],
   port: [PortElement, 'address documentation'],
   binding: [BindingElement, '_binding SecuritySpec operation documentation'],
@@ -634,7 +634,6 @@ BindingElement.prototype.postProcess = function(definitions) {
   if (portType){
     portType.postProcess(definitions);
     this.methods = portType.methods;
-    // delete portType.methods; both binding and portType should keep the same set of operations
 
     for (var i = 0, child; child = children[i]; i++) {
       if (child.name !== 'operation')
@@ -643,14 +642,15 @@ BindingElement.prototype.postProcess = function(definitions) {
       children.splice(i--, 1);
       child.style || (child.style = style);
       var method = this.methods[child.$name];
-      method.style = child.style;
-      method.soapAction = child.soapAction;
-      method.inputSoap = child.input || null;
-      method.outputSoap = child.output || null;
-      method.inputSoap && method.inputSoap.deleteFixedAttrs();
-      method.outputSoap && method.outputSoap.deleteFixedAttrs();
-      // delete method.$name; client will use it to make right request for top element name in body
-      // method.deleteFixedAttrs(); why ???
+
+      if (method) {
+        method.style = child.style;
+        method.soapAction = child.soapAction;
+        method.inputSoap = child.input || null;
+        method.outputSoap = child.output || null;
+        method.inputSoap && method.inputSoap.deleteFixedAttrs();
+        method.outputSoap && method.outputSoap.deleteFixedAttrs();
+      }
     }
   }
   delete this.$name;
@@ -705,7 +705,7 @@ RestrictionElement.prototype.description = function(definitions, xmlns) {
       ns = xmlns && xmlns[type.namespace] || definitions.xmlns[type.namespace],
       schema = definitions.schemas[ns],
       typeElement = schema && ( schema.complexTypes[typeName] || schema.types[typeName] || schema.elements[typeName] );
-    
+
     desc.getBase = function() {
       return typeElement.description(definitions, xmlns);
     };
@@ -802,7 +802,7 @@ ElementElement.prototype.description = function(definitions, xmlns) {
       ns = xmlns && xmlns[type.namespace] || definitions.xmlns[type.namespace],
       schema = definitions.schemas[ns],
       typeElement = schema && ( schema.complexTypes[typeName] || schema.types[typeName] || schema.elements[typeName] );
-  
+
     if (typeElement && !(typeName in Primitives)) {
 
       if (!(typeName in definitions.descriptions.types)) {
@@ -1342,6 +1342,9 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsA
       }
 
       var child = obj[name];
+      if (typeof child === 'undefined')
+        continue;
+
       var attr = self.processAttributes(child);
 
       var value = '';

--- a/test/wsdl/Dummy.wsdl
+++ b/test/wsdl/Dummy.wsdl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" 
-xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" 
-xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+xmlns:xs="http://www.w3.org/2001/XMLSchema"
 xmlns:tns="http://www.Dummy.com"  xmlns:n="http://www.Dummy.com/Name/Types"  xmlns:ns="http://schemas.xmlsoap.org/soap/encoding/" targetNamespace="http://www.Dummy.com">
 	<wsdl:types>
 		<xs:schema>
@@ -25,6 +25,15 @@ xmlns:tns="http://www.Dummy.com"  xmlns:n="http://www.Dummy.com/Name/Types"  xml
 		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
 		<wsdl:operation name="Dummy">
 			<soap:operation soapAction="http://www.Dummy.com#Dummy" style="document"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="DummySave">
+			<soap:operation soapAction="http://www.Dummy.com#DummySave" style="document"/>
 			<wsdl:input>
 				<soap:body use="literal"/>
 			</wsdl:input>


### PR DESCRIPTION
This also includes a "feature" to not serialize `undefined` element values in XML. If that is not a prerogative of the serializer, I can remove it.
