### PR TITLE
Don't append port to Host header if not required

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -115,6 +115,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
     encoding = '',
     message = '',
     xml = null,
+    req = null,
     soapAction = this.SOAPAction ? this.SOAPAction(ns, name) : (method.soapAction || (((ns.lastIndexOf("/") !== ns.length - 1) ? ns + "/" : ns) + name)),
     headers = {
       SOAPAction: '"' + soapAction + '"',
@@ -161,12 +162,12 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
   self.lastMessage = message;
   self.lastRequest = xml;
 
-  http.request(location, xml, function(err, response, body) {
+  req = http.request(location, xml, function(err, response, body) {
     var result;
     var obj;
     self.lastResponse = body;
     self.lastResponseHeaders = response && response.headers;
-    
+
     if (err) {
       callback(err);
     } else if (response.statusCode !== 200) {
@@ -198,6 +199,9 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
       callback(null, result, body);
     }
   }, headers, options);
+
+  // Added mostly for testability, but possibly useful for debugging
+  self.lastRequestHeaders = req.headers;
 };
 
 exports.Client = Client;

--- a/lib/http.js
+++ b/lib/http.js
@@ -61,4 +61,6 @@ exports.request = function(rurl, data, callback, exheaders, exoptions) {
     }
   });
   request.end(data);
+
+  return request;
 };


### PR DESCRIPTION
This is possibly a an issue relating more to misconfiguration of remote servers, however a couple of SOAP servers I wish to use don't correctly respond with WSDL if the port is appended to the `Host` header in the http request. This is what `node-soap@0.5.0` does currently where previous versions did not.

Since this is optional for HTTP requests, this PR changes the current behaviour by not appending `:80` to the `Host` header. 

If this is not a desirable solution, possibly an option could be added to account for this behaviour?
