### PR TITLE
More elementFormQualified enhancements

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1363,12 +1363,12 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsA
   var parts = [];
 
   var xmlnsAttrib = '';
-  if (xmlns && first) {
+  if (xmlns && first && !self.xmlnsInEnvelope.indexOf(xmlns)) {
     if (namespace && namespace !== 'xmlns') {
       xmlnsAttrib += ' xmlns:' + namespace + '="' + xmlns + '"';
+    } else {
+      xmlnsAttrib += ' xmlns="' + xmlns + '"';
     }
-
-    xmlnsAttrib += ' xmlns="' + xmlns + '"';
   }
 
   var ancXmlns = first ? new Array(xmlns) : ancestorXmlns;
@@ -1379,7 +1379,7 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsA
   }
 
   var ns = '';
-  if (namespace && namespace !== 'xmlns' && qualified) {
+  if (namespace && namespace !== 'xmlns' && (qualified || first)) {
     ns = namespace.indexOf(":") === -1 ? namespace + ':' : namespace;
   }
 


### PR DESCRIPTION
1. The qualified elementFormQualified must be respected only when the current element is not a global element. 
2. The namespace attribute is only needed if it's not included in the xmlnsInEnvelope collection.
