### PR TITLE
Remove possible existing BOM characters from XML String before passing i...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 node_js:
   - 0.8
   - 0.10
+before_install:
+  - npm install -g npm@~1.4.6

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -14,6 +14,7 @@ var fs = require('fs');
 var url = require('url');
 var path = require('path');
 var assert = require('assert').ok;
+var stripBom = require('strip-bom');
 
 var Primitives = {
   string: 1,
@@ -947,6 +948,7 @@ var WSDL = function(definition, uri, options) {
   this._initializeOptions(options);
 
   if (typeof definition === 'string') {
+    definition = stripBom(definition);
     fromFunc = this._fromXML;
   }
   else if (typeof definition === 'object') {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
   },
   "author": "Vinay Pulim <v@pulim.com>",
   "dependencies": {
-    "sax": ">=0.6",
+    "lodash": "~2.4.1",
     "request": ">=2.9.0",
-    "lodash": "~2.4.1"
+    "sax": ">=0.6",
+    "strip-bom": "~0.3.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
...t to `WSDL._fromXML()` and parsing it.

This PR uses the `strip-bom` module to remove possibly existing BOM characters of the `XML` string **before** it is passed to `WSDL._fromXML()` so that the `sax-parser` in `WSDL._parse` can operate on a _clean_ `XML` and also `WSDL.xml` is set to the BOM-stripped String representation.

I added no tests as the `strip-bom` module is used in the way it is showed at his own repository (https://github.com/sindresorhus/strip-bom) and is well-tested there. Any tests under `node-soap` would be redundant in my opinion.
