### PR TITLE
Modified to handle complex types

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -16,161 +16,161 @@ var path = require('path');
 var assert = require('assert').ok;
 
 var Primitives = {
-  string: 1,
-  boolean: 1,
-  decimal: 1,
-  float: 1,
-  double: 1,
-  anyType: 1,
-  byte: 1,
-  int: 1,
-  long: 1,
-  short: 1,
-  unsignedByte: 1,
-  unsignedInt: 1,
-  unsignedLong: 1,
-  unsignedShort: 1,
-  duration: 0,
-  dateTime: 0,
-  time: 0,
-  date: 0,
-  gYearMonth: 0,
-  gYear: 0,
-  gMonthDay: 0,
-  gDay: 0,
-  gMonth: 0,
-  hexBinary: 0,
-  base64Binary: 0,
-  anyURI: 0,
-  QName: 0,
-  NOTATION: 0
+    string: 1,
+    boolean: 1,
+    decimal: 1,
+    float: 1,
+    double: 1,
+    anyType: 1,
+    byte: 1,
+    int: 1,
+    long: 1,
+    short: 1,
+    unsignedByte: 1,
+    unsignedInt: 1,
+    unsignedLong: 1,
+    unsignedShort: 1,
+    duration: 0,
+    dateTime: 0,
+    time: 0,
+    date: 0,
+    gYearMonth: 0,
+    gYear: 0,
+    gMonthDay: 0,
+    gDay: 0,
+    gMonth: 0,
+    hexBinary: 0,
+    base64Binary: 0,
+    anyURI: 0,
+    QName: 0,
+    NOTATION: 0
 };
 
 function splitNSName(nsName) {
-  var i = typeof nsName === 'string' ? nsName.indexOf(':') : -1;
-  return i < 0 ? {namespace: 'xmlns', name: nsName} : {namespace: nsName.substring(0, i), name: nsName.substring(i + 1)};
+    var i = typeof nsName === 'string' ? nsName.indexOf(':') : -1;
+    return i < 0 ? {namespace: 'xmlns', name: nsName} : {namespace: nsName.substring(0, i), name: nsName.substring(i + 1)};
 }
 
 function xmlEscape(obj) {
-  if (typeof (obj) === 'string') {
-    return obj
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&apos;');
-  }
+    if (typeof (obj) === 'string') {
+        return obj
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&apos;');
+    }
 
-  return obj;
+    return obj;
 }
 
 var trimLeft = /^[\s\xA0]+/;
 var trimRight = /[\s\xA0]+$/;
 
 function trim(text) {
-  return text.replace(trimLeft, '').replace(trimRight, '');
+    return text.replace(trimLeft, '').replace(trimRight, '');
 }
 
 function extend(base, obj) {
-  for (var key in obj) {
-    if (!obj.hasOwnProperty(key)) {
-      base[key] = obj[key];
+    for (var key in obj) {
+        if (!obj.hasOwnProperty(key)) {
+            base[key] = obj[key];
+        }
     }
-  }
-  return base;
+    return base;
 }
 
 function findKey(obj, val) {
-  for (var n in obj)
-    if (obj[n] === val)
-      return n;
+    for (var n in obj)
+        if (obj[n] === val)
+            return n;
 }
 
-var Element = function(nsName, attrs, ignoredNamespaces) {
-  var parts = splitNSName(nsName);
+var Element = function (nsName, attrs, ignoredNamespaces) {
+    var parts = splitNSName(nsName);
 
-  this.nsName = nsName;
-  this.namespace = parts.namespace;
-  this.ignoredNamespaces = ignoredNamespaces;
-  this.name = parts.name;
-  this.children = [];
-  this.xmlns = {};
-  for (var key in attrs) {
-    var match = /^xmlns:?(.*)$/.exec(key);
-    if (match) {
-      this.xmlns[match[1] ? match[1] : 'xmlns'] = attrs[key];
+    this.nsName = nsName;
+    this.namespace = parts.namespace;
+    this.ignoredNamespaces = ignoredNamespaces;
+    this.name = parts.name;
+    this.children = [];
+    this.xmlns = {};
+    for (var key in attrs) {
+        var match = /^xmlns:?(.*)$/.exec(key);
+        if (match) {
+            this.xmlns[match[1] ? match[1] : 'xmlns'] = attrs[key];
+        }
+        else {
+            this['$' + key] = attrs[key];
+        }
     }
-    else {
-      this['$' + key] = attrs[key];
-    }
-  }
 };
 
-Element.prototype.deleteFixedAttrs = function() {
-  this.children && this.children.length === 0 && delete this.children;
-  this.xmlns && Object.keys(this.xmlns).length === 0 && delete this.xmlns;
-  delete this.nsName;
-  delete this.namespace;
-  delete this.name;
+Element.prototype.deleteFixedAttrs = function () {
+    this.children && this.children.length === 0 && delete this.children;
+    this.xmlns && Object.keys(this.xmlns).length === 0 && delete this.xmlns;
+    delete this.nsName;
+    delete this.namespace;
+    delete this.name;
 };
 
 Element.prototype.allowedChildren = [];
 
-Element.prototype.startElement = function(stack, nsName, attrs, ignoredNamespaces) {
-  if (!this.allowedChildren)
-    return;
+Element.prototype.startElement = function (stack, nsName, attrs, ignoredNamespaces) {
+    if (!this.allowedChildren)
+        return;
 
-  var ChildClass = this.allowedChildren[splitNSName(nsName).name],
-    element = null;
+    var ChildClass = this.allowedChildren[splitNSName(nsName).name],
+        element = null;
 
-  if (ChildClass) {
-    stack.push(new ChildClass(nsName, attrs, ignoredNamespaces));
-  }
-  else {
-    this.unexpected(nsName);
-  }
-
-};
-
-Element.prototype.endElement = function(stack, nsName) {
-  if (this.nsName === nsName) {
-    if (stack.length < 2)
-      return;
-    var parent = stack[stack.length - 2];
-    if (this !== stack[0]) {
-      extend(stack[0].xmlns, this.xmlns);
-      // delete this.xmlns;
-      parent.children.push(this);
-      parent.addChild(this);
+    if (ChildClass) {
+        stack.push(new ChildClass(nsName, attrs, ignoredNamespaces));
     }
-    stack.pop();
-  }
+    else {
+        this.unexpected(nsName);
+    }
+
 };
 
-Element.prototype.addChild = function(child) {
-  return;
+Element.prototype.endElement = function (stack, nsName) {
+    if (this.nsName === nsName) {
+        if (stack.length < 2)
+            return;
+        var parent = stack[stack.length - 2];
+        if (this !== stack[0]) {
+            extend(stack[0].xmlns, this.xmlns);
+            // delete this.xmlns;
+            parent.children.push(this);
+            parent.addChild(this);
+        }
+        stack.pop();
+    }
 };
 
-Element.prototype.unexpected = function(name) {
-  throw new Error('Found unexpected element (' + name + ') inside ' + this.nsName);
+Element.prototype.addChild = function (child) {
+    return;
 };
 
-Element.prototype.description = function(definitions) {
-  return this.$name || this.name;
+Element.prototype.unexpected = function (name) {
+    throw new Error('Found unexpected element (' + name + ') inside ' + this.nsName);
 };
 
-Element.prototype.init = function() {
+Element.prototype.description = function (definitions) {
+    return this.$name || this.name;
 };
 
-Element.createSubClass = function() {
-  var root = this;
-  var subElement = function() {
-    root.apply(this, arguments);
-    this.init();
-  };
-  // inherits(subElement, root);
-  subElement.prototype.__proto__ = root.prototype;
-  return subElement;
+Element.prototype.init = function () {
+};
+
+Element.createSubClass = function () {
+    var root = this;
+    var subElement = function () {
+        root.apply(this, arguments);
+        this.init();
+    };
+    // inherits(subElement, root);
+    subElement.prototype.__proto__ = root.prototype;
+    return subElement;
 };
 
 
@@ -201,329 +201,329 @@ var ServiceElement = Element.createSubClass();
 var DefinitionsElement = Element.createSubClass();
 
 var ElementTypeMap = {
-  types: [TypesElement, 'schema documentation'],
-  schema: [SchemaElement, 'element complexType simpleType include import'],
-  element: [ElementElement, 'annotation complexType'],
-  any: [AnyElement, ''],
-  simpleType: [SimpleTypeElement, 'restriction'],
-  restriction: [RestrictionElement, 'enumeration choice sequence'],
-  extension: [ExtensionElement, 'sequence choice'],
-  choice: [ChoiceElement, 'element choice'],
+    types: [TypesElement, 'schema documentation'],
+    schema: [SchemaElement, 'element complexType simpleType include import'],
+    element: [ElementElement, 'annotation complexType'],
+    any: [AnyElement, ''],
+    simpleType: [SimpleTypeElement, 'restriction'],
+    restriction: [RestrictionElement, 'enumeration choice sequence'],
+    extension: [ExtensionElement, 'sequence choice'],
+    choice: [ChoiceElement, 'element choice'],
     // group: [GroupElement, 'element group'],
-  enumeration: [EnumerationElement, ''],
-  complexType: [ComplexTypeElement,  'annotation sequence all complexContent simpleContent choice'],
-  complexContent: [ComplexContentElement,  'extension'],
-  simpleContent: [SimpleContentElement,  'extension'],
-  sequence: [SequenceElement, 'element choice any'],
-  all: [AllElement, 'element choice'],
+    enumeration: [EnumerationElement, ''],
+    complexType: [ComplexTypeElement, 'annotation sequence all complexContent simpleContent choice'],
+    complexContent: [ComplexContentElement, 'extension'],
+    simpleContent: [SimpleContentElement, 'extension'],
+    sequence: [SequenceElement, 'element choice any'],
+    all: [AllElement, 'element choice'],
 
-  service: [ServiceElement, 'port documentation'],
-  port: [PortElement, 'address documentation'],
-  binding: [BindingElement, '_binding SecuritySpec operation documentation'],
-  portType: [PortTypeElement, 'operation documentation'],
-  message: [MessageElement, 'part documentation'],
-  operation: [OperationElement, 'documentation input output fault _operation'],
-  input: [InputElement, 'body SecuritySpecRef documentation header'],
-  output: [OutputElement, 'body SecuritySpecRef documentation header'],
-  fault: [Element, '_fault documentation'],
-  definitions: [DefinitionsElement, 'types message portType binding service import documentation'],
-  documentation: [DocumentationElement, '']
+    service: [ServiceElement, 'port documentation'],
+    port: [PortElement, 'address documentation'],
+    binding: [BindingElement, '_binding SecuritySpec operation documentation'],
+    portType: [PortTypeElement, 'operation documentation'],
+    message: [MessageElement, 'part documentation'],
+    operation: [OperationElement, 'documentation input output fault _operation'],
+    input: [InputElement, 'body SecuritySpecRef documentation header'],
+    output: [OutputElement, 'body SecuritySpecRef documentation header'],
+    fault: [Element, '_fault documentation'],
+    definitions: [DefinitionsElement, 'types message portType binding service import documentation'],
+    documentation: [DocumentationElement, '']
 };
 
 function mapElementTypes(types) {
-  var rtn = {};
-  types = types.split(' ');
-  types.forEach(function(type) {
-    rtn[type.replace(/^_/, '')] = (ElementTypeMap[type] || [Element]) [0];
-  });
-  return rtn;
+    var rtn = {};
+    types = types.split(' ');
+    types.forEach(function (type) {
+        rtn[type.replace(/^_/, '')] = (ElementTypeMap[type] || [Element]) [0];
+    });
+    return rtn;
 }
 
 for (var n in ElementTypeMap) {
-  var v = ElementTypeMap[n];
-  v[0].prototype.allowedChildren = mapElementTypes(v[1]);
+    var v = ElementTypeMap[n];
+    v[0].prototype.allowedChildren = mapElementTypes(v[1]);
 }
 
-MessageElement.prototype.init = function() {
-  this.element = null;
-  this.parts = null;
+MessageElement.prototype.init = function () {
+    this.element = null;
+    this.parts = null;
 };
 
-SchemaElement.prototype.init = function() {
-  this.complexTypes = {};
-  this.types = {};
-  this.elements = {};
-  this.includes = [];
+SchemaElement.prototype.init = function () {
+    this.complexTypes = {};
+    this.types = {};
+    this.elements = {};
+    this.includes = [];
 };
 
-TypesElement.prototype.init = function() {
-  this.schemas = {};
+TypesElement.prototype.init = function () {
+    this.schemas = {};
 };
 
-OperationElement.prototype.init = function() {
-  this.input = null;
-  this.output = null;
-  this.inputSoap = null;
-  this.outputSoap = null;
-  this.style = '';
-  this.soapAction = '';
+OperationElement.prototype.init = function () {
+    this.input = null;
+    this.output = null;
+    this.inputSoap = null;
+    this.outputSoap = null;
+    this.style = '';
+    this.soapAction = '';
 };
 
-PortTypeElement.prototype.init = function() {
-  this.methods = {};
+PortTypeElement.prototype.init = function () {
+    this.methods = {};
 };
 
-BindingElement.prototype.init = function() {
-  this.transport = '';
-  this.style = '';
-  this.methods = {};
+BindingElement.prototype.init = function () {
+    this.transport = '';
+    this.style = '';
+    this.methods = {};
 };
 
-PortElement.prototype.init = function() {
-  this.location = null;
+PortElement.prototype.init = function () {
+    this.location = null;
 };
 
-ServiceElement.prototype.init = function() {
-  this.ports = {};
+ServiceElement.prototype.init = function () {
+    this.ports = {};
 };
 
-DefinitionsElement.prototype.init = function() {
-  if (this.name !== 'definitions')this.unexpected(this.nsName);
-  this.messages = {};
-  this.portTypes = {};
-  this.bindings = {};
-  this.services = {};
-  this.schemas = {};
+DefinitionsElement.prototype.init = function () {
+    if (this.name !== 'definitions')this.unexpected(this.nsName);
+    this.messages = {};
+    this.portTypes = {};
+    this.bindings = {};
+    this.services = {};
+    this.schemas = {};
 };
 
-DocumentationElement.prototype.init = function() {
+DocumentationElement.prototype.init = function () {
 };
 
-SchemaElement.prototype.addChild = function(child) {
-  if (child.$name in Primitives)
-    return;
-  if (child.name === 'include' || child.name === 'import') {
-    var location = child.$schemaLocation || child.$location;
-    if (location) {
-      this.includes.push({
-        namespace: child.$namespace || child.$targetNamespace || this.$targetNamespace,
-        location: location
-      });
+SchemaElement.prototype.addChild = function (child) {
+    if (child.$name in Primitives)
+        return;
+    if (child.name === 'include' || child.name === 'import') {
+        var location = child.$schemaLocation || child.$location;
+        if (location) {
+            this.includes.push({
+                namespace: child.$namespace || child.$targetNamespace || this.$targetNamespace,
+                location: location
+            });
+        }
     }
-  }
-  else if (child.name === 'complexType') {
-    this.complexTypes[child.$name] = child;
-  }
-  else if (child.name === 'element') {
-    this.elements[child.$name] = child;
-  }
-  else if (child.$name) {
-    this.types[child.$name] = child;
-  }
-  this.children.pop();
-  // child.deleteFixedAttrs();
+    else if (child.name === 'complexType') {
+        this.complexTypes[child.$name] = child;
+    }
+    else if (child.name === 'element') {
+        this.elements[child.$name] = child;
+    }
+    else if (child.$name) {
+        this.types[child.$name] = child;
+    }
+    this.children.pop();
+    // child.deleteFixedAttrs();
 };
 //fix#325
 TypesElement.prototype.addChild = function (child) {
-  assert(child instanceof SchemaElement);
+    assert(child instanceof SchemaElement);
 
-  var targetNamespace = child.$targetNamespace;
+    var targetNamespace = child.$targetNamespace;
 
-  if(!targetNamespace) {
-    if(child.includes && (child.includes instanceof Array) && child.includes.length > 0) {
-      targetNamespace = child.includes[0].namespace;
+    if (!targetNamespace) {
+        if (child.includes && (child.includes instanceof Array) && child.includes.length > 0) {
+            targetNamespace = child.includes[0].namespace;
+        }
     }
-  }
 
-  if(!this.schemas.hasOwnProperty(targetNamespace)) {
-    this.schemas[targetNamespace] = child;
-  } else {
-    console.error('Target-Namespace "'+ targetNamespace +'" already in use by another Schema!');
-  }
+    if (!this.schemas.hasOwnProperty(targetNamespace)) {
+        this.schemas[targetNamespace] = child;
+    } else {
+        console.error('Target-Namespace "' + targetNamespace + '" already in use by another Schema!');
+    }
 };
 
-InputElement.prototype.addChild = function(child) {
-  if (child.name === 'body') {
-    this.use = child.$use;
-    if (this.use === 'encoded') {
-      this.encodingStyle = child.$encodingStyle;
+InputElement.prototype.addChild = function (child) {
+    if (child.name === 'body') {
+        this.use = child.$use;
+        if (this.use === 'encoded') {
+            this.encodingStyle = child.$encodingStyle;
+        }
+        this.children.pop();
+    }
+};
+
+OutputElement.prototype.addChild = function (child) {
+    if (child.name === 'body') {
+        this.use = child.$use;
+        if (this.use === 'encoded') {
+            this.encodingStyle = child.$encodingStyle;
+        }
+        this.children.pop();
+    }
+};
+
+OperationElement.prototype.addChild = function (child) {
+    if (child.name === 'operation') {
+        this.soapAction = child.$soapAction || '';
+        this.style = child.$style || '';
+        this.children.pop();
+    }
+};
+
+BindingElement.prototype.addChild = function (child) {
+    if (child.name === 'binding') {
+        this.transport = child.$transport;
+        this.style = child.$style;
+        this.children.pop();
+    }
+};
+
+PortElement.prototype.addChild = function (child) {
+    if (child.name === 'address' && typeof (child.$location) !== 'undefined') {
+        this.location = child.$location;
+    }
+};
+
+DefinitionsElement.prototype.addChild = function (child) {
+    var self = this;
+    if (child instanceof TypesElement) {
+        self.schemas = child.schemas;
+    }
+    else if (child instanceof MessageElement) {
+        self.messages[child.$name] = child;
+    }
+    else if (child.name === 'import') {
+        self.schemas[child.$namespace] = new SchemaElement(child.$namespace, {});
+        self.schemas[child.$namespace].addChild(child);
+    }
+    else if (child instanceof PortTypeElement) {
+        self.portTypes[child.$name] = child;
+    }
+    else if (child instanceof BindingElement) {
+        if (child.transport === 'http://schemas.xmlsoap.org/soap/http' ||
+            child.transport === 'http://www.w3.org/2003/05/soap/bindings/HTTP/')
+            self.bindings[child.$name] = child;
+    }
+    else if (child instanceof ServiceElement) {
+        self.services[child.$name] = child;
+    }
+    else if (child instanceof DocumentationElement) {
     }
     this.children.pop();
-  }
 };
 
-OutputElement.prototype.addChild = function(child) {
-  if (child.name === 'body') {
-    this.use = child.$use;
-    if (this.use === 'encoded') {
-      this.encodingStyle = child.$encodingStyle;
-    }
-    this.children.pop();
-  }
-};
+MessageElement.prototype.postProcess = function (definitions) {
+    var part = null;
+    var child;
+    var children = this.children || [];
+    var ns;
+    var nsName;
+    var i;
+    var type;
 
-OperationElement.prototype.addChild = function(child) {
-  if (child.name === 'operation') {
-    this.soapAction = child.$soapAction || '';
-    this.style = child.$style || '';
-    this.children.pop();
-  }
-};
-
-BindingElement.prototype.addChild = function(child) {
-  if (child.name === 'binding') {
-    this.transport = child.$transport;
-    this.style = child.$style;
-    this.children.pop();
-  }
-};
-
-PortElement.prototype.addChild = function(child) {
-  if (child.name === 'address' && typeof (child.$location) !== 'undefined') {
-    this.location = child.$location;
-  }
-};
-
-DefinitionsElement.prototype.addChild = function(child) {
-  var self = this;
-  if (child instanceof TypesElement) {
-    self.schemas = child.schemas;
-  }
-  else if (child instanceof MessageElement) {
-    self.messages[child.$name] = child;
-  }
-  else if (child.name === 'import') {
-    self.schemas[child.$namespace] = new SchemaElement(child.$namespace, {});
-    self.schemas[child.$namespace].addChild(child);
-  }
-  else if (child instanceof PortTypeElement) {
-    self.portTypes[child.$name] = child;
-  }
-  else if (child instanceof BindingElement) {
-    if (child.transport === 'http://schemas.xmlsoap.org/soap/http' ||
-      child.transport === 'http://www.w3.org/2003/05/soap/bindings/HTTP/')
-      self.bindings[child.$name] = child;
-  }
-  else if (child instanceof ServiceElement) {
-    self.services[child.$name] = child;
-  }
-  else if (child instanceof DocumentationElement) {
-  }
-  this.children.pop();
-};
-
-MessageElement.prototype.postProcess = function(definitions) {
-  var part = null;
-  var child;
-  var children = this.children || [];
-  var ns;
-  var nsName;
-  var i;
-  var type;
-
-  for (i in children) {
-    if ((child = children[i]).name === 'part') {
-      part = child;
-      break;
-    }
-  }
-
-  if (!part) {
-    return;
-  }
-
-  if (part.$element) {
-    var lookupTypes = [],
-        elementChildren ;
-
-    delete this.parts;
-
-    nsName = splitNSName(part.$element);
-    ns = nsName.namespace;
-    var schema = definitions.schemas[definitions.xmlns[ns]];
-    this.element = schema.elements[nsName.name];
-    this.element.targetNSAlias = ns;
-    this.element.targetNamespace = definitions.xmlns[ns];
-
-    // set the optional $lookupType to be used within `client#_invoke()` when
-    // calling `wsdl#objectToDocumentXML()
-    this.element.$lookupType = part.$name;
-
-    elementChildren = this.element.children;
-
-    // get all nested lookup types (only complex types are followed)
-    if (elementChildren.length > 0) {
-      for (i = 0; i < elementChildren.length; i++) {
-        lookupTypes.push(this._getNestedLookupTypeString(elementChildren[i]));
-      }
+    for (i in children) {
+        if ((child = children[i]).name === 'part') {
+            part = child;
+            break;
+        }
     }
 
-    // if nested lookup types where found, prepare them for furter usage
-    if (lookupTypes.length > 0) {
-      lookupTypes = lookupTypes.
-          join('_').
-          split('_').
-          filter(function removeEmptyLookupTypes (type) {
-            return type !== '^';
-          });
-
-      var schemaXmlns = definitions.schemas[this.element.targetNamespace].xmlns;
-
-      for (i = 0; i < lookupTypes.length; i++) {
-        lookupTypes[i] = this._createLookupTypeObject(lookupTypes[i], schemaXmlns);
-      }
+    if (!part) {
+        return;
     }
 
-    this.element.$lookupTypes = lookupTypes;
+    if (part.$element) {
+        var lookupTypes = [],
+            elementChildren;
 
-    if (this.element.$type) {
-      type = splitNSName(this.element.$type);
-      var typeNs = schema.xmlns && schema.xmlns[type.namespace] || definitions.xmlns[type.namespace];
+        delete this.parts;
 
-      if (typeNs) {
-        if (type.name in Primitives) {
-            // this.element = this.element.$type;
+        nsName = splitNSName(part.$element);
+        ns = nsName.namespace;
+        var schema = definitions.schemas[definitions.xmlns[ns]];
+        this.element = schema.elements[nsName.name];
+        this.element.targetNSAlias = ns;
+        this.element.targetNamespace = definitions.xmlns[ns];
+
+        // set the optional $lookupType to be used within `client#_invoke()` when
+        // calling `wsdl#objectToDocumentXML()
+        this.element.$lookupType = part.$name;
+
+        elementChildren = this.element.children;
+
+        // get all nested lookup types (only complex types are followed)
+        if (elementChildren.length > 0) {
+            for (i = 0; i < elementChildren.length; i++) {
+                lookupTypes.push(this._getNestedLookupTypeString(elementChildren[i]));
+            }
+        }
+
+        // if nested lookup types where found, prepare them for furter usage
+        if (lookupTypes.length > 0) {
+            lookupTypes = lookupTypes.
+                join('_').
+                split('_').
+                filter(function removeEmptyLookupTypes(type) {
+                    return type !== '^';
+                });
+
+            var schemaXmlns = definitions.schemas[this.element.targetNamespace].xmlns;
+
+            for (i = 0; i < lookupTypes.length; i++) {
+                lookupTypes[i] = this._createLookupTypeObject(lookupTypes[i], schemaXmlns);
+            }
+        }
+
+        this.element.$lookupTypes = lookupTypes;
+
+        if (this.element.$type) {
+            type = splitNSName(this.element.$type);
+            var typeNs = schema.xmlns && schema.xmlns[type.namespace] || definitions.xmlns[type.namespace];
+
+            if (typeNs) {
+                if (type.name in Primitives) {
+                    // this.element = this.element.$type;
+                }
+                else {
+                    // first check local mapping of ns alias to namespace
+                    schema = definitions.schemas[typeNs];
+                    var ctype = schema.complexTypes[type.name] || schema.types[type.name] || schema.elements[type.name];
+
+
+                    if (ctype) {
+                        this.parts = ctype.description(definitions, schema.xmlns);
+                    }
+                }
+            }
         }
         else {
-          // first check local mapping of ns alias to namespace
-          schema = definitions.schemas[typeNs];
-          var ctype = schema.complexTypes[type.name] || schema.types[type.name] || schema.elements[type.name];
-
-
-          if (ctype) {
-            this.parts = ctype.description(definitions, schema.xmlns);
-          }
+            var method = this.element.description(definitions, schema.xmlns);
+            this.parts = method[nsName.name];
         }
-      }
-    }
-    else {
-      var method = this.element.description(definitions, schema.xmlns);
-      this.parts = method[nsName.name];
-    }
 
 
-    this.children.splice(0, 1);
-  } else {
-    // rpc encoding
-    this.parts = {};
-    delete this.element;
-    for (i = 0; part = this.children[i]; i++) {
-      assert(part.name === 'part', 'Expected part element');
-      nsName = splitNSName(part.$type);
-      ns = definitions.xmlns[nsName.namespace];
-      type = nsName.name;
-      var schemaDefinition = definitions.schemas[ns];
-      if (typeof schemaDefinition !== 'undefined') {
-        this.parts[part.$name] = definitions.schemas[ns].types[type] || definitions.schemas[ns].complexTypes[type];
-      } else {
-        this.parts[part.$name] = part.$type;
-      }
-      this.parts[part.$name].namespace = nsName.namespace;
-      this.parts[part.$name].xmlns = ns;
-      this.children.splice(i--, 1);
+        this.children.splice(0, 1);
+    } else {
+        // rpc encoding
+        this.parts = {};
+        delete this.element;
+        for (i = 0; part = this.children[i]; i++) {
+            assert(part.name === 'part', 'Expected part element');
+            nsName = splitNSName(part.$type);
+            ns = definitions.xmlns[nsName.namespace];
+            type = nsName.name;
+            var schemaDefinition = definitions.schemas[ns];
+            if (typeof schemaDefinition !== 'undefined') {
+                this.parts[part.$name] = definitions.schemas[ns].types[type] || definitions.schemas[ns].complexTypes[type];
+            } else {
+                this.parts[part.$name] = part.$type;
+            }
+            this.parts[part.$name].namespace = nsName.namespace;
+            this.parts[part.$name].xmlns = ns;
+            this.children.splice(i--, 1);
+        }
     }
-  }
-  this.deleteFixedAttrs();
+    this.deleteFixedAttrs();
 };
 
 /**
@@ -538,18 +538,18 @@ MessageElement.prototype.postProcess = function(definitions) {
  * @private
  */
 MessageElement.prototype._createLookupTypeObject = function (nsString, xmlns) {
-  var splittedNSString = splitNSName(nsString),
-      nsAlias = splittedNSString.namespace,
-      splittedName = splittedNSString.name.split('#'),
-      type = splittedName[0],
-      name = splittedName[1],
-      lookupTypeObj = {};
+    var splittedNSString = splitNSName(nsString),
+        nsAlias = splittedNSString.namespace,
+        splittedName = splittedNSString.name.split('#'),
+        type = splittedName[0],
+        name = splittedName[1],
+        lookupTypeObj = {};
 
-  lookupTypeObj.$namespace = xmlns[nsAlias];
-  lookupTypeObj.$type = nsAlias + ':' + type;
-  lookupTypeObj.$name = name;
+    lookupTypeObj.$namespace = xmlns[nsAlias];
+    lookupTypeObj.$type = nsAlias + ':' + type;
+    lookupTypeObj.$name = name;
 
-  return lookupTypeObj;
+    return lookupTypeObj;
 };
 
 /**
@@ -563,864 +563,757 @@ MessageElement.prototype._createLookupTypeObject = function (nsString, xmlns) {
  * @private
  */
 MessageElement.prototype._getNestedLookupTypeString = function (element) {
-  var resolvedType = '^',
-      excluded = this.ignoredNamespaces.concat('xs'); // do not process $type values wich start with
+    var resolvedType = '^',
+        excluded = this.ignoredNamespaces.concat('xs'); // do not process $type values wich start with
 
-  if (element.hasOwnProperty('$type') && typeof element.$type === 'string') {
-    if (excluded.indexOf(element.$type.split(':')[0]) === -1) {
-      resolvedType += ('_' + element.$type + '#' + element.$name);
+    if (element.hasOwnProperty('$type') && typeof element.$type === 'string') {
+        if (excluded.indexOf(element.$type.split(':')[0]) === -1) {
+            resolvedType += ('_' + element.$type + '#' + element.$name);
+        }
     }
-  }
 
-  if (element.children.length > 0) {
-    var self = this;
+    if (element.children.length > 0) {
+        var self = this;
 
-    element.children.forEach(function (child) {
-      var resolvedChildType = self._getNestedLookupTypeString(child).replace(/\^_/, '');
+        element.children.forEach(function (child) {
+            var resolvedChildType = self._getNestedLookupTypeString(child).replace(/\^_/, '');
 
-      if (resolvedChildType && typeof resolvedChildType === 'string') {
-        resolvedType += ('_' + resolvedChildType);
-      }
-    });
-  }
+            if (resolvedChildType && typeof resolvedChildType === 'string') {
+                resolvedType += ('_' + resolvedChildType);
+            }
+        });
+    }
 
-  return resolvedType;
+    return resolvedType;
 };
 
-OperationElement.prototype.postProcess = function(definitions, tag) {
-  var children = this.children;
-  for (var i = 0, child; child = children[i]; i++) {
-    if (child.name !== 'input' && child.name !== 'output')
-      continue;
-    if (tag === 'binding') {
-      this[child.name] = child;
-      children.splice(i--, 1);
-      continue;
-    }
-    var messageName = splitNSName(child.$message).name;
-    var message = definitions.messages[messageName];
-    message.postProcess(definitions);
-    if (message.element) {
-      definitions.messages[message.element.$name] = message;
-      this[child.name] = message.element;
-    }
-    else {
-      this[child.name] = message;
-    }
-    children.splice(i--, 1);
-  }
-  this.deleteFixedAttrs();
-};
-
-PortTypeElement.prototype.postProcess = function(definitions) {
-  var children = this.children;
-  if (typeof children === 'undefined')
-    return;
-  for (var i = 0, child; child = children[i]; i++) {
-    if (child.name !== 'operation')
-      continue;
-    child.postProcess(definitions, 'portType');
-    this.methods[child.$name] = child;
-    children.splice(i--, 1);
-  }
-  delete this.$name;
-  this.deleteFixedAttrs();
-};
-
-BindingElement.prototype.postProcess = function(definitions) {
-  var type = splitNSName(this.$type).name,
-    portType = definitions.portTypes[type],
-    style = this.style,
-    children = this.children;
-  if (portType){
-    portType.postProcess(definitions);
-    this.methods = portType.methods;
-
+OperationElement.prototype.postProcess = function (definitions, tag) {
+    var children = this.children;
     for (var i = 0, child; child = children[i]; i++) {
-      if (child.name !== 'operation')
-        continue;
-      child.postProcess(definitions, 'binding');
-      children.splice(i--, 1);
-      child.style || (child.style = style);
-      var method = this.methods[child.$name];
-
-      if (method) {
-        method.style = child.style;
-        method.soapAction = child.soapAction;
-        method.inputSoap = child.input || null;
-        method.outputSoap = child.output || null;
-        method.inputSoap && method.inputSoap.deleteFixedAttrs();
-        method.outputSoap && method.outputSoap.deleteFixedAttrs();
-      }
+        if (child.name !== 'input' && child.name !== 'output')
+            continue;
+        if (tag === 'binding') {
+            this[child.name] = child;
+            children.splice(i--, 1);
+            continue;
+        }
+        var messageName = splitNSName(child.$message).name;
+        var message = definitions.messages[messageName];
+        message.postProcess(definitions);
+        if (message.element) {
+            definitions.messages[message.element.$name] = message;
+            this[child.name] = message.element;
+        }
+        else {
+            this[child.name] = message;
+        }
+        children.splice(i--, 1);
     }
-  }
-  delete this.$name;
-  delete this.$type;
-  this.deleteFixedAttrs();
+    this.deleteFixedAttrs();
 };
 
-ServiceElement.prototype.postProcess = function(definitions) {
-  var children = this.children,
-    bindings = definitions.bindings;
-  for (var i = 0, child; child = children[i]; i++) {
-    if (child.name !== 'port')
-      continue;
-    var bindingName = splitNSName(child.$binding).name;
-    var binding = bindings[bindingName];
-    if (binding) {
-      binding.postProcess(definitions);
-      this.ports[child.$name] = {
-        location: child.location,
-        binding: binding
-      };
-      children.splice(i--, 1);
+PortTypeElement.prototype.postProcess = function (definitions) {
+    var children = this.children;
+    if (typeof children === 'undefined')
+        return;
+    for (var i = 0, child; child = children[i]; i++) {
+        if (child.name !== 'operation')
+            continue;
+        child.postProcess(definitions, 'portType');
+        this.methods[child.$name] = child;
+        children.splice(i--, 1);
     }
-  }
-  delete this.$name;
-  this.deleteFixedAttrs();
+    delete this.$name;
+    this.deleteFixedAttrs();
+};
+
+BindingElement.prototype.postProcess = function (definitions) {
+    var type = splitNSName(this.$type).name,
+        portType = definitions.portTypes[type],
+        style = this.style,
+        children = this.children;
+    if (portType) {
+        portType.postProcess(definitions);
+        this.methods = portType.methods;
+
+        for (var i = 0, child; child = children[i]; i++) {
+            if (child.name !== 'operation')
+                continue;
+            child.postProcess(definitions, 'binding');
+            children.splice(i--, 1);
+            child.style || (child.style = style);
+            var method = this.methods[child.$name];
+
+            if (method) {
+                method.style = child.style;
+                method.soapAction = child.soapAction;
+                method.inputSoap = child.input || null;
+                method.outputSoap = child.output || null;
+                method.inputSoap && method.inputSoap.deleteFixedAttrs();
+                method.outputSoap && method.outputSoap.deleteFixedAttrs();
+            }
+        }
+    }
+    delete this.$name;
+    delete this.$type;
+    this.deleteFixedAttrs();
+};
+
+ServiceElement.prototype.postProcess = function (definitions) {
+    var children = this.children,
+        bindings = definitions.bindings;
+    for (var i = 0, child; child = children[i]; i++) {
+        if (child.name !== 'port')
+            continue;
+        var bindingName = splitNSName(child.$binding).name;
+        var binding = bindings[bindingName];
+        if (binding) {
+            binding.postProcess(definitions);
+            this.ports[child.$name] = {
+                location: child.location,
+                binding: binding
+            };
+            children.splice(i--, 1);
+        }
+    }
+    delete this.$name;
+    this.deleteFixedAttrs();
 };
 
 
-SimpleTypeElement.prototype.description = function(definitions) {
-  var children = this.children;
-  for (var i = 0, child; child = children[i]; i++) {
-    if (child instanceof RestrictionElement)
-      return this.$name + "|" + child.description();
-  }
-  return {};
+SimpleTypeElement.prototype.description = function (definitions) {
+    var children = this.children;
+    for (var i = 0, child; child = children[i]; i++) {
+        if (child instanceof RestrictionElement)
+            return this.$name + "|" + child.description();
+    }
+    return {};
 };
 
-RestrictionElement.prototype.description = function(definitions, xmlns) {
-  var children = this.children;
-  var desc;
-  for (var i=0, child; child=children[i]; i++) {
-    if (child instanceof SequenceElement ||
+RestrictionElement.prototype.description = function (definitions, xmlns) {
+    var children = this.children;
+    var desc;
+    for (var i = 0, child; child = children[i]; i++) {
+        if (child instanceof SequenceElement ||
             child instanceof ChoiceElement) {
-      desc = child.description(definitions);
-      break;
+            desc = child.description(definitions);
+            break;
+        }
     }
-  }
-  if (desc && this.$base) {
-    var type = splitNSName(this.$base),
-      typeName = type.name,
-      ns = xmlns && xmlns[type.namespace] || definitions.xmlns[type.namespace],
-      schema = definitions.schemas[ns],
-      typeElement = schema && ( schema.complexTypes[typeName] || schema.types[typeName] || schema.elements[typeName] );
+    if (desc && this.$base) {
+        var type = splitNSName(this.$base),
+            typeName = type.name,
+            ns = xmlns && xmlns[type.namespace] || definitions.xmlns[type.namespace],
+            schema = definitions.schemas[ns],
+            typeElement = schema && ( schema.complexTypes[typeName] || schema.types[typeName] || schema.elements[typeName] );
 
-    desc.getBase = function() {
-      return typeElement.description(definitions, xmlns);
-    };
-    return desc;
-  }
+        desc.getBase = function () {
+            return typeElement.description(definitions, xmlns);
+        };
+        return desc;
+    }
 
     // then simple element
-  var base = this.$base ? this.$base + "|" : "";
-  return base + this.children.map(function(child) {
-    return child.description();
-  }).join(",");
+    var base = this.$base ? this.$base + "|" : "";
+    return base + this.children.map(function (child) {
+        return child.description();
+    }).join(",");
 };
 
-ExtensionElement.prototype.description = function(definitions, xmlns) {
-  var children = this.children;
-  var desc = {};
-  for (var i=0, child; child=children[i]; i++) {
-    if (child instanceof SequenceElement ||
-      child instanceof ChoiceElement) {
-      desc = child.description(definitions);
-    }
-  }
-  if (this.$base) {
-    var type = splitNSName(this.$base),
-      typeName = type.name,
-      ns = xmlns && xmlns[type.namespace] || definitions.xmlns[type.namespace],
-      schema = definitions.schemas[ns];
-
-    if (typeName in Primitives) {
-      return this.$base;
-    }
-    else {
-      var typeElement = schema && ( schema.complexTypes[typeName] ||
-        schema.types[typeName] || schema.elements[typeName] );
-
-      var base = typeElement.description(definitions, xmlns);
-      extend(desc, base);
-    }
-  }
-  return desc;
-};
-
-EnumerationElement.prototype.description = function() {
-  return this.$value;
-};
-
-ComplexTypeElement.prototype.description = function(definitions, xmlns) {
-  var children = this.children || [];
-  for (var i=0, child; child=children[i]; i++) {
-    if (child instanceof ChoiceElement ||
-      child instanceof SequenceElement ||
-      child instanceof AllElement ||
-      child instanceof SimpleContentElement ||
-      child instanceof ComplexContentElement) {
-
-      return child.description(definitions, xmlns);
-    }
-  }
-  return {};
-};
-
-ComplexContentElement.prototype.description = function(definitions, xmlns) {
-  var children = this.children;
-  for (var i = 0, child; child = children[i]; i++) {
-    if (child instanceof ExtensionElement) {
-      return child.description(definitions, xmlns);
-    }
-  }
-  return {};
-};
-
-SimpleContentElement.prototype.description = function(definitions, xmlns) {
-  var children = this.children;
-  for (var i = 0, child; child = children[i]; i++) {
-    if (child instanceof ExtensionElement) {
-      return child.description(definitions, xmlns);
-    }
-  }
-  return {};
-};
-
-ElementElement.prototype.description = function(definitions, xmlns) {
-  var element = {},
-    name = this.$name;
-  var isMany = !this.$maxOccurs ? false : (isNaN(this.$maxOccurs) ? (this.$maxOccurs === 'unbounded') : (this.$maxOccurs > 1));
-  if (this.$minOccurs !== this.$maxOccurs && isMany) {
-    name += '[]';
-  }
-
-  var type = this.$type || this.$ref;
-  if (type) {
-    type = splitNSName(type);
-    var typeName = type.name,
-      ns = xmlns && xmlns[type.namespace] || definitions.xmlns[type.namespace],
-      schema = definitions.schemas[ns],
-      typeElement = schema && ( schema.complexTypes[typeName] || schema.types[typeName] || schema.elements[typeName] );
-
-    if (typeElement && !(typeName in Primitives)) {
-
-      if (!(typeName in definitions.descriptions.types)) {
-
-        var elem = {};
-        definitions.descriptions.types[typeName] = elem;
-        if (this.$ref) {
-          elem = element = typeElement.description(definitions, xmlns);
-        }
-        else {
-          elem = element[name] = typeElement.description(definitions, xmlns);
-        }
-        elem.targetNSAlias = type.namespace;
-        elem.targetNamespace = ns;
-
-        definitions.descriptions.types[typeName] = elem;
-      }
-      else {
-        if (this.$ref) {
-          element = definitions.descriptions.types[typeName];
-        }
-        else {
-          element[name] = definitions.descriptions.types[typeName];
-        }
-      }
-
-    }
-    else {
-      element[name] = this.$type;
-    }
-  }
-  else {
+ExtensionElement.prototype.description = function (definitions, xmlns) {
     var children = this.children;
-    element[name] = {};
+    var desc = {};
     for (var i = 0, child; child = children[i]; i++) {
-      if (child instanceof ComplexTypeElement) {
-        element[name] = child.description(definitions, xmlns);
-      }
+        if (child instanceof SequenceElement ||
+            child instanceof ChoiceElement) {
+            desc = child.description(definitions);
+        }
     }
-  }
-  return element;
+    if (this.$base) {
+        var type = splitNSName(this.$base),
+            typeName = type.name,
+            ns = xmlns && xmlns[type.namespace] || definitions.xmlns[type.namespace],
+            schema = definitions.schemas[ns];
+
+        if (typeName in Primitives) {
+            return this.$base;
+        }
+        else {
+            var typeElement = schema && ( schema.complexTypes[typeName] ||
+                schema.types[typeName] || schema.elements[typeName] );
+
+            var base = typeElement.description(definitions, xmlns);
+            extend(desc, base);
+        }
+    }
+    return desc;
+};
+
+EnumerationElement.prototype.description = function () {
+    return this.$value;
+};
+
+ComplexTypeElement.prototype.description = function (definitions, xmlns) {
+    var children = this.children || [];
+    for (var i = 0, child; child = children[i]; i++) {
+        if (child instanceof ChoiceElement ||
+            child instanceof SequenceElement ||
+            child instanceof AllElement ||
+            child instanceof SimpleContentElement ||
+            child instanceof ComplexContentElement) {
+
+            return child.description(definitions, xmlns);
+        }
+    }
+    return {};
+};
+
+ComplexContentElement.prototype.description = function (definitions, xmlns) {
+    var children = this.children;
+    for (var i = 0, child; child = children[i]; i++) {
+        if (child instanceof ExtensionElement) {
+            return child.description(definitions, xmlns);
+        }
+    }
+    return {};
+};
+
+SimpleContentElement.prototype.description = function (definitions, xmlns) {
+    var children = this.children;
+    for (var i = 0, child; child = children[i]; i++) {
+        if (child instanceof ExtensionElement) {
+            return child.description(definitions, xmlns);
+        }
+    }
+    return {};
+};
+
+ElementElement.prototype.description = function (definitions, xmlns) {
+    var element = {},
+        name = this.$name;
+    var isMany = !this.$maxOccurs ? false : (isNaN(this.$maxOccurs) ? (this.$maxOccurs === 'unbounded') : (this.$maxOccurs > 1));
+    if (this.$minOccurs !== this.$maxOccurs && isMany) {
+        name += '[]';
+    }
+
+    var type = this.$type || this.$ref;
+    if (type) {
+        type = splitNSName(type);
+        var typeName = type.name,
+            ns = xmlns && xmlns[type.namespace] || definitions.xmlns[type.namespace],
+            schema = definitions.schemas[ns],
+            typeElement = schema && ( schema.complexTypes[typeName] || schema.types[typeName] || schema.elements[typeName] );
+
+        if (typeElement && !(typeName in Primitives)) {
+
+            if (!(typeName in definitions.descriptions.types)) {
+
+                var elem = {};
+                definitions.descriptions.types[typeName] = elem;
+                if (this.$ref) {
+                    elem = element = typeElement.description(definitions, xmlns);
+                }
+                else {
+                    elem = element[name] = typeElement.description(definitions, xmlns);
+                }
+                elem.targetNSAlias = type.namespace;
+                elem.targetNamespace = ns;
+
+                definitions.descriptions.types[typeName] = elem;
+            }
+            else {
+                if (this.$ref) {
+                    element = definitions.descriptions.types[typeName];
+                }
+                else {
+                    element[name] = definitions.descriptions.types[typeName];
+                }
+            }
+
+        }
+        else {
+            element[name] = this.$type;
+        }
+    }
+    else {
+        var children = this.children;
+        element[name] = {};
+        for (var i = 0, child; child = children[i]; i++) {
+            if (child instanceof ComplexTypeElement) {
+                element[name] = child.description(definitions, xmlns);
+            }
+        }
+    }
+    return element;
 };
 
 AllElement.prototype.description =
-SequenceElement.prototype.description = function(definitions, xmlns) {
-  var children = this.children;
-  var sequence = {};
-  for (var i = 0, child; child = children[i]; i++) {
-    if (child instanceof AnyElement) {
-      continue;
-    }
-    var description = child.description(definitions, xmlns);
-    for (var key in description) {
-      sequence[key] = description[key];
-    }
-  }
-  return sequence;
-};
-
-ChoiceElement.prototype.description = function(definitions, xmlns) {
-  var children = this.children;
-  var choice = {};
-  for (var i=0, child; child=children[i]; i++) {
-    var description = child.description(definitions, xmlns);
-    for (var key in description) {
-      choice[key] = description[key];
-    }
-  }
-  return choice;
-};
-
-MessageElement.prototype.description = function(definitions) {
-  if (this.element) {
-    return this.element && this.element.description(definitions);
-  }
-  var desc = {};
-  desc[this.$name] = this.parts;
-  return desc;
-};
-
-PortTypeElement.prototype.description = function(definitions) {
-  var methods = {};
-  for (var name in this.methods) {
-    var method = this.methods[name];
-    methods[name] = method.description(definitions);
-  }
-  return methods;
-};
-
-OperationElement.prototype.description = function(definitions) {
-  var inputDesc = this.input ? this.input.description(definitions) : null;
-  var outputDesc = this.output ? this.output.description(definitions) : null;
-  return {
-    input: inputDesc && inputDesc[Object.keys(inputDesc)[0]],
-    output: outputDesc && outputDesc[Object.keys(outputDesc)[0]]
-  };
-};
-
-BindingElement.prototype.description = function(definitions) {
-  var methods = {};
-  for (var name in this.methods) {
-    var method = this.methods[name];
-    methods[name] = method.description(definitions);
-  }
-  return methods;
-};
-
-ServiceElement.prototype.description = function(definitions) {
-  var ports = {};
-  for (var name in this.ports) {
-    var port = this.ports[name];
-    ports[name] = port.binding.description(definitions);
-  }
-  return ports;
-};
-
-var WSDL = function(definition, uri, options) {
-  var self = this,
-      fromFunc,
-      ignoredNamespaces;
-
-  this.uri = uri;
-  this.callback = function() {
-  };
-  this.options = options || {};
-
-  ignoredNamespaces = this.options.ignoredNamespaces;
-
-  if (ignoredNamespaces &&
-      (Array.isArray(ignoredNamespaces.namespaces) || typeof ignoredNamespaces.namespaces === 'string')) {
-    if (ignoredNamespaces.override) {
-      this.ignoredNamespaces = ignoredNamespaces.namespaces;
-    } else {
-      this.ignoredNamespaces.concat(ignoredNamespaces.namespaces);
-    }
-  }
-
-  if (typeof definition === 'string') {
-    fromFunc = this._fromXML;
-  }
-  else if (typeof definition === 'object') {
-    fromFunc = this._fromServices;
-  }
-  else {
-    throw new Error('WSDL constructor takes either an XML string or service definition');
-  }
-
-  process.nextTick(function() {
-    try {
-      fromFunc.call(self, definition);
-    } catch (e) {
-      return self.callback(e.message);
-    }
-
-    self.processIncludes(function(err) {
-      var name;
-      if (err) {
-        return self.callback(err);
-      }
-
-      self.definitions.deleteFixedAttrs();
-      var services = self.services = self.definitions.services;
-      if (services) {
-        for (name in services) {
-          services[name].postProcess(self.definitions);
+    SequenceElement.prototype.description = function (definitions, xmlns) {
+        var children = this.children;
+        var sequence = {};
+        for (var i = 0, child; child = children[i]; i++) {
+            if (child instanceof AnyElement) {
+                continue;
+            }
+            var description = child.description(definitions, xmlns);
+            for (var key in description) {
+                sequence[key] = description[key];
+            }
         }
-      }
-      var complexTypes = self.definitions.complexTypes;
-      if (complexTypes) {
-        for (name in complexTypes) {
-          complexTypes[name].deleteFixedAttrs();
-        }
-      }
+        return sequence;
+    };
 
-      // for document style, for every binding, prepare input message element name to (methodName, output message element name) mapping
-      var bindings = self.definitions.bindings;
-      for (var bindingName in bindings) {
-        var binding = bindings[bindingName];
-        if (typeof binding.style === 'undefined') {
-          binding.style = 'document';
+ChoiceElement.prototype.description = function (definitions, xmlns) {
+    var children = this.children;
+    var choice = {};
+    for (var i = 0, child; child = children[i]; i++) {
+        var description = child.description(definitions, xmlns);
+        for (var key in description) {
+            choice[key] = description[key];
         }
-        if (binding.style !== 'document')
-          continue;
-        var methods = binding.methods;
-        var topEls = binding.topElements = {};
-        for (var methodName in methods) {
-          var inputName = methods[methodName].input.$name;
-          var outputName="";
-          if(methods[methodName].output )
-            outputName = methods[methodName].output.$name;
-          topEls[inputName] = {"methodName": methodName, "outputName": outputName};
+    }
+    return choice;
+};
+
+MessageElement.prototype.description = function (definitions) {
+    if (this.element) {
+        return this.element && this.element.description(definitions);
+    }
+    var desc = {};
+    desc[this.$name] = this.parts;
+    return desc;
+};
+
+PortTypeElement.prototype.description = function (definitions) {
+    var methods = {};
+    for (var name in this.methods) {
+        var method = this.methods[name];
+        methods[name] = method.description(definitions);
+    }
+    return methods;
+};
+
+OperationElement.prototype.description = function (definitions) {
+    var inputDesc = this.input ? this.input.description(definitions) : null;
+    var outputDesc = this.output ? this.output.description(definitions) : null;
+    return {
+        input: inputDesc && inputDesc[Object.keys(inputDesc)[0]],
+        output: outputDesc && outputDesc[Object.keys(outputDesc)[0]]
+    };
+};
+
+BindingElement.prototype.description = function (definitions) {
+    var methods = {};
+    for (var name in this.methods) {
+        var method = this.methods[name];
+        methods[name] = method.description(definitions);
+    }
+    return methods;
+};
+
+ServiceElement.prototype.description = function (definitions) {
+    var ports = {};
+    for (var name in this.ports) {
+        var port = this.ports[name];
+        ports[name] = port.binding.description(definitions);
+    }
+    return ports;
+};
+
+var WSDL = function (definition, uri, options) {
+    var self = this,
+        fromFunc,
+        ignoredNamespaces;
+
+    this.uri = uri;
+    this.callback = function () {
+    };
+    this.options = options || {};
+
+    ignoredNamespaces = this.options.ignoredNamespaces;
+
+    if (ignoredNamespaces &&
+        (Array.isArray(ignoredNamespaces.namespaces) || typeof ignoredNamespaces.namespaces === 'string')) {
+        if (ignoredNamespaces.override) {
+            this.ignoredNamespaces = ignoredNamespaces.namespaces;
+        } else {
+            this.ignoredNamespaces.concat(ignoredNamespaces.namespaces);
         }
-      }
+    }
 
-      // prepare soap envelope xmlns definition string
-      self.xmlnsInEnvelope = self._xmlnsMap();
+    if (typeof definition === 'string') {
+        fromFunc = this._fromXML;
+    }
+    else if (typeof definition === 'object') {
+        fromFunc = this._fromServices;
+    }
+    else {
+        throw new Error('WSDL constructor takes either an XML string or service definition');
+    }
 
-      self.callback(err, self);
+    process.nextTick(function () {
+        try {
+            fromFunc.call(self, definition);
+        } catch (e) {
+            return self.callback(e.message);
+        }
+
+        self.processIncludes(function (err) {
+            var name;
+            if (err) {
+                return self.callback(err);
+            }
+
+            self.definitions.deleteFixedAttrs();
+            var services = self.services = self.definitions.services;
+            if (services) {
+                for (name in services) {
+                    services[name].postProcess(self.definitions);
+                }
+            }
+            var complexTypes = self.definitions.complexTypes;
+            if (complexTypes) {
+                for (name in complexTypes) {
+                    complexTypes[name].deleteFixedAttrs();
+                }
+            }
+
+            // for document style, for every binding, prepare input message element name to (methodName, output message element name) mapping
+            var bindings = self.definitions.bindings;
+            for (var bindingName in bindings) {
+                var binding = bindings[bindingName];
+                if (typeof binding.style === 'undefined') {
+                    binding.style = 'document';
+                }
+                if (binding.style !== 'document')
+                    continue;
+                var methods = binding.methods;
+                var topEls = binding.topElements = {};
+                for (var methodName in methods) {
+                    var inputName = methods[methodName].input.$name;
+                    var outputName = "";
+                    if (methods[methodName].output)
+                        outputName = methods[methodName].output.$name;
+                    topEls[inputName] = {"methodName": methodName, "outputName": outputName};
+                }
+            }
+
+            // prepare soap envelope xmlns definition string
+            self.xmlnsInEnvelope = self._xmlnsMap();
+
+            self.callback(err, self);
+        });
+
     });
-
-  });
 };
 
 WSDL.prototype.ignoredNamespaces = ['tns', 'targetNamespace', 'typedNamespace'];
 
-WSDL.prototype.onReady = function(callback) {
-  if (callback)
-    this.callback = callback;
+WSDL.prototype.onReady = function (callback) {
+    if (callback)
+        this.callback = callback;
 };
 
-WSDL.prototype._processNextInclude = function(includes, callback) {
-  var self = this,
-    include = includes.shift();
+WSDL.prototype._processNextInclude = function (includes, callback) {
+    var self = this,
+        include = includes.shift();
 
-  if (!include)
-    return callback();
+    if (!include)
+        return callback();
 
-  var includePath;
-  if (!/^http/.test(self.uri) && !/^http/.test(include.location)) {
-    includePath = path.resolve(path.dirname(self.uri), include.location);
-  } else {
-    includePath = url.resolve(self.uri, include.location);
-  }
-
-  open_wsdl(includePath, function(err, wsdl) {
-    if (err) {
-      return callback(err);
+    var includePath;
+    if (!/^http/.test(self.uri) && !/^http/.test(include.location)) {
+        includePath = path.resolve(path.dirname(self.uri), include.location);
+    } else {
+        includePath = url.resolve(self.uri, include.location);
     }
 
-    self.definitions.schemas[include.namespace || wsdl.definitions.$targetNamespace] = wsdl.definitions;
-    self._processNextInclude(includes, function(err) {
-      callback(err);
+    open_wsdl(includePath, function (err, wsdl) {
+        if (err) {
+            return callback(err);
+        }
+
+        self.definitions.schemas[include.namespace || wsdl.definitions.$targetNamespace] = wsdl.definitions;
+        self._processNextInclude(includes, function (err) {
+            callback(err);
+        });
     });
-  });
 };
 
-WSDL.prototype.processIncludes = function(callback) {
-  var schemas = this.definitions.schemas,
-    includes = [];
+WSDL.prototype.processIncludes = function (callback) {
+    var schemas = this.definitions.schemas,
+        includes = [];
 
-  for (var ns in schemas) {
-    var schema = schemas[ns];
-    includes = includes.concat(schema.includes || []);
-  }
+    for (var ns in schemas) {
+        var schema = schemas[ns];
+        includes = includes.concat(schema.includes || []);
+    }
 
-  this._processNextInclude(includes, callback);
+    this._processNextInclude(includes, callback);
 };
 
-WSDL.prototype.describeServices = function() {
-  var services = {};
-  for (var name in this.services) {
-    var service = this.services[name];
-    services[name] = service.description(this.definitions);
-  }
-  return services;
+WSDL.prototype.describeServices = function () {
+    var services = {};
+    for (var name in this.services) {
+        var service = this.services[name];
+        services[name] = service.description(this.definitions);
+    }
+    return services;
 };
 
-WSDL.prototype.toXML = function() {
-  return this.xml || '';
+WSDL.prototype.toXML = function () {
+    return this.xml || '';
 };
 
-WSDL.prototype.xmlToObject = function(xml) {
-  var self = this;
-  var p = sax.parser(true);
-  var objectName = null;
-  var root = {};
-  var schema = {
-    Envelope: {
-      Header: {
-        Security: {
-          UsernameToken: {
-            Username: 'string',
-            Password: 'string'
-          }
-        }
-      },
-      Body: {
-        Fault: {
-          faultcode: 'string',
-          faultstring: 'string',
-          detail: 'string'
-        }
-      }
-    }
-  };
-  var stack = [{name: null, object: root, schema: schema}];
-
-  var refs = {}, id; // {id:{hrefs:[],obj:}, ...}
-
-  p.onopentag = function(node) {
-    var nsName = node.name;
-    var attrs  = node.attributes;
-
-    var name = splitNSName(nsName).name,
-      attributeName,
-      top = stack[stack.length - 1],
-      topSchema = top.schema,
-      elementAttributes = {},
-      hasNonXmlnsAttribute = false,
-      obj = {};
-    var originalName = name;
-
-    if (!objectName && top.name === 'Body' && name !== 'Fault') {
-      var message = self.definitions.messages[name];
-      // Support RPC/literal messages where response body contains one element named
-      // after the operation + 'Response'. See http://www.w3.org/TR/wsdl#_names
-      if (!message) {
-        // Determine if this is request or response
-        var isInput = false;
-        var isOutput = false;
-        if ((/Response$/).test(name)) {
-          isOutput = true;
-          name = name.replace(/Response$/, '');
-        } else if ((/Request$/).test(name)) {
-          isInput = true;
-          name = name.replace(/Request$/, '');
-        } else if ((/Solicit$/).test(name)) {
-          isInput = true;
-          name = name.replace(/Solicit$/, '');
-        }
-        // Look up the appropriate message as given in the portType's operations
-        var portTypes = self.definitions.portTypes;
-        var portTypeNames = Object.keys(portTypes);
-        // Currently this supports only one portType definition.
-        var portType = portTypes[portTypeNames[0]];
-        if (isInput)
-          name = portType.methods[name].input.$name;
-        else
-          name = portType.methods[name].output.$name;
-        message = self.definitions.messages[name];
-        // 'cache' this alias to speed future lookups
-        self.definitions.messages[originalName] = self.definitions.messages[name];
-      }
-
-      topSchema = message.description(self.definitions);
-      objectName = originalName;
-    }
-
-    if (attrs.href) {
-      id = attrs.href.substr(1);
-      if (!refs[id])
-        refs[id] = {hrefs: [], obj: null};
-      refs[id].hrefs.push({par: top.object, key: name, obj: obj});
-    }
-    if (id = attrs.id) {
-      if (!refs[id])
-        refs[id] = {hrefs: [], obj: null};
-    }
-
-    //Handle element attributes
-    for(attributeName in attrs){
-      if(/^xmlns:?/.test(attributeName))continue;
-      hasNonXmlnsAttribute = true;
-      elementAttributes[attributeName] = attrs[attributeName];
-    }
-
-    if(hasNonXmlnsAttribute)obj[self.options.attributesKey] = elementAttributes;
-
-    if (topSchema && topSchema[name + '[]'])
-      name = name + '[]';
-    stack.push({name: originalName, object: obj, schema: topSchema && topSchema[name], id: attrs.id});
-  };
-
-  p.onclosetag = function(nsName) {
-    var cur = stack.pop(),
-      obj = cur.object,
-      top = stack[stack.length - 1],
-      topObject = top.object,
-      topSchema = top.schema,
-      name = splitNSName(nsName).name;
-
-    if (topSchema && topSchema[name + '[]']) {
-      if (!topObject[name])
-        topObject[name] = [];
-      topObject[name].push(obj);
-    }
-    else if (name in topObject) {
-      if (!Array.isArray(topObject[name])) {
-        topObject[name] = [topObject[name]];
-      }
-      topObject[name].push(obj);
-    }
-    else {
-      topObject[name] = obj;
-    }
-
-    if (cur.id) {
-      refs[cur.id].obj = obj;
-    }
-  };
-
-  p.ontext = function(text) {
-    text = trim(text);
-    if (!text.length)
-      return;
-
-    var top = stack[stack.length - 1];
-    var name = splitNSName(top.schema).name,
-      value;
-    if (name === 'int' || name === 'integer') {
-      value = parseInt(text, 10);
-    } else if (name === 'bool' || name === 'boolean') {
-      value = text.toLowerCase() === 'true' || text === '1';
-    } else if (name === 'dateTime' || name === 'date') {
-      value = new Date(text);
-    } else {
-      // handle string or other types
-      if (typeof top.object !== 'string') {
-        value = text;
-      } else {
-        value = top.object + text;
-      }
-    }
-
-    if(top.object[self.options.attributesKey]) {
-      top.object.$value = value;
-    } else {
-      top.object = value;
-    }
-  };
-
-  p.write(xml).close();
-
-  // merge obj with href
-  var merge = function(href, obj) {
-    for (var j in obj) {
-      if (obj.hasOwnProperty(j)) {
-        href.obj[j] = obj[j];
-      }
-    }
-  };
-
-  // MultiRef support: merge objects instead of replacing
-  for (var n in refs) {
-    var ref = refs[n];
-    for (var i = 0; i < ref.hrefs.length; i++) {
-      merge(ref.hrefs[i], ref.obj);
-    }
-
-  }
-
-  var body = root.Envelope.Body;
-  if (body.Fault) {
-    var error = new Error(body.Fault.faultcode + ': ' + body.Fault.faultstring + (body.Fault.detail ? ': ' + body.Fault.detail : ''));
-    error.root = root;
-    throw error;
-  }
-  return root.Envelope;
-};
-
-WSDL.prototype.findParameterObject = function(xmlns, parameterType) {
-  if (!xmlns || !parameterType) {
-    return null;
-  }
-
-  var parameterTypeObj = null;
-
-  if (this.definitions.schemas) {
-    var schema = this.definitions.schemas[xmlns];
-    if (schema) {
-      if (parameterType.indexOf(':') !== -1) {
-        parameterType = parameterType.substring(parameterType.indexOf(':') + 1, parameterType.length);
-      }
-
-      // if the client passed an input element which has a `$lookupType` property instead of `$type`
-      // the `parameterTypeObj` is found in `schema.elements`.
-      parameterTypeObj = schema.complexTypes[parameterType] || schema.elements[parameterType];
-    }
-  }
-
-  return parameterTypeObj;
-};
-
-WSDL.prototype.objectToDocumentXML = function(name, params, ns, xmlns, type) {
-  var args = {};
-  args[name] = params;
-  var parameterTypeObj = type ? this.findParameterObject(xmlns, type) : null;
-  if (this.namespaceNumber) {
-    this.namespaceNumber = 0;
-  }
-  return this.objectToXML(args, null, ns, xmlns, true, null, parameterTypeObj);
-};
-
-WSDL.prototype.objectToRpcXML = function(name, params, namespace, xmlns) {
-  var self = this;
-  var parts = [];
-  var defs = this.definitions;
-  var nsAttrName = '_xmlns';
-
-  namespace = namespace || findKey(defs.xmlns, xmlns);
-  xmlns = xmlns || defs.xmlns[namespace];
-  namespace = namespace === 'xmlns' ? '' : (namespace + ':');
-  parts.push(['<', namespace, name, '>'].join(''));
-
-  for (var key in params) {
-    if (key !== nsAttrName) {
-      var value = params[key];
-      parts.push(['<', key, '>'].join(''));
-      parts.push((typeof value === 'object') ? this.objectToXML(value, key, namespace, xmlns) : xmlEscape(value));
-      parts.push(['</', key, '>'].join(''));
-    }
-  }
-  parts.push(['</', namespace, name, '>'].join(''));
-
-  return parts.join('');
-};
-
-/*WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsAttr, parameterTypeObject, ancestorXmlns) {
-  var self = this;
-  var schema = this.definitions.schemas[xmlns];
-  var qualified = schema && schema.$elementFormDefault === 'qualified';
-  var parts = [];
-
-  var xmlnsAttrib = '';
-  if (xmlns && first) {
-    if (namespace && namespace !== 'xmlns') {
-      xmlnsAttrib += ' xmlns:' + namespace + '="' + xmlns + '"';
-    }
-
-    xmlnsAttrib += ' xmlns="' + xmlns + '"';
-  }
-
-  var ancXmlns = first ? new Array(xmlns) : ancestorXmlns;
-
-  // explicitly use xmlns attribute if available
-  if (xmlnsAttr) {
-    xmlnsAttrib = xmlnsAttr;
-  }
-
-  var ns = '';
-  if (namespace && namespace !== 'xmlns' && qualified) {
-    ns = namespace.indexOf(":") === -1 ? namespace + ':' : namespace;
-  }
-
-  if (Array.isArray(obj)) {
-    for (var i = 0, item; item = obj[i]; i++) {
-      var arrayAttr = self.processAttributes(item);
-      parts.push(['<', ns, name, arrayAttr, xmlnsAttrib, '>'].join(''));
-      parts.push(self.objectToXML(item, name, namespace, xmlns, false, null, null, ancXmlns));
-      parts.push(['</', ns, name, '>'].join(''));
-    }
-  } else if (typeof obj === 'object') {
-    for (name in obj) {
-      //don't process attributes as element
-      if (name === self.options.attributesKey) {
-        continue;
-      }
-      //Its the value of an item. Return it directly.
-      if (name === '$value') {
-        return xmlEscape(obj[name]);
-      }
-
-      var child = obj[name];
-      if (typeof child === 'undefined')
-        continue;
-
-      var attr = self.processAttributes(child);
-
-      var value = '';
-      if (first) {
-        value = self.objectToXML(child, name, namespace, xmlns, false, null, parameterTypeObject, ancXmlns);
-      } else {
-
-        if (self.definitions.schemas) {
-          if (schema) {
-            var childParameterTypeObject = self.findChildParameterObject(parameterTypeObject, name);
-            //find sub namespace if not a primitive
-            if (childParameterTypeObject && childParameterTypeObject.$type && (childParameterTypeObject.$type.indexOf('xsd') === -1)) {
-              var childParameterType = childParameterTypeObject.$type;
-
-              var childNamespace = '';
-              var childName = '';
-              if (childParameterType.indexOf(':') !== -1) {
-                childNamespace = childParameterType.substring(0, childParameterType.indexOf(':'));
-                childName = childParameterType.substring(childParameterType.indexOf(':') + 1);
-              }
-              var childXmlns = schema.xmlns[childNamespace] || self.definitions.xmlns[childNamespace];
-              var childXmlnsAttrib = '';
-              if ((ancXmlns.indexOf(childXmlns) === -1) && (childXmlns)) {
-                childXmlnsAttrib = ' xmlns:' + childNamespace + '="' + childXmlns+ '"';
-                if ((childXmlns)) {
-                  ancXmlns.push(childXmlns);
+WSDL.prototype.xmlToObject = function (xml) {
+    var self = this;
+    var p = sax.parser(true);
+    var objectName = null;
+    var root = {};
+    var schema = {
+        Envelope: {
+            Header: {
+                Security: {
+                    UsernameToken: {
+                        Username: 'string',
+                        Password: 'string'
+                    }
                 }
-              }
-              var completeChildParameterTypeObject = self.findChildParameterObjectFromSchema(childName, childXmlns) || childParameterTypeObject;
-              value = self.objectToXML(child, name, childNamespace, childXmlns, false, childXmlnsAttrib, completeChildParameterTypeObject, ancXmlns);
-            } else if (obj[self.options.attributesKey] && obj[self.options.attributesKey].xsi_type) { //if parent object has complex type defined and child not found in parent
-              var completeChildParamTypeObject = self.findChildParameterObjectFromSchema(obj[self.options.attributesKey].xsi_type.type, obj[self.options.attributesKey].xsi_type.xmlns);
-
-              ns = obj[self.options.attributesKey].xsi_type.namespace + ':';
-              ancXmlns.push(obj[self.options.attributesKey].xsi_type.xmlns);
-              value = self.objectToXML(child, name, obj[self.options.attributesKey].xsi_type.namespace, obj[self.options.attributesKey].xsi_type.xmlns, false, null, null, ancXmlns);
-            } else {
-              value = self.objectToXML(child, name, namespace, xmlns, false, null, null, ancXmlns);
+            },
+            Body: {
+                Fault: {
+                    faultcode: 'string',
+                    faultstring: 'string',
+                    detail: 'string'
+                }
             }
-          } else {
-            value = self.objectToXML(child, name, namespace, xmlns, false, null, null, ancXmlns);
-          }
         }
-      }
+    };
+    var stack = [
+        {name: null, object: root, schema: schema}
+    ];
 
-      if (!Array.isArray(child)) {
-        parts.push(['<', ns, name, attr, xmlnsAttrib, '>'].join(''));
-      }
+    var refs = {}, id; // {id:{hrefs:[],obj:}, ...}
 
-      parts.push(value);
-      if (!Array.isArray(child)) {
-        parts.push(['</', ns, name, '>'].join(''));
-      }
+    p.onopentag = function (node) {
+        var nsName = node.name;
+        var attrs = node.attributes;
+
+        var name = splitNSName(nsName).name,
+            attributeName,
+            top = stack[stack.length - 1],
+            topSchema = top.schema,
+            elementAttributes = {},
+            hasNonXmlnsAttribute = false,
+            obj = {};
+        var originalName = name;
+
+        if (!objectName && top.name === 'Body' && name !== 'Fault') {
+            var message = self.definitions.messages[name];
+            // Support RPC/literal messages where response body contains one element named
+            // after the operation + 'Response'. See http://www.w3.org/TR/wsdl#_names
+            if (!message) {
+                // Determine if this is request or response
+                var isInput = false;
+                var isOutput = false;
+                if ((/Response$/).test(name)) {
+                    isOutput = true;
+                    name = name.replace(/Response$/, '');
+                } else if ((/Request$/).test(name)) {
+                    isInput = true;
+                    name = name.replace(/Request$/, '');
+                } else if ((/Solicit$/).test(name)) {
+                    isInput = true;
+                    name = name.replace(/Solicit$/, '');
+                }
+                // Look up the appropriate message as given in the portType's operations
+                var portTypes = self.definitions.portTypes;
+                var portTypeNames = Object.keys(portTypes);
+                // Currently this supports only one portType definition.
+                var portType = portTypes[portTypeNames[0]];
+                if (isInput)
+                    name = portType.methods[name].input.$name;
+                else
+                    name = portType.methods[name].output.$name;
+                message = self.definitions.messages[name];
+                // 'cache' this alias to speed future lookups
+                self.definitions.messages[originalName] = self.definitions.messages[name];
+            }
+
+            topSchema = message.description(self.definitions);
+            objectName = originalName;
+        }
+
+        if (attrs.href) {
+            id = attrs.href.substr(1);
+            if (!refs[id])
+                refs[id] = {hrefs: [], obj: null};
+            refs[id].hrefs.push({par: top.object, key: name, obj: obj});
+        }
+        if (id = attrs.id) {
+            if (!refs[id])
+                refs[id] = {hrefs: [], obj: null};
+        }
+
+        //Handle element attributes
+        for (attributeName in attrs) {
+            if (/^xmlns:?/.test(attributeName))continue;
+            hasNonXmlnsAttribute = true;
+            elementAttributes[attributeName] = attrs[attributeName];
+        }
+
+        if (hasNonXmlnsAttribute)obj[self.options.attributesKey] = elementAttributes;
+
+        if (topSchema && topSchema[name + '[]'])
+            name = name + '[]';
+        stack.push({name: originalName, object: obj, schema: topSchema && topSchema[name], id: attrs.id});
+    };
+
+    p.onclosetag = function (nsName) {
+        var cur = stack.pop(),
+            obj = cur.object,
+            top = stack[stack.length - 1],
+            topObject = top.object,
+            topSchema = top.schema,
+            name = splitNSName(nsName).name;
+
+        if (topSchema && topSchema[name + '[]']) {
+            if (!topObject[name])
+                topObject[name] = [];
+            topObject[name].push(obj);
+        }
+        else if (name in topObject) {
+            if (!Array.isArray(topObject[name])) {
+                topObject[name] = [topObject[name]];
+            }
+            topObject[name].push(obj);
+        }
+        else {
+            topObject[name] = obj;
+        }
+
+        if (cur.id) {
+            refs[cur.id].obj = obj;
+        }
+    };
+
+    p.ontext = function (text) {
+        text = trim(text);
+        if (!text.length)
+            return;
+
+        var top = stack[stack.length - 1];
+        var name = splitNSName(top.schema).name,
+            value;
+        if (name === 'int' || name === 'integer') {
+            value = parseInt(text, 10);
+        } else if (name === 'bool' || name === 'boolean') {
+            value = text.toLowerCase() === 'true' || text === '1';
+        } else if (name === 'dateTime' || name === 'date') {
+            value = new Date(text);
+        } else {
+            // handle string or other types
+            if (typeof top.object !== 'string') {
+                value = text;
+            } else {
+                value = top.object + text;
+            }
+        }
+
+        if (top.object[self.options.attributesKey]) {
+            top.object.$value = value;
+        } else {
+            top.object = value;
+        }
+    };
+
+    p.write(xml).close();
+
+    // merge obj with href
+    var merge = function (href, obj) {
+        for (var j in obj) {
+            if (obj.hasOwnProperty(j)) {
+                href.obj[j] = obj[j];
+            }
+        }
+    };
+
+    // MultiRef support: merge objects instead of replacing
+    for (var n in refs) {
+        var ref = refs[n];
+        for (var i = 0; i < ref.hrefs.length; i++) {
+            merge(ref.hrefs[i], ref.obj);
+        }
+
     }
-  } else if (obj !== undefined) {
-    parts.push(xmlEscape(obj));
-  }
-  return parts.join('');
-};*/
 
-WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsAttr, parameterTypeObject, ancestorXmlns) {
+    var body = root.Envelope.Body;
+    if (body.Fault) {
+        var error = new Error(body.Fault.faultcode + ': ' + body.Fault.faultstring + (body.Fault.detail ? ': ' + body.Fault.detail : ''));
+        error.root = root;
+        throw error;
+    }
+    return root.Envelope;
+};
+
+WSDL.prototype.findParameterObject = function (xmlns, parameterType) {
+    if (!xmlns || !parameterType) {
+        return null;
+    }
+
+    var parameterTypeObj = null;
+
+    if (this.definitions.schemas) {
+        var schema = this.definitions.schemas[xmlns];
+        if (schema) {
+            if (parameterType.indexOf(':') !== -1) {
+                parameterType = parameterType.substring(parameterType.indexOf(':') + 1, parameterType.length);
+            }
+
+            // if the client passed an input element which has a `$lookupType` property instead of `$type`
+            // the `parameterTypeObj` is found in `schema.elements`.
+            parameterTypeObj = schema.complexTypes[parameterType] || schema.elements[parameterType];
+        }
+    }
+
+    return parameterTypeObj;
+};
+
+WSDL.prototype.objectToDocumentXML = function (name, params, ns, xmlns, type) {
+    var args = {};
+    args[name] = params;
+    var parameterTypeObj = type ? this.findParameterObject(xmlns, type) : null;
+    if (this.namespaceNumber) {
+        this.namespaceNumber = 0;
+    }
+    return this.objectToXML(args, null, ns, xmlns, true, null, parameterTypeObj);
+};
+
+WSDL.prototype.objectToRpcXML = function (name, params, namespace, xmlns) {
+    var self = this;
+    var parts = [];
+    var defs = this.definitions;
+    var nsAttrName = '_xmlns';
+
+    namespace = namespace || findKey(defs.xmlns, xmlns);
+    xmlns = xmlns || defs.xmlns[namespace];
+    namespace = namespace === 'xmlns' ? '' : (namespace + ':');
+    parts.push(['<', namespace, name, '>'].join(''));
+
+    for (var key in params) {
+        if (key !== nsAttrName) {
+            var value = params[key];
+            parts.push(['<', key, '>'].join(''));
+            parts.push((typeof value === 'object') ? this.objectToXML(value, key, namespace, xmlns) : xmlEscape(value));
+            parts.push(['</', key, '>'].join(''));
+        }
+    }
+    parts.push(['</', namespace, name, '>'].join(''));
+
+    return parts.join('');
+};
+
+WSDL.prototype.objectToXML = function (obj, name, namespace, xmlns, first, xmlnsAttr, parameterTypeObject, ancestorXmlns) {
     var self = this;
     var parts = [];
     var firstDone = false;
@@ -1493,7 +1386,7 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsA
                                 childName = childParameterType.substring(childParameterType.indexOf(':') + 1);
                             }
                             var childXmlns = schema.xmlns[childNamespace];
-                            var childXmlnsAttrib = ' xmlns:' + childNamespace + '="' + childXmlns+ '"';
+                            var childXmlnsAttrib = ' xmlns:' + childNamespace + '="' + childXmlns + '"';
                             if (ancXmlns.indexOf(childXmlns) !== -1) {
                                 childXmlnsAttrib = '';
                             } else {
@@ -1527,8 +1420,8 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsA
             }
 
             if (this.options.customNs && firstDone) {
-                parts.splice(1,0, ['<', ns, 'request', '>'].join(''));
-                parts.splice(-1,0, ['</', ns, 'request', '>'].join(''));
+                parts.splice(1, 0, ['<', ns, 'request', '>'].join(''));
+                parts.splice(-1, 0, ['</', ns, 'request', '>'].join(''));
             }
         }
     } else if (obj !== undefined) {
@@ -1537,219 +1430,218 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsA
     return parts.join('');
 };
 
-WSDL.prototype.processAttributes = function(child) {
-  var self = this;
-  var attr = '';
+WSDL.prototype.processAttributes = function (child) {
+    var self = this;
+    var attr = '';
 
-  if (child[this.options.attributesKey] && child[this.options.attributesKey].xsi_type) {
-    var xsiType = child[this.options.attributesKey].xsi_type;
+    if (child[this.options.attributesKey] && child[this.options.attributesKey].xsi_type) {
+        var xsiType = child[this.options.attributesKey].xsi_type;
 
-    // Generate a new namespace for complex extension if one not provided
-    if (!xsiType.namespace) {
-      if (self.namespaceNumber) {
-        self.namespaceNumber++;
-      } else {
-        self.namespaceNumber = 1;
-      }
-      xsiType.namespace = 'ns' + self.namespaceNumber;
-    }
-  }
-
-  if (child[this.options.attributesKey]) {
-    for (var attrKey in child[this.options.attributesKey]) {
-      //handle complex extension separately
-      if (attrKey === 'xsi_type') {
-        var attrValue = child[this.options.attributesKey][attrKey];
-        attr += ' xsi:type="' + attrValue.namespace + ':' + attrValue.type + '"';
-        attr += ' xmlns:' + attrValue.namespace + '="' + attrValue.xmlns + '"';
-
-        continue;
-      } else {
-        attr += ' ' + attrKey + '="' + xmlEscape(child[this.options.attributesKey][attrKey]) + '"';
-      }
-    }
-  }
-
-  return attr;
-};
-
-WSDL.prototype.findChildParameterObjectFromSchema = function(name, xmlns) {
-  if (!this.definitions.schemas || !name || !xmlns) {
-    return null;
-  }
-
-  var schema = this.definitions.schemas[xmlns];
-  if (!schema || !schema.complexTypes) {
-    return null;
-  }
-
-  return schema.complexTypes[name];
-};
-
-WSDL.prototype.findChildParameterObject = function(parameterTypeObj, childName) {
-  if (!parameterTypeObj || !childName) {
-    return null;
-  }
-  var found = null,
-      i = 0,
-      child;
-
-  if(parameterTypeObj.$lookupTypes && Array.isArray(parameterTypeObj.$lookupTypes)) {
-    var types = parameterTypeObj.$lookupTypes;
-
-    for(i = 0; i < types.length; i++) {
-      var typeObj = types[i];
-
-      if(typeObj.$name === childName) {
-        found = typeObj;
-        break;
-      }
-    }
-  } else {
-    var object = parameterTypeObj;
-    if (object.$name === childName) {
-      return object;
-    }
-
-    if (object.children) {
-      for (i = 0, child; child = object.children[i]; i++) {
-        found = this.findChildParameterObject(child, childName);
-        if (found) {
-          break;
+        // Generate a new namespace for complex extension if one not provided
+        if (!xsiType.namespace) {
+            if (self.namespaceNumber) {
+                self.namespaceNumber++;
+            } else {
+                self.namespaceNumber = 1;
+            }
+            xsiType.namespace = 'ns' + self.namespaceNumber;
         }
-      }
     }
-  }
 
-  return found;
+    if (child[this.options.attributesKey]) {
+        for (var attrKey in child[this.options.attributesKey]) {
+            //handle complex extension separately
+            if (attrKey === 'xsi_type') {
+                var attrValue = child[this.options.attributesKey][attrKey];
+                attr += ' xsi:type="' + attrValue.namespace + ':' + attrValue.type + '"';
+                attr += ' xmlns:' + attrValue.namespace + '="' + attrValue.xmlns + '"';
+
+                continue;
+            } else {
+                attr += ' ' + attrKey + '="' + xmlEscape(child[this.options.attributesKey][attrKey]) + '"';
+            }
+        }
+    }
+
+    return attr;
 };
 
-WSDL.prototype._parse = function(xml) {
-  var self = this,
-    p = sax.parser(true),
-    stack = [],
-    root = null,
-      ignoredNamespaces = this.ignoredNamespaces;
+WSDL.prototype.findChildParameterObjectFromSchema = function (name, xmlns) {
+    if (!this.definitions.schemas || !name || !xmlns) {
+        return null;
+    }
 
-  p.onopentag = function(node) {
-    var nsName = node.name;
-    var attrs  = node.attributes;
+    var schema = this.definitions.schemas[xmlns];
+    if (!schema || !schema.complexTypes) {
+        return null;
+    }
 
-    var top = stack[stack.length - 1];
-    var name;
-    if (top) {
-      try {
-        top.startElement(stack, nsName, attrs, ignoredNamespaces);
-      } catch (e) {
-        if (self.options.strict) {
-          throw e;
-        } else {
-          stack.push(new Element(nsName, attrs));
+    return schema.complexTypes[name];
+};
+
+WSDL.prototype.findChildParameterObject = function (parameterTypeObj, childName) {
+    if (!parameterTypeObj || !childName) {
+        return null;
+    }
+    var found = null,
+        i = 0,
+        child;
+
+    if (parameterTypeObj.$lookupTypes && Array.isArray(parameterTypeObj.$lookupTypes)) {
+        var types = parameterTypeObj.$lookupTypes;
+
+        for (i = 0; i < types.length; i++) {
+            var typeObj = types[i];
+
+            if (typeObj.$name === childName) {
+                found = typeObj;
+                break;
+            }
         }
-      }
     } else {
-      name = splitNSName(nsName).name;
-      if (name === 'definitions') {
-        root = new DefinitionsElement(nsName, attrs);
-      } else if (name === 'schema') {
-        root = new SchemaElement(nsName, attrs);
-      } else {
-        throw new Error('Unexpected root element of WSDL or include');
-      }
-      stack.push(root);
+        var object = parameterTypeObj;
+        if (object.$name === childName) {
+            return object;
+        }
+
+        if (object.children) {
+            for (i = 0, child; child = object.children[i]; i++) {
+                found = this.findChildParameterObject(child, childName);
+                if (found) {
+                    break;
+                }
+            }
+        }
     }
-  };
 
-  p.onclosetag = function(name) {
-    var top = stack[stack.length - 1];
-    assert(top, 'Unmatched close tag: ' + name);
-
-    top.endElement(stack, name);
-  };
-
-  p.write(xml).close();
-
-  return root;
+    return found;
 };
 
-WSDL.prototype._fromXML = function(xml) {
-  this.definitions = this._parse(xml);
-  this.definitions.descriptions = {
-    types:{}
-  };
-  this.xml = xml;
+WSDL.prototype._parse = function (xml) {
+    var self = this,
+        p = sax.parser(true),
+        stack = [],
+        root = null,
+        ignoredNamespaces = this.ignoredNamespaces;
+
+    p.onopentag = function (node) {
+        var nsName = node.name;
+        var attrs = node.attributes;
+
+        var top = stack[stack.length - 1];
+        var name;
+        if (top) {
+            try {
+                top.startElement(stack, nsName, attrs, ignoredNamespaces);
+            } catch (e) {
+                if (self.options.strict) {
+                    throw e;
+                } else {
+                    stack.push(new Element(nsName, attrs));
+                }
+            }
+        } else {
+            name = splitNSName(nsName).name;
+            if (name === 'definitions') {
+                root = new DefinitionsElement(nsName, attrs);
+            } else if (name === 'schema') {
+                root = new SchemaElement(nsName, attrs);
+            } else {
+                throw new Error('Unexpected root element of WSDL or include');
+            }
+            stack.push(root);
+        }
+    };
+
+    p.onclosetag = function (name) {
+        var top = stack[stack.length - 1];
+        assert(top, 'Unmatched close tag: ' + name);
+
+        top.endElement(stack, name);
+    };
+
+    p.write(xml).close();
+
+    return root;
 };
 
-WSDL.prototype._fromServices = function(services) {
+WSDL.prototype._fromXML = function (xml) {
+    this.definitions = this._parse(xml);
+    this.definitions.descriptions = {
+        types: {}
+    };
+    this.xml = xml;
+};
+
+WSDL.prototype._fromServices = function (services) {
 
 };
 
 
-
-WSDL.prototype._xmlnsMap = function() {
-  var xmlns = this.definitions.xmlns;
-  var str = '';
-  for (var alias in xmlns) {
-    if (alias === '' || alias === 'xmlns')
-      continue;
-    var ns = xmlns[alias];
-    switch (ns) {
-      case "http://xml.apache.org/xml-soap" : // apachesoap
-      case "http://schemas.xmlsoap.org/wsdl/" : // wsdl
-      case "http://schemas.xmlsoap.org/wsdl/soap/" : // wsdlsoap
-      case "http://schemas.xmlsoap.org/soap/encoding/" : // soapenc
-      case "http://www.w3.org/2001/XMLSchema" : // xsd
-        continue;
+WSDL.prototype._xmlnsMap = function () {
+    var xmlns = this.definitions.xmlns;
+    var str = '';
+    for (var alias in xmlns) {
+        if (alias === '' || alias === 'xmlns')
+            continue;
+        var ns = xmlns[alias];
+        switch (ns) {
+            case "http://xml.apache.org/xml-soap" : // apachesoap
+            case "http://schemas.xmlsoap.org/wsdl/" : // wsdl
+            case "http://schemas.xmlsoap.org/wsdl/soap/" : // wsdlsoap
+            case "http://schemas.xmlsoap.org/soap/encoding/" : // soapenc
+            case "http://www.w3.org/2001/XMLSchema" : // xsd
+                continue;
+        }
+        if (~ns.indexOf('http://schemas.xmlsoap.org/'))
+            continue;
+        if (~ns.indexOf('http://www.w3.org/'))
+            continue;
+        if (~ns.indexOf('http://xml.apache.org/'))
+            continue;
+        str += ' xmlns:' + alias + '="' + ns + '"';
     }
-    if (~ns.indexOf('http://schemas.xmlsoap.org/'))
-      continue;
-    if (~ns.indexOf('http://www.w3.org/'))
-      continue;
-    if (~ns.indexOf('http://xml.apache.org/'))
-      continue;
-    str += ' xmlns:' + alias + '="' + ns + '"';
-  }
-  return str;
+    return str;
 };
 
 function open_wsdl(uri, options, callback) {
-  if (typeof options === 'function') {
-    callback = options;
-    options = {};
-  }
+    if (typeof options === 'function') {
+        callback = options;
+        options = {};
+    }
 
-  var request_headers = options.wsdl_headers;
-  var request_options = options.wsdl_options;
+    var request_headers = options.wsdl_headers;
+    var request_options = options.wsdl_options;
 
-  delete options.wsdl_headers;
-  delete options.wsdl_options;
+    delete options.wsdl_headers;
+    delete options.wsdl_options;
 
-  var wsdl;
-  if (!/^http/.test(uri)) {
-    fs.readFile(uri, 'utf8', function(err, definition) {
-      if (err) {
-        callback(err);
-      }
-      else {
-        wsdl = new WSDL(definition, uri, options);
-        wsdl.onReady(callback);
-      }
-    });
-  }
-  else {
-    http.request(uri, null /* options */, function(err, response, definition) {
-      if (err) {
-        callback(err);
-      } else if (response && response.statusCode === 200) {
-        wsdl = new WSDL(definition, uri, options);
-        wsdl.onReady(callback);
-      } else {
-        callback(new Error('Invalid WSDL URL: ' + uri + "\n\n\r Code: " + response.statusCode + "\n\n\r Response Body: " + response.body));
-      }
-    }, request_headers, request_options);
-  }
+    var wsdl;
+    if (!/^http/.test(uri)) {
+        fs.readFile(uri, 'utf8', function (err, definition) {
+            if (err) {
+                callback(err);
+            }
+            else {
+                wsdl = new WSDL(definition, uri, options);
+                wsdl.onReady(callback);
+            }
+        });
+    }
+    else {
+        http.request(uri, null /* options */, function (err, response, definition) {
+            if (err) {
+                callback(err);
+            } else if (response && response.statusCode === 200) {
+                wsdl = new WSDL(definition, uri, options);
+                wsdl.onReady(callback);
+            } else {
+                callback(new Error('Invalid WSDL URL: ' + uri + "\n\n\r Code: " + response.statusCode + "\n\n\r Response Body: " + response.body));
+            }
+        }, request_headers, request_options);
+    }
 
-  return wsdl;
+    return wsdl;
 }
 
 exports.open_wsdl = open_wsdl;

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -44,16 +44,16 @@ var Primitives = {
     anyURI: 0,
     QName: 0,
     NOTATION: 0
-};
+  };
 
 function splitNSName(nsName) {
     var i = typeof nsName === 'string' ? nsName.indexOf(':') : -1;
     return i < 0 ? {namespace: 'xmlns', name: nsName} : {namespace: nsName.substring(0, i), name: nsName.substring(i + 1)};
-}
+  }
 
 function xmlEscape(obj) {
     if (typeof (obj) === 'string') {
-        return obj
+      return obj
             .replace(/&/g, '&amp;')
             .replace(/</g, '&lt;')
             .replace(/>/g, '&gt;')
@@ -62,115 +62,115 @@ function xmlEscape(obj) {
     }
 
     return obj;
-}
+  }
 
 var trimLeft = /^[\s\xA0]+/;
 var trimRight = /[\s\xA0]+$/;
 
 function trim(text) {
-    return text.replace(trimLeft, '').replace(trimRight, '');
+  return text.replace(trimLeft, '').replace(trimRight, '');
 }
 
 function extend(base, obj) {
-    for (var key in obj) {
-        if (!obj.hasOwnProperty(key)) {
-            base[key] = obj[key];
-        }
+  for (var key in obj) {
+    if (!obj.hasOwnProperty(key)) {
+      base[key] = obj[key];
     }
-    return base;
+  }
+  return base;
 }
 
 function findKey(obj, val) {
-    for (var n in obj)
-        if (obj[n] === val)
-            return n;
+  for (var n in obj)
+    if (obj[n] === val)
+      return n;
 }
 
 var Element = function (nsName, attrs, ignoredNamespaces) {
-    var parts = splitNSName(nsName);
+  var parts = splitNSName(nsName);
 
-    this.nsName = nsName;
-    this.namespace = parts.namespace;
-    this.ignoredNamespaces = ignoredNamespaces;
-    this.name = parts.name;
-    this.children = [];
-    this.xmlns = {};
-    for (var key in attrs) {
-        var match = /^xmlns:?(.*)$/.exec(key);
-        if (match) {
-            this.xmlns[match[1] ? match[1] : 'xmlns'] = attrs[key];
-        }
-        else {
-            this['$' + key] = attrs[key];
-        }
+  this.nsName = nsName;
+  this.namespace = parts.namespace;
+  this.ignoredNamespaces = ignoredNamespaces;
+  this.name = parts.name;
+  this.children = [];
+  this.xmlns = {};
+  for (var key in attrs) {
+    var match = /^xmlns:?(.*)$/.exec(key);
+    if (match) {
+      this.xmlns[match[1] ? match[1] : 'xmlns'] = attrs[key];
     }
+    else {
+      this['$' + key] = attrs[key];
+    }
+  }
 };
 
 Element.prototype.deleteFixedAttrs = function () {
-    this.children && this.children.length === 0 && delete this.children;
-    this.xmlns && Object.keys(this.xmlns).length === 0 && delete this.xmlns;
-    delete this.nsName;
-    delete this.namespace;
-    delete this.name;
+  this.children && this.children.length === 0 && delete this.children;
+  this.xmlns && Object.keys(this.xmlns).length === 0 && delete this.xmlns;
+  delete this.nsName;
+  delete this.namespace;
+  delete this.name;
 };
 
 Element.prototype.allowedChildren = [];
 
 Element.prototype.startElement = function (stack, nsName, attrs, ignoredNamespaces) {
-    if (!this.allowedChildren)
-        return;
+  if (!this.allowedChildren)
+    return;
 
-    var ChildClass = this.allowedChildren[splitNSName(nsName).name],
-        element = null;
+  var ChildClass = this.allowedChildren[splitNSName(nsName).name],
+    element = null;
 
-    if (ChildClass) {
-        stack.push(new ChildClass(nsName, attrs, ignoredNamespaces));
-    }
-    else {
-        this.unexpected(nsName);
-    }
+  if (ChildClass) {
+    stack.push(new ChildClass(nsName, attrs, ignoredNamespaces));
+  }
+  else {
+    this.unexpected(nsName);
+  }
 
 };
 
 Element.prototype.endElement = function (stack, nsName) {
-    if (this.nsName === nsName) {
-        if (stack.length < 2)
-            return;
-        var parent = stack[stack.length - 2];
-        if (this !== stack[0]) {
-            extend(stack[0].xmlns, this.xmlns);
-            // delete this.xmlns;
-            parent.children.push(this);
-            parent.addChild(this);
-        }
-        stack.pop();
+  if (this.nsName === nsName) {
+    if (stack.length < 2)
+      return;
+    var parent = stack[stack.length - 2];
+    if (this !== stack[0]) {
+      extend(stack[0].xmlns, this.xmlns);
+      // delete this.xmlns;
+      parent.children.push(this);
+      parent.addChild(this);
     }
+    stack.pop();
+  }
 };
 
 Element.prototype.addChild = function (child) {
-    return;
+  return;
 };
 
 Element.prototype.unexpected = function (name) {
-    throw new Error('Found unexpected element (' + name + ') inside ' + this.nsName);
+  throw new Error('Found unexpected element (' + name + ') inside ' + this.nsName);
 };
 
 Element.prototype.description = function (definitions) {
-    return this.$name || this.name;
+  return this.$name || this.name;
 };
 
 Element.prototype.init = function () {
 };
 
 Element.createSubClass = function () {
-    var root = this;
-    var subElement = function () {
-        root.apply(this, arguments);
-        this.init();
-    };
-    // inherits(subElement, root);
-    subElement.prototype.__proto__ = root.prototype;
-    return subElement;
+  var root = this;
+  var subElement = function () {
+    root.apply(this, arguments);
+    this.init();
+  };
+  // inherits(subElement, root);
+  subElement.prototype.__proto__ = root.prototype;
+  return subElement;
 };
 
 
@@ -201,329 +201,329 @@ var ServiceElement = Element.createSubClass();
 var DefinitionsElement = Element.createSubClass();
 
 var ElementTypeMap = {
-    types: [TypesElement, 'schema documentation'],
-    schema: [SchemaElement, 'element complexType simpleType include import'],
-    element: [ElementElement, 'annotation complexType'],
-    any: [AnyElement, ''],
-    simpleType: [SimpleTypeElement, 'restriction'],
-    restriction: [RestrictionElement, 'enumeration choice sequence'],
-    extension: [ExtensionElement, 'sequence choice'],
-    choice: [ChoiceElement, 'element choice'],
-    // group: [GroupElement, 'element group'],
-    enumeration: [EnumerationElement, ''],
-    complexType: [ComplexTypeElement, 'annotation sequence all complexContent simpleContent choice'],
-    complexContent: [ComplexContentElement, 'extension'],
-    simpleContent: [SimpleContentElement, 'extension'],
-    sequence: [SequenceElement, 'element choice any'],
-    all: [AllElement, 'element choice'],
+  types: [TypesElement, 'schema documentation'],
+  schema: [SchemaElement, 'element complexType simpleType include import'],
+  element: [ElementElement, 'annotation complexType'],
+  any: [AnyElement, ''],
+  simpleType: [SimpleTypeElement, 'restriction'],
+  restriction: [RestrictionElement, 'enumeration choice sequence'],
+  extension: [ExtensionElement, 'sequence choice'],
+  choice: [ChoiceElement, 'element choice'],
+  // group: [GroupElement, 'element group'],
+  enumeration: [EnumerationElement, ''],
+  complexType: [ComplexTypeElement, 'annotation sequence all complexContent simpleContent choice'],
+  complexContent: [ComplexContentElement, 'extension'],
+  simpleContent: [SimpleContentElement, 'extension'],
+  sequence: [SequenceElement, 'element choice any'],
+  all: [AllElement, 'element choice'],
 
-    service: [ServiceElement, 'port documentation'],
-    port: [PortElement, 'address documentation'],
-    binding: [BindingElement, '_binding SecuritySpec operation documentation'],
-    portType: [PortTypeElement, 'operation documentation'],
-    message: [MessageElement, 'part documentation'],
-    operation: [OperationElement, 'documentation input output fault _operation'],
-    input: [InputElement, 'body SecuritySpecRef documentation header'],
-    output: [OutputElement, 'body SecuritySpecRef documentation header'],
-    fault: [Element, '_fault documentation'],
-    definitions: [DefinitionsElement, 'types message portType binding service import documentation'],
-    documentation: [DocumentationElement, '']
+  service: [ServiceElement, 'port documentation'],
+  port: [PortElement, 'address documentation'],
+  binding: [BindingElement, '_binding SecuritySpec operation documentation'],
+  portType: [PortTypeElement, 'operation documentation'],
+  message: [MessageElement, 'part documentation'],
+  operation: [OperationElement, 'documentation input output fault _operation'],
+  input: [InputElement, 'body SecuritySpecRef documentation header'],
+  output: [OutputElement, 'body SecuritySpecRef documentation header'],
+  fault: [Element, '_fault documentation'],
+  definitions: [DefinitionsElement, 'types message portType binding service import documentation'],
+  documentation: [DocumentationElement, '']
 };
 
 function mapElementTypes(types) {
-    var rtn = {};
-    types = types.split(' ');
-    types.forEach(function (type) {
-        rtn[type.replace(/^_/, '')] = (ElementTypeMap[type] || [Element]) [0];
-    });
-    return rtn;
+  var rtn = {};
+  types = types.split(' ');
+  types.forEach(function (type) {
+    rtn[type.replace(/^_/, '')] = (ElementTypeMap[type] || [Element]) [0];
+  });
+  return rtn;
 }
 
 for (var n in ElementTypeMap) {
-    var v = ElementTypeMap[n];
-    v[0].prototype.allowedChildren = mapElementTypes(v[1]);
+  var v = ElementTypeMap[n];
+  v[0].prototype.allowedChildren = mapElementTypes(v[1]);
 }
 
 MessageElement.prototype.init = function () {
-    this.element = null;
-    this.parts = null;
+  this.element = null;
+  this.parts = null;
 };
 
 SchemaElement.prototype.init = function () {
-    this.complexTypes = {};
-    this.types = {};
-    this.elements = {};
-    this.includes = [];
+  this.complexTypes = {};
+  this.types = {};
+  this.elements = {};
+  this.includes = [];
 };
 
 TypesElement.prototype.init = function () {
-    this.schemas = {};
+  this.schemas = {};
 };
 
 OperationElement.prototype.init = function () {
-    this.input = null;
-    this.output = null;
-    this.inputSoap = null;
-    this.outputSoap = null;
-    this.style = '';
-    this.soapAction = '';
+  this.input = null;
+  this.output = null;
+  this.inputSoap = null;
+  this.outputSoap = null;
+  this.style = '';
+  this.soapAction = '';
 };
 
 PortTypeElement.prototype.init = function () {
-    this.methods = {};
+  this.methods = {};
 };
 
 BindingElement.prototype.init = function () {
-    this.transport = '';
-    this.style = '';
-    this.methods = {};
+  this.transport = '';
+  this.style = '';
+  this.methods = {};
 };
 
 PortElement.prototype.init = function () {
-    this.location = null;
+  this.location = null;
 };
 
 ServiceElement.prototype.init = function () {
-    this.ports = {};
+  this.ports = {};
 };
 
 DefinitionsElement.prototype.init = function () {
-    if (this.name !== 'definitions')this.unexpected(this.nsName);
-    this.messages = {};
-    this.portTypes = {};
-    this.bindings = {};
-    this.services = {};
-    this.schemas = {};
+  if (this.name !== 'definitions')this.unexpected(this.nsName);
+  this.messages = {};
+  this.portTypes = {};
+  this.bindings = {};
+  this.services = {};
+  this.schemas = {};
 };
 
 DocumentationElement.prototype.init = function () {
 };
 
 SchemaElement.prototype.addChild = function (child) {
-    if (child.$name in Primitives)
-        return;
-    if (child.name === 'include' || child.name === 'import') {
-        var location = child.$schemaLocation || child.$location;
-        if (location) {
-            this.includes.push({
-                namespace: child.$namespace || child.$targetNamespace || this.$targetNamespace,
-                location: location
-            });
-        }
+  if (child.$name in Primitives)
+    return;
+  if (child.name === 'include' || child.name === 'import') {
+    var location = child.$schemaLocation || child.$location;
+    if (location) {
+      this.includes.push({
+        namespace: child.$namespace || child.$targetNamespace || this.$targetNamespace,
+        location: location
+      });
     }
-    else if (child.name === 'complexType') {
-        this.complexTypes[child.$name] = child;
-    }
-    else if (child.name === 'element') {
-        this.elements[child.$name] = child;
-    }
-    else if (child.$name) {
-        this.types[child.$name] = child;
-    }
-    this.children.pop();
-    // child.deleteFixedAttrs();
+  }
+  else if (child.name === 'complexType') {
+    this.complexTypes[child.$name] = child;
+  }
+  else if (child.name === 'element') {
+    this.elements[child.$name] = child;
+  }
+  else if (child.$name) {
+    this.types[child.$name] = child;
+  }
+  this.children.pop();
+  // child.deleteFixedAttrs();
 };
 //fix#325
 TypesElement.prototype.addChild = function (child) {
-    assert(child instanceof SchemaElement);
+  assert(child instanceof SchemaElement);
 
-    var targetNamespace = child.$targetNamespace;
+  var targetNamespace = child.$targetNamespace;
 
-    if (!targetNamespace) {
-        if (child.includes && (child.includes instanceof Array) && child.includes.length > 0) {
-            targetNamespace = child.includes[0].namespace;
-        }
+  if (!targetNamespace) {
+    if (child.includes && (child.includes instanceof Array) && child.includes.length > 0) {
+      targetNamespace = child.includes[0].namespace;
     }
+  }
 
-    if (!this.schemas.hasOwnProperty(targetNamespace)) {
-        this.schemas[targetNamespace] = child;
-    } else {
-        console.error('Target-Namespace "' + targetNamespace + '" already in use by another Schema!');
-    }
+  if (!this.schemas.hasOwnProperty(targetNamespace)) {
+    this.schemas[targetNamespace] = child;
+  } else {
+    console.error('Target-Namespace "' + targetNamespace + '" already in use by another Schema!');
+  }
 };
 
 InputElement.prototype.addChild = function (child) {
-    if (child.name === 'body') {
-        this.use = child.$use;
-        if (this.use === 'encoded') {
-            this.encodingStyle = child.$encodingStyle;
-        }
-        this.children.pop();
+  if (child.name === 'body') {
+    this.use = child.$use;
+    if (this.use === 'encoded') {
+      this.encodingStyle = child.$encodingStyle;
     }
+    this.children.pop();
+  }
 };
 
 OutputElement.prototype.addChild = function (child) {
-    if (child.name === 'body') {
-        this.use = child.$use;
-        if (this.use === 'encoded') {
-            this.encodingStyle = child.$encodingStyle;
-        }
-        this.children.pop();
+  if (child.name === 'body') {
+    this.use = child.$use;
+    if (this.use === 'encoded') {
+      this.encodingStyle = child.$encodingStyle;
     }
+    this.children.pop();
+  }
 };
 
 OperationElement.prototype.addChild = function (child) {
-    if (child.name === 'operation') {
-        this.soapAction = child.$soapAction || '';
-        this.style = child.$style || '';
-        this.children.pop();
-    }
+  if (child.name === 'operation') {
+    this.soapAction = child.$soapAction || '';
+    this.style = child.$style || '';
+    this.children.pop();
+  }
 };
 
 BindingElement.prototype.addChild = function (child) {
-    if (child.name === 'binding') {
-        this.transport = child.$transport;
-        this.style = child.$style;
-        this.children.pop();
-    }
+  if (child.name === 'binding') {
+    this.transport = child.$transport;
+    this.style = child.$style;
+    this.children.pop();
+  }
 };
 
 PortElement.prototype.addChild = function (child) {
-    if (child.name === 'address' && typeof (child.$location) !== 'undefined') {
-        this.location = child.$location;
-    }
+  if (child.name === 'address' && typeof (child.$location) !== 'undefined') {
+    this.location = child.$location;
+  }
 };
 
 DefinitionsElement.prototype.addChild = function (child) {
-    var self = this;
-    if (child instanceof TypesElement) {
-        self.schemas = child.schemas;
-    }
-    else if (child instanceof MessageElement) {
-        self.messages[child.$name] = child;
-    }
-    else if (child.name === 'import') {
-        self.schemas[child.$namespace] = new SchemaElement(child.$namespace, {});
-        self.schemas[child.$namespace].addChild(child);
-    }
-    else if (child instanceof PortTypeElement) {
-        self.portTypes[child.$name] = child;
-    }
-    else if (child instanceof BindingElement) {
-        if (child.transport === 'http://schemas.xmlsoap.org/soap/http' ||
-            child.transport === 'http://www.w3.org/2003/05/soap/bindings/HTTP/')
-            self.bindings[child.$name] = child;
-    }
-    else if (child instanceof ServiceElement) {
-        self.services[child.$name] = child;
-    }
-    else if (child instanceof DocumentationElement) {
-    }
-    this.children.pop();
+  var self = this;
+  if (child instanceof TypesElement) {
+    self.schemas = child.schemas;
+  }
+  else if (child instanceof MessageElement) {
+    self.messages[child.$name] = child;
+  }
+  else if (child.name === 'import') {
+    self.schemas[child.$namespace] = new SchemaElement(child.$namespace, {});
+    self.schemas[child.$namespace].addChild(child);
+  }
+  else if (child instanceof PortTypeElement) {
+    self.portTypes[child.$name] = child;
+  }
+  else if (child instanceof BindingElement) {
+    if (child.transport === 'http://schemas.xmlsoap.org/soap/http' ||
+      child.transport === 'http://www.w3.org/2003/05/soap/bindings/HTTP/')
+      self.bindings[child.$name] = child;
+  }
+  else if (child instanceof ServiceElement) {
+    self.services[child.$name] = child;
+  }
+  else if (child instanceof DocumentationElement) {
+  }
+  this.children.pop();
 };
 
 MessageElement.prototype.postProcess = function (definitions) {
-    var part = null;
-    var child;
-    var children = this.children || [];
-    var ns;
-    var nsName;
-    var i;
-    var type;
+  var part = null;
+  var child;
+  var children = this.children || [];
+  var ns;
+  var nsName;
+  var i;
+  var type;
 
-    for (i in children) {
-        if ((child = children[i]).name === 'part') {
-            part = child;
-            break;
-        }
+  for (i in children) {
+    if ((child = children[i]).name === 'part') {
+      part = child;
+      break;
+    }
+  }
+
+  if (!part) {
+    return;
+  }
+
+  if (part.$element) {
+    var lookupTypes = [],
+      elementChildren;
+
+    delete this.parts;
+
+    nsName = splitNSName(part.$element);
+    ns = nsName.namespace;
+    var schema = definitions.schemas[definitions.xmlns[ns]];
+    this.element = schema.elements[nsName.name];
+    this.element.targetNSAlias = ns;
+    this.element.targetNamespace = definitions.xmlns[ns];
+
+    // set the optional $lookupType to be used within `client#_invoke()` when
+    // calling `wsdl#objectToDocumentXML()
+    this.element.$lookupType = part.$name;
+
+    elementChildren = this.element.children;
+
+    // get all nested lookup types (only complex types are followed)
+    if (elementChildren.length > 0) {
+      for (i = 0; i < elementChildren.length; i++) {
+        lookupTypes.push(this._getNestedLookupTypeString(elementChildren[i]));
+      }
     }
 
-    if (!part) {
-        return;
+    // if nested lookup types where found, prepare them for furter usage
+    if (lookupTypes.length > 0) {
+      lookupTypes = lookupTypes.
+        join('_').
+        split('_').
+        filter(function removeEmptyLookupTypes(type) {
+          return type !== '^';
+        });
+
+      var schemaXmlns = definitions.schemas[this.element.targetNamespace].xmlns;
+
+      for (i = 0; i < lookupTypes.length; i++) {
+        lookupTypes[i] = this._createLookupTypeObject(lookupTypes[i], schemaXmlns);
+      }
     }
 
-    if (part.$element) {
-        var lookupTypes = [],
-            elementChildren;
+    this.element.$lookupTypes = lookupTypes;
 
-        delete this.parts;
+    if (this.element.$type) {
+      type = splitNSName(this.element.$type);
+      var typeNs = schema.xmlns && schema.xmlns[type.namespace] || definitions.xmlns[type.namespace];
 
-        nsName = splitNSName(part.$element);
-        ns = nsName.namespace;
-        var schema = definitions.schemas[definitions.xmlns[ns]];
-        this.element = schema.elements[nsName.name];
-        this.element.targetNSAlias = ns;
-        this.element.targetNamespace = definitions.xmlns[ns];
-
-        // set the optional $lookupType to be used within `client#_invoke()` when
-        // calling `wsdl#objectToDocumentXML()
-        this.element.$lookupType = part.$name;
-
-        elementChildren = this.element.children;
-
-        // get all nested lookup types (only complex types are followed)
-        if (elementChildren.length > 0) {
-            for (i = 0; i < elementChildren.length; i++) {
-                lookupTypes.push(this._getNestedLookupTypeString(elementChildren[i]));
-            }
-        }
-
-        // if nested lookup types where found, prepare them for furter usage
-        if (lookupTypes.length > 0) {
-            lookupTypes = lookupTypes.
-                join('_').
-                split('_').
-                filter(function removeEmptyLookupTypes(type) {
-                    return type !== '^';
-                });
-
-            var schemaXmlns = definitions.schemas[this.element.targetNamespace].xmlns;
-
-            for (i = 0; i < lookupTypes.length; i++) {
-                lookupTypes[i] = this._createLookupTypeObject(lookupTypes[i], schemaXmlns);
-            }
-        }
-
-        this.element.$lookupTypes = lookupTypes;
-
-        if (this.element.$type) {
-            type = splitNSName(this.element.$type);
-            var typeNs = schema.xmlns && schema.xmlns[type.namespace] || definitions.xmlns[type.namespace];
-
-            if (typeNs) {
-                if (type.name in Primitives) {
-                    // this.element = this.element.$type;
-                }
-                else {
-                    // first check local mapping of ns alias to namespace
-                    schema = definitions.schemas[typeNs];
-                    var ctype = schema.complexTypes[type.name] || schema.types[type.name] || schema.elements[type.name];
-
-
-                    if (ctype) {
-                        this.parts = ctype.description(definitions, schema.xmlns);
-                    }
-                }
-            }
+      if (typeNs) {
+        if (type.name in Primitives) {
+          // this.element = this.element.$type;
         }
         else {
-            var method = this.element.description(definitions, schema.xmlns);
-            this.parts = method[nsName.name];
-        }
+          // first check local mapping of ns alias to namespace
+          schema = definitions.schemas[typeNs];
+          var ctype = schema.complexTypes[type.name] || schema.types[type.name] || schema.elements[type.name];
 
 
-        this.children.splice(0, 1);
-    } else {
-        // rpc encoding
-        this.parts = {};
-        delete this.element;
-        for (i = 0; part = this.children[i]; i++) {
-            assert(part.name === 'part', 'Expected part element');
-            nsName = splitNSName(part.$type);
-            ns = definitions.xmlns[nsName.namespace];
-            type = nsName.name;
-            var schemaDefinition = definitions.schemas[ns];
-            if (typeof schemaDefinition !== 'undefined') {
-                this.parts[part.$name] = definitions.schemas[ns].types[type] || definitions.schemas[ns].complexTypes[type];
-            } else {
-                this.parts[part.$name] = part.$type;
-            }
-            this.parts[part.$name].namespace = nsName.namespace;
-            this.parts[part.$name].xmlns = ns;
-            this.children.splice(i--, 1);
+          if (ctype) {
+            this.parts = ctype.description(definitions, schema.xmlns);
+          }
         }
+      }
     }
-    this.deleteFixedAttrs();
+    else {
+      var method = this.element.description(definitions, schema.xmlns);
+      this.parts = method[nsName.name];
+    }
+
+
+    this.children.splice(0, 1);
+  } else {
+    // rpc encoding
+    this.parts = {};
+    delete this.element;
+    for (i = 0; part = this.children[i]; i++) {
+      assert(part.name === 'part', 'Expected part element');
+      nsName = splitNSName(part.$type);
+      ns = definitions.xmlns[nsName.namespace];
+      type = nsName.name;
+      var schemaDefinition = definitions.schemas[ns];
+      if (typeof schemaDefinition !== 'undefined') {
+        this.parts[part.$name] = definitions.schemas[ns].types[type] || definitions.schemas[ns].complexTypes[type];
+      } else {
+        this.parts[part.$name] = part.$type;
+      }
+      this.parts[part.$name].namespace = nsName.namespace;
+      this.parts[part.$name].xmlns = ns;
+      this.children.splice(i--, 1);
+    }
+  }
+  this.deleteFixedAttrs();
 };
 
 /**
@@ -538,18 +538,18 @@ MessageElement.prototype.postProcess = function (definitions) {
  * @private
  */
 MessageElement.prototype._createLookupTypeObject = function (nsString, xmlns) {
-    var splittedNSString = splitNSName(nsString),
-        nsAlias = splittedNSString.namespace,
-        splittedName = splittedNSString.name.split('#'),
-        type = splittedName[0],
-        name = splittedName[1],
-        lookupTypeObj = {};
+  var splittedNSString = splitNSName(nsString),
+    nsAlias = splittedNSString.namespace,
+    splittedName = splittedNSString.name.split('#'),
+    type = splittedName[0],
+    name = splittedName[1],
+    lookupTypeObj = {};
 
-    lookupTypeObj.$namespace = xmlns[nsAlias];
-    lookupTypeObj.$type = nsAlias + ':' + type;
-    lookupTypeObj.$name = name;
+  lookupTypeObj.$namespace = xmlns[nsAlias];
+  lookupTypeObj.$type = nsAlias + ':' + type;
+  lookupTypeObj.$name = name;
 
-    return lookupTypeObj;
+  return lookupTypeObj;
 };
 
 /**
@@ -563,1014 +563,1017 @@ MessageElement.prototype._createLookupTypeObject = function (nsString, xmlns) {
  * @private
  */
 MessageElement.prototype._getNestedLookupTypeString = function (element) {
-    var resolvedType = '^',
-        excluded = this.ignoredNamespaces.concat('xs'); // do not process $type values wich start with
+  var resolvedType = '^',
+    excluded = this.ignoredNamespaces.concat('xs'); // do not process $type values wich start with
 
-    if (element.hasOwnProperty('$type') && typeof element.$type === 'string') {
-        if (excluded.indexOf(element.$type.split(':')[0]) === -1) {
-            resolvedType += ('_' + element.$type + '#' + element.$name);
-        }
+  if (element.hasOwnProperty('$type') && typeof element.$type === 'string') {
+    if (excluded.indexOf(element.$type.split(':')[0]) === -1) {
+      resolvedType += ('_' + element.$type + '#' + element.$name);
     }
+  }
 
-    if (element.children.length > 0) {
-        var self = this;
+  if (element.children.length > 0) {
+    var self = this;
 
-        element.children.forEach(function (child) {
-            var resolvedChildType = self._getNestedLookupTypeString(child).replace(/\^_/, '');
+    element.children.forEach(function (child) {
+      var resolvedChildType = self._getNestedLookupTypeString(child).replace(/\^_/, '');
 
-            if (resolvedChildType && typeof resolvedChildType === 'string') {
-                resolvedType += ('_' + resolvedChildType);
-            }
-        });
-    }
+      if (resolvedChildType && typeof resolvedChildType === 'string') {
+        resolvedType += ('_' + resolvedChildType);
+      }
+    });
+  }
 
-    return resolvedType;
+  return resolvedType;
 };
 
 OperationElement.prototype.postProcess = function (definitions, tag) {
-    var children = this.children;
-    for (var i = 0, child; child = children[i]; i++) {
-        if (child.name !== 'input' && child.name !== 'output')
-            continue;
-        if (tag === 'binding') {
-            this[child.name] = child;
-            children.splice(i--, 1);
-            continue;
-        }
-        var messageName = splitNSName(child.$message).name;
-        var message = definitions.messages[messageName];
-        message.postProcess(definitions);
-        if (message.element) {
-            definitions.messages[message.element.$name] = message;
-            this[child.name] = message.element;
-        }
-        else {
-            this[child.name] = message;
-        }
-        children.splice(i--, 1);
+  var children = this.children;
+  for (var i = 0, child; child = children[i]; i++) {
+    if (child.name !== 'input' && child.name !== 'output')
+      continue;
+    if (tag === 'binding') {
+      this[child.name] = child;
+      children.splice(i--, 1);
+      continue;
     }
-    this.deleteFixedAttrs();
+    var messageName = splitNSName(child.$message).name;
+    var message = definitions.messages[messageName];
+    message.postProcess(definitions);
+    if (message.element) {
+      definitions.messages[message.element.$name] = message;
+      this[child.name] = message.element;
+    }
+    else {
+      this[child.name] = message;
+    }
+    children.splice(i--, 1);
+  }
+  this.deleteFixedAttrs();
 };
 
 PortTypeElement.prototype.postProcess = function (definitions) {
-    var children = this.children;
-    if (typeof children === 'undefined')
-        return;
-    for (var i = 0, child; child = children[i]; i++) {
-        if (child.name !== 'operation')
-            continue;
-        child.postProcess(definitions, 'portType');
-        this.methods[child.$name] = child;
-        children.splice(i--, 1);
-    }
-    delete this.$name;
-    this.deleteFixedAttrs();
+  var children = this.children;
+  if (typeof children === 'undefined')
+    return;
+  for (var i = 0, child; child = children[i]; i++) {
+    if (child.name !== 'operation')
+      continue;
+    child.postProcess(definitions, 'portType');
+    this.methods[child.$name] = child;
+    children.splice(i--, 1);
+  }
+  delete this.$name;
+  this.deleteFixedAttrs();
 };
 
 BindingElement.prototype.postProcess = function (definitions) {
-    var type = splitNSName(this.$type).name,
-        portType = definitions.portTypes[type],
-        style = this.style,
-        children = this.children;
-    if (portType) {
-        portType.postProcess(definitions);
-        this.methods = portType.methods;
+  var type = splitNSName(this.$type).name,
+    portType = definitions.portTypes[type],
+    style = this.style,
+    children = this.children;
+  if (portType) {
+    portType.postProcess(definitions);
+    this.methods = portType.methods;
 
-        for (var i = 0, child; child = children[i]; i++) {
-            if (child.name !== 'operation')
-                continue;
-            child.postProcess(definitions, 'binding');
-            children.splice(i--, 1);
-            child.style || (child.style = style);
-            var method = this.methods[child.$name];
+    for (var i = 0, child; child = children[i]; i++) {
+      if (child.name !== 'operation')
+        continue;
+      child.postProcess(definitions, 'binding');
+      children.splice(i--, 1);
+      child.style || (child.style = style);
+      var method = this.methods[child.$name];
 
-            if (method) {
-                method.style = child.style;
-                method.soapAction = child.soapAction;
-                method.inputSoap = child.input || null;
-                method.outputSoap = child.output || null;
-                method.inputSoap && method.inputSoap.deleteFixedAttrs();
-                method.outputSoap && method.outputSoap.deleteFixedAttrs();
-            }
-        }
+      if (method) {
+        method.style = child.style;
+        method.soapAction = child.soapAction;
+        method.inputSoap = child.input || null;
+        method.outputSoap = child.output || null;
+        method.inputSoap && method.inputSoap.deleteFixedAttrs();
+        method.outputSoap && method.outputSoap.deleteFixedAttrs();
+      }
     }
-    delete this.$name;
-    delete this.$type;
-    this.deleteFixedAttrs();
+  }
+  delete this.$name;
+  delete this.$type;
+  this.deleteFixedAttrs();
 };
 
 ServiceElement.prototype.postProcess = function (definitions) {
-    var children = this.children,
-        bindings = definitions.bindings;
-    for (var i = 0, child; child = children[i]; i++) {
-        if (child.name !== 'port')
-            continue;
-        var bindingName = splitNSName(child.$binding).name;
-        var binding = bindings[bindingName];
-        if (binding) {
-            binding.postProcess(definitions);
-            this.ports[child.$name] = {
-                location: child.location,
-                binding: binding
-            };
-            children.splice(i--, 1);
-        }
+  var children = this.children,
+    bindings = definitions.bindings;
+  for (var i = 0, child; child = children[i]; i++) {
+    if (child.name !== 'port')
+      continue;
+    var bindingName = splitNSName(child.$binding).name;
+    var binding = bindings[bindingName];
+    if (binding) {
+      binding.postProcess(definitions);
+      this.ports[child.$name] = {
+        location: child.location,
+        binding: binding
+      };
+      children.splice(i--, 1);
     }
-    delete this.$name;
-    this.deleteFixedAttrs();
+  }
+  delete this.$name;
+  this.deleteFixedAttrs();
 };
 
 
 SimpleTypeElement.prototype.description = function (definitions) {
-    var children = this.children;
-    for (var i = 0, child; child = children[i]; i++) {
-        if (child instanceof RestrictionElement)
-            return this.$name + "|" + child.description();
-    }
-    return {};
+  var children = this.children;
+  for (var i = 0, child; child = children[i]; i++) {
+    if (child instanceof RestrictionElement)
+      return this.$name + "|" + child.description();
+  }
+  return {};
 };
 
 RestrictionElement.prototype.description = function (definitions, xmlns) {
-    var children = this.children;
-    var desc;
-    for (var i = 0, child; child = children[i]; i++) {
-        if (child instanceof SequenceElement ||
-            child instanceof ChoiceElement) {
-            desc = child.description(definitions);
-            break;
-        }
+  var children = this.children;
+  var desc;
+  for (var i = 0, child; child = children[i]; i++) {
+    if (child instanceof SequenceElement ||
+      child instanceof ChoiceElement) {
+      desc = child.description(definitions);
+      break;
     }
-    if (desc && this.$base) {
-        var type = splitNSName(this.$base),
-            typeName = type.name,
-            ns = xmlns && xmlns[type.namespace] || definitions.xmlns[type.namespace],
-            schema = definitions.schemas[ns],
-            typeElement = schema && ( schema.complexTypes[typeName] || schema.types[typeName] || schema.elements[typeName] );
+  }
+  if (desc && this.$base) {
+    var type = splitNSName(this.$base),
+      typeName = type.name,
+      ns = xmlns && xmlns[type.namespace] || definitions.xmlns[type.namespace],
+      schema = definitions.schemas[ns],
+      typeElement = schema && ( schema.complexTypes[typeName] || schema.types[typeName] || schema.elements[typeName] );
 
-        desc.getBase = function () {
-            return typeElement.description(definitions, xmlns);
-        };
-        return desc;
-    }
+    desc.getBase = function () {
+      return typeElement.description(definitions, xmlns);
+    };
+    return desc;
+  }
 
-    // then simple element
-    var base = this.$base ? this.$base + "|" : "";
-    return base + this.children.map(function (child) {
-        return child.description();
-    }).join(",");
+  // then simple element
+  var base = this.$base ? this.$base + "|" : "";
+  return base + this.children.map(function (child) {
+    return child.description();
+  }).join(",");
 };
 
 ExtensionElement.prototype.description = function (definitions, xmlns) {
-    var children = this.children;
-    var desc = {};
-    for (var i = 0, child; child = children[i]; i++) {
-        if (child instanceof SequenceElement ||
-            child instanceof ChoiceElement) {
-            desc = child.description(definitions);
-        }
+  var children = this.children;
+  var desc = {};
+  for (var i = 0, child; child = children[i]; i++) {
+    if (child instanceof SequenceElement ||
+      child instanceof ChoiceElement) {
+      desc = child.description(definitions);
     }
-    if (this.$base) {
-        var type = splitNSName(this.$base),
-            typeName = type.name,
-            ns = xmlns && xmlns[type.namespace] || definitions.xmlns[type.namespace],
-            schema = definitions.schemas[ns];
+  }
+  if (this.$base) {
+    var type = splitNSName(this.$base),
+      typeName = type.name,
+      ns = xmlns && xmlns[type.namespace] || definitions.xmlns[type.namespace],
+      schema = definitions.schemas[ns];
 
-        if (typeName in Primitives) {
-            return this.$base;
-        }
-        else {
-            var typeElement = schema && ( schema.complexTypes[typeName] ||
-                schema.types[typeName] || schema.elements[typeName] );
-
-            var base = typeElement.description(definitions, xmlns);
-            extend(desc, base);
-        }
+    if (typeName in Primitives) {
+      return this.$base;
     }
-    return desc;
+    else {
+      var typeElement = schema && ( schema.complexTypes[typeName] ||
+        schema.types[typeName] || schema.elements[typeName] );
+
+      var base = typeElement.description(definitions, xmlns);
+      extend(desc, base);
+    }
+  }
+  return desc;
 };
 
 EnumerationElement.prototype.description = function () {
-    return this.$value;
+  return this.$value;
 };
 
 ComplexTypeElement.prototype.description = function (definitions, xmlns) {
-    var children = this.children || [];
-    for (var i = 0, child; child = children[i]; i++) {
-        if (child instanceof ChoiceElement ||
-            child instanceof SequenceElement ||
-            child instanceof AllElement ||
-            child instanceof SimpleContentElement ||
-            child instanceof ComplexContentElement) {
+  var children = this.children || [];
+  for (var i = 0, child; child = children[i]; i++) {
+    if (child instanceof ChoiceElement ||
+      child instanceof SequenceElement ||
+      child instanceof AllElement ||
+      child instanceof SimpleContentElement ||
+      child instanceof ComplexContentElement) {
 
-            return child.description(definitions, xmlns);
-        }
+      return child.description(definitions, xmlns);
     }
-    return {};
+  }
+  return {};
 };
 
 ComplexContentElement.prototype.description = function (definitions, xmlns) {
-    var children = this.children;
-    for (var i = 0, child; child = children[i]; i++) {
-        if (child instanceof ExtensionElement) {
-            return child.description(definitions, xmlns);
-        }
+  var children = this.children;
+  for (var i = 0, child; child = children[i]; i++) {
+    if (child instanceof ExtensionElement) {
+      return child.description(definitions, xmlns);
     }
-    return {};
+  }
+  return {};
 };
 
 SimpleContentElement.prototype.description = function (definitions, xmlns) {
-    var children = this.children;
-    for (var i = 0, child; child = children[i]; i++) {
-        if (child instanceof ExtensionElement) {
-            return child.description(definitions, xmlns);
-        }
+  var children = this.children;
+  for (var i = 0, child; child = children[i]; i++) {
+    if (child instanceof ExtensionElement) {
+      return child.description(definitions, xmlns);
     }
-    return {};
+  }
+  return {};
 };
 
 ElementElement.prototype.description = function (definitions, xmlns) {
-    var element = {},
-        name = this.$name;
-    var isMany = !this.$maxOccurs ? false : (isNaN(this.$maxOccurs) ? (this.$maxOccurs === 'unbounded') : (this.$maxOccurs > 1));
-    if (this.$minOccurs !== this.$maxOccurs && isMany) {
-        name += '[]';
-    }
+  var element = {},
+    name = this.$name;
+  var isMany = !this.$maxOccurs ? false : (isNaN(this.$maxOccurs) ? (this.$maxOccurs === 'unbounded') : (this.$maxOccurs > 1));
+  if (this.$minOccurs !== this.$maxOccurs && isMany) {
+    name += '[]';
+  }
 
-    var type = this.$type || this.$ref;
-    if (type) {
-        type = splitNSName(type);
-        var typeName = type.name,
-            ns = xmlns && xmlns[type.namespace] || definitions.xmlns[type.namespace],
-            schema = definitions.schemas[ns],
-            typeElement = schema && ( schema.complexTypes[typeName] || schema.types[typeName] || schema.elements[typeName] );
+  var type = this.$type || this.$ref;
+  if (type) {
+    type = splitNSName(type);
+    var typeName = type.name,
+      ns = xmlns && xmlns[type.namespace] || definitions.xmlns[type.namespace],
+      schema = definitions.schemas[ns],
+      typeElement = schema && ( schema.complexTypes[typeName] || schema.types[typeName] || schema.elements[typeName] );
 
-        if (typeElement && !(typeName in Primitives)) {
+    if (typeElement && !(typeName in Primitives)) {
 
-            if (!(typeName in definitions.descriptions.types)) {
+      if (!(typeName in definitions.descriptions.types)) {
 
-                var elem = {};
-                definitions.descriptions.types[typeName] = elem;
-                if (this.$ref) {
-                    elem = element = typeElement.description(definitions, xmlns);
-                }
-                else {
-                    elem = element[name] = typeElement.description(definitions, xmlns);
-                }
-                elem.targetNSAlias = type.namespace;
-                elem.targetNamespace = ns;
-
-                definitions.descriptions.types[typeName] = elem;
-            }
-            else {
-                if (this.$ref) {
-                    element = definitions.descriptions.types[typeName];
-                }
-                else {
-                    element[name] = definitions.descriptions.types[typeName];
-                }
-            }
-
+        var elem = {};
+        definitions.descriptions.types[typeName] = elem;
+        if (this.$ref) {
+          elem = element = typeElement.description(definitions, xmlns);
         }
         else {
-            element[name] = this.$type;
+          elem = element[name] = typeElement.description(definitions, xmlns);
         }
+        elem.targetNSAlias = type.namespace;
+        elem.targetNamespace = ns;
+
+        definitions.descriptions.types[typeName] = elem;
+      }
+      else {
+        if (this.$ref) {
+          element = definitions.descriptions.types[typeName];
+        }
+        else {
+          element[name] = definitions.descriptions.types[typeName];
+        }
+      }
+
     }
     else {
-        var children = this.children;
-        element[name] = {};
-        for (var i = 0, child; child = children[i]; i++) {
-            if (child instanceof ComplexTypeElement) {
-                element[name] = child.description(definitions, xmlns);
-            }
-        }
+      element[name] = this.$type;
     }
-    return element;
+  }
+  else {
+    var children = this.children;
+    element[name] = {};
+    for (var i = 0, child; child = children[i]; i++) {
+      if (child instanceof ComplexTypeElement) {
+        element[name] = child.description(definitions, xmlns);
+      }
+    }
+  }
+  return element;
 };
 
 AllElement.prototype.description =
     SequenceElement.prototype.description = function (definitions, xmlns) {
-        var children = this.children;
-        var sequence = {};
-        for (var i = 0, child; child = children[i]; i++) {
-            if (child instanceof AnyElement) {
-                continue;
-            }
-            var description = child.description(definitions, xmlns);
-            for (var key in description) {
-                sequence[key] = description[key];
-            }
+      var children = this.children;
+      var sequence = {};
+      for (var i = 0, child; child = children[i]; i++) {
+        if (child instanceof AnyElement) {
+          continue;
         }
-        return sequence;
+        var description = child.description(definitions, xmlns);
+        for (var key in description) {
+          sequence[key] = description[key];
+        }
+      }
+      return sequence;
     };
 
 ChoiceElement.prototype.description = function (definitions, xmlns) {
-    var children = this.children;
-    var choice = {};
-    for (var i = 0, child; child = children[i]; i++) {
-        var description = child.description(definitions, xmlns);
-        for (var key in description) {
-            choice[key] = description[key];
-        }
+  var children = this.children;
+  var choice = {};
+  for (var i = 0, child; child = children[i]; i++) {
+    var description = child.description(definitions, xmlns);
+    for (var key in description) {
+      choice[key] = description[key];
     }
-    return choice;
+  }
+  return choice;
 };
 
 MessageElement.prototype.description = function (definitions) {
-    if (this.element) {
-        return this.element && this.element.description(definitions);
-    }
-    var desc = {};
-    desc[this.$name] = this.parts;
-    return desc;
+  if (this.element) {
+    return this.element && this.element.description(definitions);
+  }
+  var desc = {};
+  desc[this.$name] = this.parts;
+  return desc;
 };
 
 PortTypeElement.prototype.description = function (definitions) {
-    var methods = {};
-    for (var name in this.methods) {
-        var method = this.methods[name];
-        methods[name] = method.description(definitions);
-    }
-    return methods;
+  var methods = {};
+  for (var name in this.methods) {
+    var method = this.methods[name];
+    methods[name] = method.description(definitions);
+  }
+  return methods;
 };
 
 OperationElement.prototype.description = function (definitions) {
-    var inputDesc = this.input ? this.input.description(definitions) : null;
-    var outputDesc = this.output ? this.output.description(definitions) : null;
-    return {
-        input: inputDesc && inputDesc[Object.keys(inputDesc)[0]],
-        output: outputDesc && outputDesc[Object.keys(outputDesc)[0]]
-    };
+  var inputDesc = this.input ? this.input.description(definitions) : null;
+  var outputDesc = this.output ? this.output.description(definitions) : null;
+  return {
+    input: inputDesc && inputDesc[Object.keys(inputDesc)[0]],
+    output: outputDesc && outputDesc[Object.keys(outputDesc)[0]]
+  };
 };
 
 BindingElement.prototype.description = function (definitions) {
-    var methods = {};
-    for (var name in this.methods) {
-        var method = this.methods[name];
-        methods[name] = method.description(definitions);
-    }
-    return methods;
+  var methods = {};
+  for (var name in this.methods) {
+    var method = this.methods[name];
+    methods[name] = method.description(definitions);
+  }
+  return methods;
 };
 
 ServiceElement.prototype.description = function (definitions) {
-    var ports = {};
-    for (var name in this.ports) {
-        var port = this.ports[name];
-        ports[name] = port.binding.description(definitions);
-    }
-    return ports;
+  var ports = {};
+  for (var name in this.ports) {
+    var port = this.ports[name];
+    ports[name] = port.binding.description(definitions);
+  }
+  return ports;
 };
 
 var WSDL = function (definition, uri, options) {
-    var self = this,
-        fromFunc,
-        ignoredNamespaces;
+  var self = this,
+    fromFunc,
+    ignoredNamespaces;
 
-    this.uri = uri;
-    this.callback = function () {
-    };
-    this.options = options || {};
+  this.uri = uri;
+  this.callback = function () {
+  };
+  this.options = options || {};
 
-    ignoredNamespaces = this.options.ignoredNamespaces;
+  ignoredNamespaces = this.options.ignoredNamespaces;
 
-    if (ignoredNamespaces &&
-        (Array.isArray(ignoredNamespaces.namespaces) || typeof ignoredNamespaces.namespaces === 'string')) {
-        if (ignoredNamespaces.override) {
-            this.ignoredNamespaces = ignoredNamespaces.namespaces;
-        } else {
-            this.ignoredNamespaces.concat(ignoredNamespaces.namespaces);
+  if (ignoredNamespaces &&
+    (Array.isArray(ignoredNamespaces.namespaces) || typeof ignoredNamespaces.namespaces === 'string')) {
+    if (ignoredNamespaces.override) {
+      this.ignoredNamespaces = ignoredNamespaces.namespaces;
+    } else {
+      this.ignoredNamespaces.concat(ignoredNamespaces.namespaces);
+    }
+  }
+
+  if (typeof definition === 'string') {
+    fromFunc = this._fromXML;
+  }
+  else if (typeof definition === 'object') {
+    fromFunc = this._fromServices;
+  }
+  else {
+    throw new Error('WSDL constructor takes either an XML string or service definition');
+  }
+
+  process.nextTick(function () {
+    try {
+      fromFunc.call(self, definition);
+    } catch (e) {
+      return self.callback(e.message);
+    }
+
+    self.processIncludes(function (err) {
+      var name;
+      if (err) {
+        return self.callback(err);
+      }
+
+      self.definitions.deleteFixedAttrs();
+      var services = self.services = self.definitions.services;
+      if (services) {
+        for (name in services) {
+          services[name].postProcess(self.definitions);
         }
-    }
-
-    if (typeof definition === 'string') {
-        fromFunc = this._fromXML;
-    }
-    else if (typeof definition === 'object') {
-        fromFunc = this._fromServices;
-    }
-    else {
-        throw new Error('WSDL constructor takes either an XML string or service definition');
-    }
-
-    process.nextTick(function () {
-        try {
-            fromFunc.call(self, definition);
-        } catch (e) {
-            return self.callback(e.message);
+      }
+      var complexTypes = self.definitions.complexTypes;
+      if (complexTypes) {
+        for (name in complexTypes) {
+          complexTypes[name].deleteFixedAttrs();
         }
+      }
 
-        self.processIncludes(function (err) {
-            var name;
-            if (err) {
-                return self.callback(err);
-            }
+      // for document style, for every binding, prepare input message element name to (methodName, output message element name) mapping
+      var bindings = self.definitions.bindings;
+      for (var bindingName in bindings) {
+        var binding = bindings[bindingName];
+        if (typeof binding.style === 'undefined') {
+          binding.style = 'document';
+        }
+        if (binding.style !== 'document')
+          continue;
+        var methods = binding.methods;
+        var topEls = binding.topElements = {};
+        for (var methodName in methods) {
+          var inputName = methods[methodName].input.$name;
+          var outputName = "";
+          if (methods[methodName].output)
+            outputName = methods[methodName].output.$name;
+          topEls[inputName] = {"methodName": methodName, "outputName": outputName};
+        }
+      }
 
-            self.definitions.deleteFixedAttrs();
-            var services = self.services = self.definitions.services;
-            if (services) {
-                for (name in services) {
-                    services[name].postProcess(self.definitions);
-                }
-            }
-            var complexTypes = self.definitions.complexTypes;
-            if (complexTypes) {
-                for (name in complexTypes) {
-                    complexTypes[name].deleteFixedAttrs();
-                }
-            }
+      // prepare soap envelope xmlns definition string
+      self.xmlnsInEnvelope = self._xmlnsMap();
 
-            // for document style, for every binding, prepare input message element name to (methodName, output message element name) mapping
-            var bindings = self.definitions.bindings;
-            for (var bindingName in bindings) {
-                var binding = bindings[bindingName];
-                if (typeof binding.style === 'undefined') {
-                    binding.style = 'document';
-                }
-                if (binding.style !== 'document')
-                    continue;
-                var methods = binding.methods;
-                var topEls = binding.topElements = {};
-                for (var methodName in methods) {
-                    var inputName = methods[methodName].input.$name;
-                    var outputName = "";
-                    if (methods[methodName].output)
-                        outputName = methods[methodName].output.$name;
-                    topEls[inputName] = {"methodName": methodName, "outputName": outputName};
-                }
-            }
-
-            // prepare soap envelope xmlns definition string
-            self.xmlnsInEnvelope = self._xmlnsMap();
-
-            self.callback(err, self);
-        });
-
+      self.callback(err, self);
     });
+
+  });
 };
 
 WSDL.prototype.ignoredNamespaces = ['tns', 'targetNamespace', 'typedNamespace'];
 
 WSDL.prototype.onReady = function (callback) {
-    if (callback)
-        this.callback = callback;
+  if (callback)
+    this.callback = callback;
 };
 
 WSDL.prototype._processNextInclude = function (includes, callback) {
-    var self = this,
-        include = includes.shift();
+  var self = this,
+    include = includes.shift();
 
-    if (!include)
-        return callback();
+  if (!include)
+    return callback();
 
-    var includePath;
-    if (!/^http/.test(self.uri) && !/^http/.test(include.location)) {
-        includePath = path.resolve(path.dirname(self.uri), include.location);
-    } else {
-        includePath = url.resolve(self.uri, include.location);
+  var includePath;
+  if (!/^http/.test(self.uri) && !/^http/.test(include.location)) {
+    includePath = path.resolve(path.dirname(self.uri), include.location);
+  } else {
+    includePath = url.resolve(self.uri, include.location);
+  }
+
+  open_wsdl(includePath, function (err, wsdl) {
+    if (err) {
+      return callback(err);
     }
 
-    open_wsdl(includePath, function (err, wsdl) {
-        if (err) {
-            return callback(err);
-        }
-
-        self.definitions.schemas[include.namespace || wsdl.definitions.$targetNamespace] = wsdl.definitions;
-        self._processNextInclude(includes, function (err) {
-            callback(err);
-        });
+    self.definitions.schemas[include.namespace || wsdl.definitions.$targetNamespace] = wsdl.definitions;
+    self._processNextInclude(includes, function (err) {
+      callback(err);
     });
+  });
 };
 
 WSDL.prototype.processIncludes = function (callback) {
-    var schemas = this.definitions.schemas,
-        includes = [];
+  var schemas = this.definitions.schemas,
+    includes = [];
 
-    for (var ns in schemas) {
-        var schema = schemas[ns];
-        includes = includes.concat(schema.includes || []);
-    }
+  for (var ns in schemas) {
+    var schema = schemas[ns];
+    includes = includes.concat(schema.includes || []);
+  }
 
-    this._processNextInclude(includes, callback);
+  this._processNextInclude(includes, callback);
 };
 
 WSDL.prototype.describeServices = function () {
-    var services = {};
-    for (var name in this.services) {
-        var service = this.services[name];
-        services[name] = service.description(this.definitions);
-    }
-    return services;
+  var services = {};
+  for (var name in this.services) {
+    var service = this.services[name];
+    services[name] = service.description(this.definitions);
+  }
+  return services;
 };
 
 WSDL.prototype.toXML = function () {
-    return this.xml || '';
+  return this.xml || '';
 };
 
 WSDL.prototype.xmlToObject = function (xml) {
-    var self = this;
-    var p = sax.parser(true);
-    var objectName = null;
-    var root = {};
-    var schema = {
-        Envelope: {
-            Header: {
-                Security: {
-                    UsernameToken: {
-                        Username: 'string',
-                        Password: 'string'
-                    }
-                }
-            },
-            Body: {
-                Fault: {
-                    faultcode: 'string',
-                    faultstring: 'string',
-                    detail: 'string'
-                }
-            }
+  var self = this;
+  var p = sax.parser(true);
+  var objectName = null;
+  var root = {};
+  var schema = {
+    Envelope: {
+      Header: {
+        Security: {
+          UsernameToken: {
+            Username: 'string',
+            Password: 'string'
+          }
         }
-    };
-    var stack = [
-        {name: null, object: root, schema: schema}
-    ];
-
-    var refs = {}, id; // {id:{hrefs:[],obj:}, ...}
-
-    p.onopentag = function (node) {
-        var nsName = node.name;
-        var attrs = node.attributes;
-
-        var name = splitNSName(nsName).name,
-            attributeName,
-            top = stack[stack.length - 1],
-            topSchema = top.schema,
-            elementAttributes = {},
-            hasNonXmlnsAttribute = false,
-            obj = {};
-        var originalName = name;
-
-        if (!objectName && top.name === 'Body' && name !== 'Fault') {
-            var message = self.definitions.messages[name];
-            // Support RPC/literal messages where response body contains one element named
-            // after the operation + 'Response'. See http://www.w3.org/TR/wsdl#_names
-            if (!message) {
-                // Determine if this is request or response
-                var isInput = false;
-                var isOutput = false;
-                if ((/Response$/).test(name)) {
-                    isOutput = true;
-                    name = name.replace(/Response$/, '');
-                } else if ((/Request$/).test(name)) {
-                    isInput = true;
-                    name = name.replace(/Request$/, '');
-                } else if ((/Solicit$/).test(name)) {
-                    isInput = true;
-                    name = name.replace(/Solicit$/, '');
-                }
-                // Look up the appropriate message as given in the portType's operations
-                var portTypes = self.definitions.portTypes;
-                var portTypeNames = Object.keys(portTypes);
-                // Currently this supports only one portType definition.
-                var portType = portTypes[portTypeNames[0]];
-                if (isInput)
-                    name = portType.methods[name].input.$name;
-                else
-                    name = portType.methods[name].output.$name;
-                message = self.definitions.messages[name];
-                // 'cache' this alias to speed future lookups
-                self.definitions.messages[originalName] = self.definitions.messages[name];
-            }
-
-            topSchema = message.description(self.definitions);
-            objectName = originalName;
+      },
+      Body: {
+        Fault: {
+          faultcode: 'string',
+          faultstring: 'string',
+          detail: 'string'
         }
+      }
+    }
+  };
+  var stack = [
+    {name: null, object: root, schema: schema}
+  ];
 
-        if (attrs.href) {
-            id = attrs.href.substr(1);
-            if (!refs[id])
-                refs[id] = {hrefs: [], obj: null};
-            refs[id].hrefs.push({par: top.object, key: name, obj: obj});
+  var refs = {}, id; // {id:{hrefs:[],obj:}, ...}
+
+  p.onopentag = function (node) {
+    var nsName = node.name;
+    var attrs = node.attributes;
+
+    var name = splitNSName(nsName).name,
+      attributeName,
+      top = stack[stack.length - 1],
+      topSchema = top.schema,
+      elementAttributes = {},
+      hasNonXmlnsAttribute = false,
+      obj = {};
+    var originalName = name;
+
+    if (!objectName && top.name === 'Body' && name !== 'Fault') {
+      var message = self.definitions.messages[name];
+      // Support RPC/literal messages where response body contains one element named
+      // after the operation + 'Response'. See http://www.w3.org/TR/wsdl#_names
+      if (!message) {
+        // Determine if this is request or response
+        var isInput = false;
+        var isOutput = false;
+        if ((/Response$/).test(name)) {
+          isOutput = true;
+          name = name.replace(/Response$/, '');
+        } else if ((/Request$/).test(name)) {
+          isInput = true;
+          name = name.replace(/Request$/, '');
+        } else if ((/Solicit$/).test(name)) {
+          isInput = true;
+          name = name.replace(/Solicit$/, '');
         }
-        if (id = attrs.id) {
-            if (!refs[id])
-                refs[id] = {hrefs: [], obj: null};
-        }
+        // Look up the appropriate message as given in the portType's operations
+        var portTypes = self.definitions.portTypes;
+        var portTypeNames = Object.keys(portTypes);
+        // Currently this supports only one portType definition.
+        var portType = portTypes[portTypeNames[0]];
+        if (isInput)
+          name = portType.methods[name].input.$name;
+        else
+          name = portType.methods[name].output.$name;
+        message = self.definitions.messages[name];
+        // 'cache' this alias to speed future lookups
+        self.definitions.messages[originalName] = self.definitions.messages[name];
+      }
 
-        //Handle element attributes
-        for (attributeName in attrs) {
-            if (/^xmlns:?/.test(attributeName))continue;
-            hasNonXmlnsAttribute = true;
-            elementAttributes[attributeName] = attrs[attributeName];
-        }
-
-        if (hasNonXmlnsAttribute)obj[self.options.attributesKey] = elementAttributes;
-
-        if (topSchema && topSchema[name + '[]'])
-            name = name + '[]';
-        stack.push({name: originalName, object: obj, schema: topSchema && topSchema[name], id: attrs.id});
-    };
-
-    p.onclosetag = function (nsName) {
-        var cur = stack.pop(),
-            obj = cur.object,
-            top = stack[stack.length - 1],
-            topObject = top.object,
-            topSchema = top.schema,
-            name = splitNSName(nsName).name;
-
-        if (topSchema && topSchema[name + '[]']) {
-            if (!topObject[name])
-                topObject[name] = [];
-            topObject[name].push(obj);
-        }
-        else if (name in topObject) {
-            if (!Array.isArray(topObject[name])) {
-                topObject[name] = [topObject[name]];
-            }
-            topObject[name].push(obj);
-        }
-        else {
-            topObject[name] = obj;
-        }
-
-        if (cur.id) {
-            refs[cur.id].obj = obj;
-        }
-    };
-
-    p.ontext = function (text) {
-        text = trim(text);
-        if (!text.length)
-            return;
-
-        var top = stack[stack.length - 1];
-        var name = splitNSName(top.schema).name,
-            value;
-        if (name === 'int' || name === 'integer') {
-            value = parseInt(text, 10);
-        } else if (name === 'bool' || name === 'boolean') {
-            value = text.toLowerCase() === 'true' || text === '1';
-        } else if (name === 'dateTime' || name === 'date') {
-            value = new Date(text);
-        } else {
-            // handle string or other types
-            if (typeof top.object !== 'string') {
-                value = text;
-            } else {
-                value = top.object + text;
-            }
-        }
-
-        if (top.object[self.options.attributesKey]) {
-            top.object.$value = value;
-        } else {
-            top.object = value;
-        }
-    };
-
-    p.write(xml).close();
-
-    // merge obj with href
-    var merge = function (href, obj) {
-        for (var j in obj) {
-            if (obj.hasOwnProperty(j)) {
-                href.obj[j] = obj[j];
-            }
-        }
-    };
-
-    // MultiRef support: merge objects instead of replacing
-    for (var n in refs) {
-        var ref = refs[n];
-        for (var i = 0; i < ref.hrefs.length; i++) {
-            merge(ref.hrefs[i], ref.obj);
-        }
-
+      topSchema = message.description(self.definitions);
+      objectName = originalName;
     }
 
-    var body = root.Envelope.Body;
-    if (body.Fault) {
-        var error = new Error(body.Fault.faultcode + ': ' + body.Fault.faultstring + (body.Fault.detail ? ': ' + body.Fault.detail : ''));
-        error.root = root;
-        throw error;
+    if (attrs.href) {
+      id = attrs.href.substr(1);
+      if (!refs[id])
+        refs[id] = {hrefs: [], obj: null};
+      refs[id].hrefs.push({par: top.object, key: name, obj: obj});
     }
-    return root.Envelope;
+    if (id = attrs.id) {
+      if (!refs[id])
+        refs[id] = {hrefs: [], obj: null};
+    }
+
+    //Handle element attributes
+    for (attributeName in attrs) {
+      if (/^xmlns:?/.test(attributeName))continue;
+      hasNonXmlnsAttribute = true;
+      elementAttributes[attributeName] = attrs[attributeName];
+    }
+
+    if (hasNonXmlnsAttribute)obj[self.options.attributesKey] = elementAttributes;
+
+    if (topSchema && topSchema[name + '[]'])
+      name = name + '[]';
+    stack.push({name: originalName, object: obj, schema: topSchema && topSchema[name], id: attrs.id});
+  };
+
+  p.onclosetag = function (nsName) {
+    var cur = stack.pop(),
+      obj = cur.object,
+      top = stack[stack.length - 1],
+      topObject = top.object,
+      topSchema = top.schema,
+      name = splitNSName(nsName).name;
+
+    if (topSchema && topSchema[name + '[]']) {
+      if (!topObject[name])
+        topObject[name] = [];
+      topObject[name].push(obj);
+    }
+    else if (name in topObject) {
+      if (!Array.isArray(topObject[name])) {
+        topObject[name] = [topObject[name]];
+      }
+      topObject[name].push(obj);
+    }
+    else {
+      topObject[name] = obj;
+    }
+
+    if (cur.id) {
+      refs[cur.id].obj = obj;
+    }
+  };
+
+  p.ontext = function (text) {
+    text = trim(text);
+    if (!text.length)
+      return;
+
+    var top = stack[stack.length - 1];
+    var name = splitNSName(top.schema).name,
+      value;
+    if (name === 'int' || name === 'integer') {
+      value = parseInt(text, 10);
+    } else if (name === 'bool' || name === 'boolean') {
+      value = text.toLowerCase() === 'true' || text === '1';
+    } else if (name === 'dateTime' || name === 'date') {
+      value = new Date(text);
+    } else {
+      // handle string or other types
+      if (typeof top.object !== 'string') {
+        value = text;
+      } else {
+        value = top.object + text;
+      }
+    }
+
+    if (top.object[self.options.attributesKey]) {
+      top.object.$value = value;
+    } else {
+      top.object = value;
+    }
+  };
+
+  p.write(xml).close();
+
+  // merge obj with href
+  var merge = function (href, obj) {
+    for (var j in obj) {
+      if (obj.hasOwnProperty(j)) {
+        href.obj[j] = obj[j];
+      }
+    }
+  };
+
+  // MultiRef support: merge objects instead of replacing
+  for (var n in refs) {
+    var ref = refs[n];
+    for (var i = 0; i < ref.hrefs.length; i++) {
+      merge(ref.hrefs[i], ref.obj);
+    }
+
+  }
+
+  var body = root.Envelope.Body;
+  if (body.Fault) {
+    var error = new Error(body.Fault.faultcode + ': ' + body.Fault.faultstring + (body.Fault.detail ? ': ' + body.Fault.detail : ''));
+    error.root = root;
+    throw error;
+  }
+  return root.Envelope;
 };
 
 WSDL.prototype.findParameterObject = function (xmlns, parameterType) {
-    if (!xmlns || !parameterType) {
-        return null;
+  if (!xmlns || !parameterType) {
+    return null;
+  }
+
+  var parameterTypeObj = null;
+
+  if (this.definitions.schemas) {
+    var schema = this.definitions.schemas[xmlns];
+    if (schema) {
+      if (parameterType.indexOf(':') !== -1) {
+        parameterType = parameterType.substring(parameterType.indexOf(':') + 1, parameterType.length);
+      }
+
+      // if the client passed an input element which has a `$lookupType` property instead of `$type`
+      // the `parameterTypeObj` is found in `schema.elements`.
+      parameterTypeObj = schema.complexTypes[parameterType] || schema.elements[parameterType];
     }
+  }
 
-    var parameterTypeObj = null;
-
-    if (this.definitions.schemas) {
-        var schema = this.definitions.schemas[xmlns];
-        if (schema) {
-            if (parameterType.indexOf(':') !== -1) {
-                parameterType = parameterType.substring(parameterType.indexOf(':') + 1, parameterType.length);
-            }
-
-            // if the client passed an input element which has a `$lookupType` property instead of `$type`
-            // the `parameterTypeObj` is found in `schema.elements`.
-            parameterTypeObj = schema.complexTypes[parameterType] || schema.elements[parameterType];
-        }
-    }
-
-    return parameterTypeObj;
+  return parameterTypeObj;
 };
 
 WSDL.prototype.objectToDocumentXML = function (name, params, ns, xmlns, type) {
-    var args = {};
-    args[name] = params;
-    var parameterTypeObj = type ? this.findParameterObject(xmlns, type) : null;
-    if (this.namespaceNumber) {
-        this.namespaceNumber = 0;
-    }
-    return this.objectToXML(args, null, ns, xmlns, true, null, parameterTypeObj);
+  var args = {};
+  args[name] = params;
+  var parameterTypeObj = type ? this.findParameterObject(xmlns, type) : null;
+  if (this.namespaceNumber) {
+    this.namespaceNumber = 0;
+  }
+  return this.objectToXML(args, null, ns, xmlns, true, null, parameterTypeObj);
 };
 
 WSDL.prototype.objectToRpcXML = function (name, params, namespace, xmlns) {
-    var self = this;
-    var parts = [];
-    var defs = this.definitions;
-    var nsAttrName = '_xmlns';
+  var self = this;
+  var parts = [];
+  var defs = this.definitions;
+  var nsAttrName = '_xmlns';
 
-    namespace = namespace || findKey(defs.xmlns, xmlns);
-    xmlns = xmlns || defs.xmlns[namespace];
-    namespace = namespace === 'xmlns' ? '' : (namespace + ':');
-    parts.push(['<', namespace, name, '>'].join(''));
+  namespace = namespace || findKey(defs.xmlns, xmlns);
+  xmlns = xmlns || defs.xmlns[namespace];
+  namespace = namespace === 'xmlns' ? '' : (namespace + ':');
+  parts.push(['<', namespace, name, '>'].join(''));
 
-    for (var key in params) {
-        if (key !== nsAttrName) {
-            var value = params[key];
-            parts.push(['<', key, '>'].join(''));
-            parts.push((typeof value === 'object') ? this.objectToXML(value, key, namespace, xmlns) : xmlEscape(value));
-            parts.push(['</', key, '>'].join(''));
-        }
+  for (var key in params) {
+    if (key !== nsAttrName) {
+      var value = params[key];
+      parts.push(['<', key, '>'].join(''));
+      parts.push((typeof value === 'object') ? this.objectToXML(value, key, namespace, xmlns) : xmlEscape(value));
+      parts.push(['</', key, '>'].join(''));
     }
-    parts.push(['</', namespace, name, '>'].join(''));
+  }
+  parts.push(['</', namespace, name, '>'].join(''));
 
-    return parts.join('');
+  return parts.join('');
 };
 
+/*
+Fix for supporting complex object arguments 
+ */
 WSDL.prototype.objectToXML = function (obj, name, namespace, xmlns, first, xmlnsAttr, parameterTypeObject, ancestorXmlns) {
-    var self = this;
-    var parts = [];
-    var firstDone = false;
+  var self = this;
+  var parts = [];
+  var firstDone = false;
 
-    var xmlnsAttrib = first
-        ? ((namespace !== 'xmlns' ? ' xmlns:' + namespace + '="' + xmlns + '"' : '') + ' xmlns="' + xmlns + '"')
-        : '';
+  var xmlnsAttrib = first
+    ? ((namespace !== 'xmlns' ? ' xmlns:' + namespace + '="' + xmlns + '"' : '') + ' xmlns="' + xmlns + '"')
+    : '';
 
-    var ancXmlns = first ? new Array(xmlns) : ancestorXmlns;
+  var ancXmlns = first ? new Array(xmlns) : ancestorXmlns;
 
-    // explicitly use xmlns attribute if available
-    if (xmlnsAttr) {
-        xmlnsAttrib = xmlnsAttr;
-    } else if (this.options.customNs && !first) {
-        xmlnsAttrib = ' xmlns:' + namespace + '="' + this.options.customNs + '"';
+  // explicitly use xmlns attribute if available
+  if (xmlnsAttr) {
+    xmlnsAttrib = xmlnsAttr;
+  } else if (this.options.customNs && !first) {
+    xmlnsAttrib = ' xmlns:' + namespace + '="' + this.options.customNs + '"';
+  }
+
+  var ns = namespace && namespace !== 'xmlns' ? (namespace.indexOf(":") === -1 ? namespace + ':' : namespace) : '';
+
+  if (Array.isArray(obj)) {
+    for (var i = 0, item; item = obj[i]; i++) {
+      var arrayAttr = self.processAttributes(item);
+      parts.push(['<', ns, name, arrayAttr, xmlnsAttrib, '>'].join(''));
+      parts.push(self.objectToXML(item, name, namespace, xmlns, false, null, null, ancXmlns));
+      parts.push(['</', ns, name, '>'].join(''));
     }
+  } else if (typeof obj === 'object') {
+    for (name in obj) {
+      //don't process attributes as element
+      if (name === 'attributes') {
+        continue;
+      }
 
-    var ns = namespace && namespace !== 'xmlns' ? (namespace.indexOf(":") === -1 ? namespace + ':' : namespace) : '';
-
-    if (Array.isArray(obj)) {
-        for (var i = 0, item; item = obj[i]; i++) {
-            var arrayAttr = self.processAttributes(item);
-            parts.push(['<', ns, name, arrayAttr, xmlnsAttrib, '>'].join(''));
-            parts.push(self.objectToXML(item, name, namespace, xmlns, false, null, null, ancXmlns));
-            parts.push(['</', ns, name, '>'].join(''));
-        }
-    } else if (typeof obj === 'object') {
-        for (name in obj) {
-            //don't process attributes as element
-            if (name === 'attributes') {
-                continue;
-            }
-
-            var child = obj[name];
-            if (child.attributes && child.attributes.xsi_type) {
-                var xsiType = child.attributes.xsi_type;
-
-                // Generate a new namespace for complex extension if one not provided
-                if (!xsiType.namespace) {
-                    if (self.namespaceNumber) {
-                        self.namespaceNumber++;
-                    } else {
-                        self.namespaceNumber = 1;
-                    }
-                    xsiType.namespace = 'ns' + self.namespaceNumber;
-                }
-            }
-
-            var attr = self.processAttributes(child);
-
-            var value = '';
-            if (first) {
-                value = self.objectToXML(child, name, namespace, xmlns, false, null, parameterTypeObject, ancXmlns);
-                firstDone = true;
-            } else {
-
-                if (self.definitions.schemas) {
-                    var schema = this.definitions.schemas[xmlns];
-                    if (schema) {
-
-                        var childParameterTypeObject = self.findChildParameterObject(parameterTypeObject, name);
-                        //find sub namespace if not a primitive
-                        if (childParameterTypeObject && childParameterTypeObject.$type && (childParameterTypeObject.$type.indexOf('xsd') === -1)) {
-                            var childParameterType = childParameterTypeObject.$type;
-
-                            var childNamespace = '';
-                            var childName = '';
-                            if (childParameterType.indexOf(':') !== -1) {
-                                childNamespace = childParameterType.substring(0, childParameterType.indexOf(':'));
-                                childName = childParameterType.substring(childParameterType.indexOf(':') + 1);
-                            }
-                            var childXmlns = schema.xmlns[childNamespace];
-                            var childXmlnsAttrib = ' xmlns:' + childNamespace + '="' + childXmlns + '"';
-                            if (ancXmlns.indexOf(childXmlns) !== -1) {
-                                childXmlnsAttrib = '';
-                            } else {
-                                ancXmlns.push(childXmlns);
-                            }
-
-                            var completeChildParameterTypeObject = self.findChildParameterObjectFromSchema(childName, childXmlns) || childParameterTypeObject;
-                            value = self.objectToXML(child, name, childNamespace, childXmlns, false, childXmlnsAttrib, completeChildParameterTypeObject, ancXmlns);
-                        } else if (obj.attributes && obj.attributes.xsi_type) { //if parent object has complex type defined and child not found in parent
-                            var completeChildParamTypeObject = self.findChildParameterObjectFromSchema(obj.attributes.xsi_type.type, obj.attributes.xsi_type.xmlns);
-
-                            ns = obj.attributes.xsi_type.namespace + ':';
-                            ancXmlns.push(obj.attributes.xsi_type.xmlns);
-                            value = self.objectToXML(child, name, obj.attributes.xsi_type.namespace, obj.attributes.xsi_type.xmlns, false, null, null, ancXmlns);
-                        } else {
-                            value = self.objectToXML(child, name, namespace, xmlns, false, null, null, ancXmlns);
-                        }
-                    } else {
-                        value = self.objectToXML(child, name, namespace, xmlns, false, null, null, ancXmlns);
-                    }
-                }
-            }
-
-            if (!Array.isArray(child)) {
-                parts.push(['<', ns, name, attr, xmlnsAttrib, '>'].join(''));
-            }
-
-            parts.push(value);
-            if (!Array.isArray(child)) {
-                parts.push(['</', ns, name, '>'].join(''));
-            }
-
-            if (this.options.customNs && firstDone) {
-                parts.splice(1, 0, ['<', ns, 'request', '>'].join(''));
-                parts.splice(-1, 0, ['</', ns, 'request', '>'].join(''));
-            }
-        }
-    } else if (obj !== undefined) {
-        parts.push(xmlEscape(obj));
-    }
-    return parts.join('');
-};
-
-WSDL.prototype.processAttributes = function (child) {
-    var self = this;
-    var attr = '';
-
-    if (child[this.options.attributesKey] && child[this.options.attributesKey].xsi_type) {
-        var xsiType = child[this.options.attributesKey].xsi_type;
+      var child = obj[name];
+      if (child.attributes && child.attributes.xsi_type) {
+        var xsiType = child.attributes.xsi_type;
 
         // Generate a new namespace for complex extension if one not provided
         if (!xsiType.namespace) {
-            if (self.namespaceNumber) {
-                self.namespaceNumber++;
-            } else {
-                self.namespaceNumber = 1;
-            }
-            xsiType.namespace = 'ns' + self.namespaceNumber;
+          if (self.namespaceNumber) {
+            self.namespaceNumber++;
+          } else {
+            self.namespaceNumber = 1;
+          }
+          xsiType.namespace = 'ns' + self.namespaceNumber;
         }
-    }
+      }
 
-    if (child[this.options.attributesKey]) {
-        for (var attrKey in child[this.options.attributesKey]) {
-            //handle complex extension separately
-            if (attrKey === 'xsi_type') {
-                var attrValue = child[this.options.attributesKey][attrKey];
-                attr += ' xsi:type="' + attrValue.namespace + ':' + attrValue.type + '"';
-                attr += ' xmlns:' + attrValue.namespace + '="' + attrValue.xmlns + '"';
+      var attr = self.processAttributes(child);
 
-                continue;
+      var value = '';
+      if (first) {
+        value = self.objectToXML(child, name, namespace, xmlns, false, null, parameterTypeObject, ancXmlns);
+        firstDone = true;
+      } else {
+
+        if (self.definitions.schemas) {
+          var schema = this.definitions.schemas[xmlns];
+          if (schema) {
+
+            var childParameterTypeObject = self.findChildParameterObject(parameterTypeObject, name);
+            //find sub namespace if not a primitive
+            if (childParameterTypeObject && childParameterTypeObject.$type && (childParameterTypeObject.$type.indexOf('xsd') === -1)) {
+              var childParameterType = childParameterTypeObject.$type;
+
+              var childNamespace = '';
+              var childName = '';
+              if (childParameterType.indexOf(':') !== -1) {
+                childNamespace = childParameterType.substring(0, childParameterType.indexOf(':'));
+                childName = childParameterType.substring(childParameterType.indexOf(':') + 1);
+              }
+              var childXmlns = schema.xmlns[childNamespace];
+              var childXmlnsAttrib = ' xmlns:' + childNamespace + '="' + childXmlns + '"';
+              if (ancXmlns.indexOf(childXmlns) !== -1) {
+                childXmlnsAttrib = '';
+              } else {
+                ancXmlns.push(childXmlns);
+              }
+
+              var completeChildParameterTypeObject = self.findChildParameterObjectFromSchema(childName, childXmlns) || childParameterTypeObject;
+              value = self.objectToXML(child, name, childNamespace, childXmlns, false, childXmlnsAttrib, completeChildParameterTypeObject, ancXmlns);
+            } else if (obj.attributes && obj.attributes.xsi_type) { //if parent object has complex type defined and child not found in parent
+              var completeChildParamTypeObject = self.findChildParameterObjectFromSchema(obj.attributes.xsi_type.type, obj.attributes.xsi_type.xmlns);
+
+              ns = obj.attributes.xsi_type.namespace + ':';
+              ancXmlns.push(obj.attributes.xsi_type.xmlns);
+              value = self.objectToXML(child, name, obj.attributes.xsi_type.namespace, obj.attributes.xsi_type.xmlns, false, null, null, ancXmlns);
             } else {
-                attr += ' ' + attrKey + '="' + xmlEscape(child[this.options.attributesKey][attrKey]) + '"';
+              value = self.objectToXML(child, name, namespace, xmlns, false, null, null, ancXmlns);
             }
+          } else {
+            value = self.objectToXML(child, name, namespace, xmlns, false, null, null, ancXmlns);
+          }
         }
-    }
+      }
 
-    return attr;
+      if (!Array.isArray(child)) {
+        parts.push(['<', ns, name, attr, xmlnsAttrib, '>'].join(''));
+      }
+
+      parts.push(value);
+      if (!Array.isArray(child)) {
+        parts.push(['</', ns, name, '>'].join(''));
+      }
+
+      if (this.options.customNs && firstDone) {
+        parts.splice(1, 0, ['<', ns, 'request', '>'].join(''));
+        parts.splice(-1, 0, ['</', ns, 'request', '>'].join(''));
+      }
+    }
+  } else if (obj !== undefined) {
+    parts.push(xmlEscape(obj));
+  }
+  return parts.join('');
+};
+
+WSDL.prototype.processAttributes = function (child) {
+  var self = this;
+  var attr = '';
+
+  if (child[this.options.attributesKey] && child[this.options.attributesKey].xsi_type) {
+    var xsiType = child[this.options.attributesKey].xsi_type;
+
+    // Generate a new namespace for complex extension if one not provided
+    if (!xsiType.namespace) {
+      if (self.namespaceNumber) {
+        self.namespaceNumber++;
+      } else {
+        self.namespaceNumber = 1;
+      }
+      xsiType.namespace = 'ns' + self.namespaceNumber;
+    }
+  }
+
+  if (child[this.options.attributesKey]) {
+    for (var attrKey in child[this.options.attributesKey]) {
+      //handle complex extension separately
+      if (attrKey === 'xsi_type') {
+        var attrValue = child[this.options.attributesKey][attrKey];
+        attr += ' xsi:type="' + attrValue.namespace + ':' + attrValue.type + '"';
+        attr += ' xmlns:' + attrValue.namespace + '="' + attrValue.xmlns + '"';
+
+        continue;
+      } else {
+        attr += ' ' + attrKey + '="' + xmlEscape(child[this.options.attributesKey][attrKey]) + '"';
+      }
+    }
+  }
+
+  return attr;
 };
 
 WSDL.prototype.findChildParameterObjectFromSchema = function (name, xmlns) {
-    if (!this.definitions.schemas || !name || !xmlns) {
-        return null;
-    }
+  if (!this.definitions.schemas || !name || !xmlns) {
+    return null;
+  }
 
-    var schema = this.definitions.schemas[xmlns];
-    if (!schema || !schema.complexTypes) {
-        return null;
-    }
+  var schema = this.definitions.schemas[xmlns];
+  if (!schema || !schema.complexTypes) {
+    return null;
+  }
 
-    return schema.complexTypes[name];
+  return schema.complexTypes[name];
 };
 
 WSDL.prototype.findChildParameterObject = function (parameterTypeObj, childName) {
-    if (!parameterTypeObj || !childName) {
-        return null;
+  if (!parameterTypeObj || !childName) {
+    return null;
+  }
+  var found = null,
+    i = 0,
+    child;
+
+  if (parameterTypeObj.$lookupTypes && Array.isArray(parameterTypeObj.$lookupTypes)) {
+    var types = parameterTypeObj.$lookupTypes;
+
+    for (i = 0; i < types.length; i++) {
+      var typeObj = types[i];
+
+      if (typeObj.$name === childName) {
+        found = typeObj;
+        break;
+      }
     }
-    var found = null,
-        i = 0,
-        child;
-
-    if (parameterTypeObj.$lookupTypes && Array.isArray(parameterTypeObj.$lookupTypes)) {
-        var types = parameterTypeObj.$lookupTypes;
-
-        for (i = 0; i < types.length; i++) {
-            var typeObj = types[i];
-
-            if (typeObj.$name === childName) {
-                found = typeObj;
-                break;
-            }
-        }
-    } else {
-        var object = parameterTypeObj;
-        if (object.$name === childName) {
-            return object;
-        }
-
-        if (object.children) {
-            for (i = 0, child; child = object.children[i]; i++) {
-                found = this.findChildParameterObject(child, childName);
-                if (found) {
-                    break;
-                }
-            }
-        }
+  } else {
+    var object = parameterTypeObj;
+    if (object.$name === childName) {
+      return object;
     }
 
-    return found;
+    if (object.children) {
+      for (i = 0, child; child = object.children[i]; i++) {
+        found = this.findChildParameterObject(child, childName);
+        if (found) {
+          break;
+        }
+      }
+    }
+  }
+
+  return found;
 };
 
 WSDL.prototype._parse = function (xml) {
-    var self = this,
-        p = sax.parser(true),
-        stack = [],
-        root = null,
-        ignoredNamespaces = this.ignoredNamespaces;
+  var self = this,
+    p = sax.parser(true),
+    stack = [],
+    root = null,
+    ignoredNamespaces = this.ignoredNamespaces;
 
-    p.onopentag = function (node) {
-        var nsName = node.name;
-        var attrs = node.attributes;
+  p.onopentag = function (node) {
+    var nsName = node.name;
+    var attrs = node.attributes;
 
-        var top = stack[stack.length - 1];
-        var name;
-        if (top) {
-            try {
-                top.startElement(stack, nsName, attrs, ignoredNamespaces);
-            } catch (e) {
-                if (self.options.strict) {
-                    throw e;
-                } else {
-                    stack.push(new Element(nsName, attrs));
-                }
-            }
+    var top = stack[stack.length - 1];
+    var name;
+    if (top) {
+      try {
+        top.startElement(stack, nsName, attrs, ignoredNamespaces);
+      } catch (e) {
+        if (self.options.strict) {
+          throw e;
         } else {
-            name = splitNSName(nsName).name;
-            if (name === 'definitions') {
-                root = new DefinitionsElement(nsName, attrs);
-            } else if (name === 'schema') {
-                root = new SchemaElement(nsName, attrs);
-            } else {
-                throw new Error('Unexpected root element of WSDL or include');
-            }
-            stack.push(root);
+          stack.push(new Element(nsName, attrs));
         }
-    };
+      }
+    } else {
+      name = splitNSName(nsName).name;
+      if (name === 'definitions') {
+        root = new DefinitionsElement(nsName, attrs);
+      } else if (name === 'schema') {
+        root = new SchemaElement(nsName, attrs);
+      } else {
+        throw new Error('Unexpected root element of WSDL or include');
+      }
+      stack.push(root);
+    }
+  };
 
-    p.onclosetag = function (name) {
-        var top = stack[stack.length - 1];
-        assert(top, 'Unmatched close tag: ' + name);
+  p.onclosetag = function (name) {
+    var top = stack[stack.length - 1];
+    assert(top, 'Unmatched close tag: ' + name);
 
-        top.endElement(stack, name);
-    };
+    top.endElement(stack, name);
+  };
 
-    p.write(xml).close();
+  p.write(xml).close();
 
-    return root;
+  return root;
 };
 
 WSDL.prototype._fromXML = function (xml) {
-    this.definitions = this._parse(xml);
-    this.definitions.descriptions = {
-        types: {}
-    };
-    this.xml = xml;
+  this.definitions = this._parse(xml);
+  this.definitions.descriptions = {
+    types: {}
+  };
+  this.xml = xml;
 };
 
 WSDL.prototype._fromServices = function (services) {
@@ -1579,69 +1582,69 @@ WSDL.prototype._fromServices = function (services) {
 
 
 WSDL.prototype._xmlnsMap = function () {
-    var xmlns = this.definitions.xmlns;
-    var str = '';
-    for (var alias in xmlns) {
-        if (alias === '' || alias === 'xmlns')
-            continue;
-        var ns = xmlns[alias];
-        switch (ns) {
-            case "http://xml.apache.org/xml-soap" : // apachesoap
-            case "http://schemas.xmlsoap.org/wsdl/" : // wsdl
-            case "http://schemas.xmlsoap.org/wsdl/soap/" : // wsdlsoap
-            case "http://schemas.xmlsoap.org/soap/encoding/" : // soapenc
-            case "http://www.w3.org/2001/XMLSchema" : // xsd
-                continue;
-        }
-        if (~ns.indexOf('http://schemas.xmlsoap.org/'))
-            continue;
-        if (~ns.indexOf('http://www.w3.org/'))
-            continue;
-        if (~ns.indexOf('http://xml.apache.org/'))
-            continue;
-        str += ' xmlns:' + alias + '="' + ns + '"';
+  var xmlns = this.definitions.xmlns;
+  var str = '';
+  for (var alias in xmlns) {
+    if (alias === '' || alias === 'xmlns')
+      continue;
+    var ns = xmlns[alias];
+    switch (ns) {
+      case "http://xml.apache.org/xml-soap" : // apachesoap
+      case "http://schemas.xmlsoap.org/wsdl/" : // wsdl
+      case "http://schemas.xmlsoap.org/wsdl/soap/" : // wsdlsoap
+      case "http://schemas.xmlsoap.org/soap/encoding/" : // soapenc
+      case "http://www.w3.org/2001/XMLSchema" : // xsd
+        continue;
     }
-    return str;
+    if (~ns.indexOf('http://schemas.xmlsoap.org/'))
+      continue;
+    if (~ns.indexOf('http://www.w3.org/'))
+      continue;
+    if (~ns.indexOf('http://xml.apache.org/'))
+      continue;
+    str += ' xmlns:' + alias + '="' + ns + '"';
+  }
+  return str;
 };
 
 function open_wsdl(uri, options, callback) {
-    if (typeof options === 'function') {
-        callback = options;
-        options = {};
-    }
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
 
-    var request_headers = options.wsdl_headers;
-    var request_options = options.wsdl_options;
+  var request_headers = options.wsdl_headers;
+  var request_options = options.wsdl_options;
 
-    delete options.wsdl_headers;
-    delete options.wsdl_options;
+  delete options.wsdl_headers;
+  delete options.wsdl_options;
 
-    var wsdl;
-    if (!/^http/.test(uri)) {
-        fs.readFile(uri, 'utf8', function (err, definition) {
-            if (err) {
-                callback(err);
-            }
-            else {
-                wsdl = new WSDL(definition, uri, options);
-                wsdl.onReady(callback);
-            }
-        });
-    }
-    else {
-        http.request(uri, null /* options */, function (err, response, definition) {
-            if (err) {
-                callback(err);
-            } else if (response && response.statusCode === 200) {
-                wsdl = new WSDL(definition, uri, options);
-                wsdl.onReady(callback);
-            } else {
-                callback(new Error('Invalid WSDL URL: ' + uri + "\n\n\r Code: " + response.statusCode + "\n\n\r Response Body: " + response.body));
-            }
-        }, request_headers, request_options);
-    }
+  var wsdl;
+  if (!/^http/.test(uri)) {
+    fs.readFile(uri, 'utf8', function (err, definition) {
+      if (err) {
+        callback(err);
+      }
+      else {
+        wsdl = new WSDL(definition, uri, options);
+        wsdl.onReady(callback);
+      }
+    });
+  }
+  else {
+    http.request(uri, null /* options */, function (err, response, definition) {
+      if (err) {
+        callback(err);
+      } else if (response && response.statusCode === 200) {
+        wsdl = new WSDL(definition, uri, options);
+        wsdl.onReady(callback);
+      } else {
+        callback(new Error('Invalid WSDL URL: ' + uri + "\n\n\r Code: " + response.statusCode + "\n\n\r Response Body: " + response.body));
+      }
+    }, request_headers, request_options);
+  }
 
-    return wsdl;
+  return wsdl;
 }
 
 exports.open_wsdl = open_wsdl;

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -14,7 +14,6 @@ var fs = require('fs');
 var url = require('url');
 var path = require('path');
 var assert = require('assert').ok;
-var stripBom = require('strip-bom');
 
 var Primitives = {
   string: 1,
@@ -87,39 +86,23 @@ function findKey(obj, val) {
       return n;
 }
 
-var Element = function(nsName, attrs, options) {
+var Element = function(nsName, attrs, ignoredNamespaces) {
   var parts = splitNSName(nsName);
 
   this.nsName = nsName;
   this.namespace = parts.namespace;
+  this.ignoredNamespaces = ignoredNamespaces;
   this.name = parts.name;
   this.children = [];
   this.xmlns = {};
-
-  this._initializeOptions(options);
-
   for (var key in attrs) {
     var match = /^xmlns:?(.*)$/.exec(key);
     if (match) {
       this.xmlns[match[1] ? match[1] : 'xmlns'] = attrs[key];
     }
     else {
-      if(key === 'value') {
-        this[this.valueKey] = attrs[key];
-      } else {
-        this['$' + key] = attrs[key];
-      }
+      this['$' + key] = attrs[key];
     }
-  }
-};
-
-Element.prototype._initializeOptions = function (options) {
-  if(options) {
-    this.valueKey = options.valueKey || '$value';
-    this.ignoredNamespaces = options.ignoredNamespaces || [];
-  } else {
-    this.valueKey = '$value';
-    this.ignoredNamespaces = [];
   }
 };
 
@@ -133,7 +116,7 @@ Element.prototype.deleteFixedAttrs = function() {
 
 Element.prototype.allowedChildren = [];
 
-Element.prototype.startElement = function(stack, nsName, attrs, options) {
+Element.prototype.startElement = function(stack, nsName, attrs, ignoredNamespaces) {
   if (!this.allowedChildren)
     return;
 
@@ -141,7 +124,7 @@ Element.prototype.startElement = function(stack, nsName, attrs, options) {
     element = null;
 
   if (ChildClass) {
-    stack.push(new ChildClass(nsName, attrs, options));
+    stack.push(new ChildClass(nsName, attrs, ignoredNamespaces));
   }
   else {
     this.unexpected(nsName);
@@ -767,7 +750,7 @@ ExtensionElement.prototype.description = function(definitions, xmlns) {
 };
 
 EnumerationElement.prototype.description = function() {
-  return this[this.valueKey];
+  return this.$value;
 };
 
 ComplexTypeElement.prototype.description = function(definitions, xmlns) {
@@ -939,16 +922,26 @@ ServiceElement.prototype.description = function(definitions) {
 
 var WSDL = function(definition, uri, options) {
   var self = this,
-      fromFunc;
+      fromFunc,
+      ignoredNamespaces;
 
   this.uri = uri;
   this.callback = function() {
   };
+  this.options = options || {};
 
-  this._initializeOptions(options);
+  ignoredNamespaces = this.options.ignoredNamespaces;
+
+  if (ignoredNamespaces &&
+      (Array.isArray(ignoredNamespaces.namespaces) || typeof ignoredNamespaces.namespaces === 'string')) {
+    if (ignoredNamespaces.override) {
+      this.ignoredNamespaces = ignoredNamespaces.namespaces;
+    } else {
+      this.ignoredNamespaces.concat(ignoredNamespaces.namespaces);
+    }
+  }
 
   if (typeof definition === 'string') {
-    definition = stripBom(definition);
     fromFunc = this._fromXML;
   }
   else if (typeof definition === 'object') {
@@ -1015,27 +1008,6 @@ var WSDL = function(definition, uri, options) {
 };
 
 WSDL.prototype.ignoredNamespaces = ['tns', 'targetNamespace', 'typedNamespace'];
-
-WSDL.prototype.valueKey = '$value';
-
-WSDL.prototype._initializeOptions = function (options) {
-  this.options = {};
-
-  var ignoredNamespaces = options ? options.ignoredNamespaces : null;
-
-  if (ignoredNamespaces &&
-      (Array.isArray(ignoredNamespaces.namespaces) || typeof ignoredNamespaces.namespaces === 'string')) {
-    if (ignoredNamespaces.override) {
-      this.options.ignoredNamespaces = ignoredNamespaces.namespaces;
-    } else {
-      this.options.ignoredNamespaces = this.ignoredNamespaces.concat(ignoredNamespaces.namespaces);
-    }
-  } else {
-    this.options.ignoredNamespaces = this.ignoredNamespaces;
-  }
-
-  this.options.valueKey = options.valueKey || this.valueKey;
-};
 
 WSDL.prototype.onReady = function(callback) {
   if (callback)
@@ -1118,7 +1090,6 @@ WSDL.prototype.xmlToObject = function(xml) {
     }
   };
   var stack = [{name: null, object: root, schema: schema}];
-  var xmlns = {};
 
   var refs = {}, id; // {id:{hrefs:[],obj:}, ...}
 
@@ -1132,7 +1103,6 @@ WSDL.prototype.xmlToObject = function(xml) {
       topSchema = top.schema,
       elementAttributes = {},
       hasNonXmlnsAttribute = false,
-      hasNilAttribute = false,
       obj = {};
     var originalName = name;
 
@@ -1185,27 +1155,16 @@ WSDL.prototype.xmlToObject = function(xml) {
 
     //Handle element attributes
     for(attributeName in attrs){
-      if(/^xmlns:|^xmlns$/.test(attributeName)){
-        xmlns[splitNSName(attributeName).name] = attrs[attributeName];
-        continue;
-      }
+      if(/^xmlns:?/.test(attributeName))continue;
       hasNonXmlnsAttribute = true;
       elementAttributes[attributeName] = attrs[attributeName];
-    }
-
-    for(attributeName in elementAttributes){
-      var res = splitNSName(attributeName);
-      if(res.name === 'nil' && xmlns[res.namespace] === 'http://www.w3.org/2001/XMLSchema-instance'){
-        hasNilAttribute = true;
-        break;
-      }
     }
 
     if(hasNonXmlnsAttribute)obj[self.options.attributesKey] = elementAttributes;
 
     if (topSchema && topSchema[name + '[]'])
       name = name + '[]';
-    stack.push({name: originalName, object: obj, schema: topSchema && topSchema[name], id: attrs.id, nil: hasNilAttribute});
+    stack.push({name: originalName, object: obj, schema: topSchema && topSchema[name], id: attrs.id});
   };
 
   p.onclosetag = function(nsName) {
@@ -1215,10 +1174,6 @@ WSDL.prototype.xmlToObject = function(xml) {
       topObject = top.object,
       topSchema = top.schema,
       name = splitNSName(nsName).name;
-
-    if(cur.nil === true) {
-      return;
-    }
 
     if (topSchema && topSchema[name + '[]']) {
       if (!topObject[name])
@@ -1264,7 +1219,7 @@ WSDL.prototype.xmlToObject = function(xml) {
     }
 
     if(top.object[self.options.attributesKey]) {
-      top.object[self.options.valueKey] = value;
+      top.object.$value = value;
     } else {
       top.object = value;
     }
@@ -1356,7 +1311,7 @@ WSDL.prototype.objectToRpcXML = function(name, params, namespace, xmlns) {
   return parts.join('');
 };
 
-WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsAttr, parameterTypeObject, ancestorXmlns) {
+/*WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsAttr, parameterTypeObject, ancestorXmlns) {
   var self = this;
   var schema = this.definitions.schemas[xmlns];
   var qualified = schema && schema.$elementFormDefault === 'qualified';
@@ -1397,7 +1352,7 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsA
         continue;
       }
       //Its the value of an item. Return it directly.
-      if (name === self.options.valueKey) {
+      if (name === '$value') {
         return xmlEscape(obj[name]);
       }
 
@@ -1463,6 +1418,123 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsA
     parts.push(xmlEscape(obj));
   }
   return parts.join('');
+};*/
+
+WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsAttr, parameterTypeObject, ancestorXmlns) {
+    var self = this;
+    var parts = [];
+    var firstDone = false;
+
+    var xmlnsAttrib = first
+        ? ((namespace !== 'xmlns' ? ' xmlns:' + namespace + '="' + xmlns + '"' : '') + ' xmlns="' + xmlns + '"')
+        : '';
+
+    var ancXmlns = first ? new Array(xmlns) : ancestorXmlns;
+
+    // explicitly use xmlns attribute if available
+    if (xmlnsAttr) {
+        xmlnsAttrib = xmlnsAttr;
+    } else if (this.options.customNs && !first) {
+        xmlnsAttrib = ' xmlns:' + namespace + '="' + this.options.customNs + '"';
+    }
+
+    var ns = namespace && namespace !== 'xmlns' ? (namespace.indexOf(":") === -1 ? namespace + ':' : namespace) : '';
+
+    if (Array.isArray(obj)) {
+        for (var i = 0, item; item = obj[i]; i++) {
+            var arrayAttr = self.processAttributes(item);
+            parts.push(['<', ns, name, arrayAttr, xmlnsAttrib, '>'].join(''));
+            parts.push(self.objectToXML(item, name, namespace, xmlns, false, null, null, ancXmlns));
+            parts.push(['</', ns, name, '>'].join(''));
+        }
+    } else if (typeof obj === 'object') {
+        for (name in obj) {
+            //don't process attributes as element
+            if (name === 'attributes') {
+                continue;
+            }
+
+            var child = obj[name];
+            if (child.attributes && child.attributes.xsi_type) {
+                var xsiType = child.attributes.xsi_type;
+
+                // Generate a new namespace for complex extension if one not provided
+                if (!xsiType.namespace) {
+                    if (self.namespaceNumber) {
+                        self.namespaceNumber++;
+                    } else {
+                        self.namespaceNumber = 1;
+                    }
+                    xsiType.namespace = 'ns' + self.namespaceNumber;
+                }
+            }
+
+            var attr = self.processAttributes(child);
+
+            var value = '';
+            if (first) {
+                value = self.objectToXML(child, name, namespace, xmlns, false, null, parameterTypeObject, ancXmlns);
+                firstDone = true;
+            } else {
+
+                if (self.definitions.schemas) {
+                    var schema = this.definitions.schemas[xmlns];
+                    if (schema) {
+
+                        var childParameterTypeObject = self.findChildParameterObject(parameterTypeObject, name);
+                        //find sub namespace if not a primitive
+                        if (childParameterTypeObject && childParameterTypeObject.$type && (childParameterTypeObject.$type.indexOf('xsd') === -1)) {
+                            var childParameterType = childParameterTypeObject.$type;
+
+                            var childNamespace = '';
+                            var childName = '';
+                            if (childParameterType.indexOf(':') !== -1) {
+                                childNamespace = childParameterType.substring(0, childParameterType.indexOf(':'));
+                                childName = childParameterType.substring(childParameterType.indexOf(':') + 1);
+                            }
+                            var childXmlns = schema.xmlns[childNamespace];
+                            var childXmlnsAttrib = ' xmlns:' + childNamespace + '="' + childXmlns+ '"';
+                            if (ancXmlns.indexOf(childXmlns) !== -1) {
+                                childXmlnsAttrib = '';
+                            } else {
+                                ancXmlns.push(childXmlns);
+                            }
+
+                            var completeChildParameterTypeObject = self.findChildParameterObjectFromSchema(childName, childXmlns) || childParameterTypeObject;
+                            value = self.objectToXML(child, name, childNamespace, childXmlns, false, childXmlnsAttrib, completeChildParameterTypeObject, ancXmlns);
+                        } else if (obj.attributes && obj.attributes.xsi_type) { //if parent object has complex type defined and child not found in parent
+                            var completeChildParamTypeObject = self.findChildParameterObjectFromSchema(obj.attributes.xsi_type.type, obj.attributes.xsi_type.xmlns);
+
+                            ns = obj.attributes.xsi_type.namespace + ':';
+                            ancXmlns.push(obj.attributes.xsi_type.xmlns);
+                            value = self.objectToXML(child, name, obj.attributes.xsi_type.namespace, obj.attributes.xsi_type.xmlns, false, null, null, ancXmlns);
+                        } else {
+                            value = self.objectToXML(child, name, namespace, xmlns, false, null, null, ancXmlns);
+                        }
+                    } else {
+                        value = self.objectToXML(child, name, namespace, xmlns, false, null, null, ancXmlns);
+                    }
+                }
+            }
+
+            if (!Array.isArray(child)) {
+                parts.push(['<', ns, name, attr, xmlnsAttrib, '>'].join(''));
+            }
+
+            parts.push(value);
+            if (!Array.isArray(child)) {
+                parts.push(['</', ns, name, '>'].join(''));
+            }
+
+            if (this.options.customNs && firstDone) {
+                parts.splice(1,0, ['<', ns, 'request', '>'].join(''));
+                parts.splice(-1,0, ['</', ns, 'request', '>'].join(''));
+            }
+        }
+    } else if (obj !== undefined) {
+        parts.push(xmlEscape(obj));
+    }
+    return parts.join('');
 };
 
 WSDL.prototype.processAttributes = function(child) {
@@ -1557,7 +1629,7 @@ WSDL.prototype._parse = function(xml) {
     p = sax.parser(true),
     stack = [],
     root = null,
-      options = self.options;
+      ignoredNamespaces = this.ignoredNamespaces;
 
   p.onopentag = function(node) {
     var nsName = node.name;
@@ -1567,20 +1639,20 @@ WSDL.prototype._parse = function(xml) {
     var name;
     if (top) {
       try {
-        top.startElement(stack, nsName, attrs, options);
+        top.startElement(stack, nsName, attrs, ignoredNamespaces);
       } catch (e) {
         if (self.options.strict) {
           throw e;
         } else {
-          stack.push(new Element(nsName, attrs, options));
+          stack.push(new Element(nsName, attrs));
         }
       }
     } else {
       name = splitNSName(nsName).name;
       if (name === 'definitions') {
-        root = new DefinitionsElement(nsName, attrs, options);
+        root = new DefinitionsElement(nsName, attrs);
       } else if (name === 'schema') {
-        root = new SchemaElement(nsName, attrs, options);
+        root = new SchemaElement(nsName, attrs);
       } else {
         throw new Error('Unexpected root element of WSDL or include');
       }


### PR DESCRIPTION
Added custom namespace to options on createClient. Borrowed
implementation from https://github.com/evgeniyarbatov/node-soap.
changed one function.

Addresses this issue.  https://github.com/vpulim/node-soap/issues/334, Attempted to use their latest but failed tests.

Can test with this.
 ```
var soap = require('soap');
var url = 'http://nodewcf.azurewebsites.net/Service1.svc?singleWsdl';

var getData = {};
getData.MyValue = "35";

var opt = { customNs: 'http://schemas.datacontract.org/2004/07/NodeSVC' };

soap.createClient (url, opt, function(err, client) {

    client.Service1.BasicHttpBinding_IService1.GetData2(getData, function (err, result) {
        if (err !== null)
            console.log(err);

        console.log(result);

        console.log('### SOAP MESSAGE ###');
        console.log(client.lastRequest);
    })
});
```