### PR TITLE
Fixing XSD conflict on imports with same namespace

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -15,6 +15,7 @@ var url = require('url');
 var path = require('path');
 var assert = require('assert').ok;
 var stripBom = require('strip-bom');
+var _ = require('lodash');
 
 var Primitives = {
   string: 1,
@@ -79,6 +80,12 @@ function extend(base, obj) {
     }
   }
   return base;
+}
+
+function deepMerge(destination, source) {
+  return _.merge(destination || {}, source, function(a, b) {
+      return _.isArray(a) ? a.concat(b) : undefined;
+    });
 }
 
 function findKey(obj, val) {
@@ -821,6 +828,10 @@ ElementElement.prototype.description = function(definitions, xmlns) {
       schema = definitions.schemas[ns],
       typeElement = schema && ( schema.complexTypes[typeName] || schema.types[typeName] || schema.elements[typeName] );
 
+    if(ns && definitions.schemas[ns]) {
+      xmlns = definitions.schemas[ns].xmlns;
+    }
+
     if (typeElement && !(typeName in Primitives)) {
 
       if (!(typeName in definitions.descriptions.types)) {
@@ -1061,7 +1072,7 @@ WSDL.prototype._processNextInclude = function(includes, callback) {
       return callback(err);
     }
 
-    self.definitions.schemas[include.namespace || wsdl.definitions.$targetNamespace] = wsdl.definitions;
+    self.definitions.schemas[include.namespace || wsdl.definitions.$targetNamespace] = deepMerge(self.definitions.schemas[include.namespace || wsdl.definitions.$targetNamespace], wsdl.definitions);
     self._processNextInclude(includes, function(err) {
       callback(err);
     });

--- a/test/wsdl/ExtendedName.xsd
+++ b/test/wsdl/ExtendedName.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:c="http://www.Dummy.com/Common/Types" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.Dummy.com/Name/Types" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:import namespace="http://www.Dummy.com/Common/Types" schemaLocation="Common.xsd"/>
+	<xs:element name="ExtendedDummyRequest">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="DummyField1" type="xs:string" minOccurs="0"/>
+				<xs:element name="DummyField2" type="xs:string" minOccurs="0"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/test/wsdl/include_with_duplicated_namespace.wsdl
+++ b/test/wsdl/include_with_duplicated_namespace.wsdl
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+xmlns:xs="http://www.w3.org/2001/XMLSchema"
+xmlns:tns="http://www.Dummy.com"  xmlns:n="http://www.Dummy.com/Name/Types"  xmlns:ns="http://schemas.xmlsoap.org/soap/encoding/" targetNamespace="http://www.Dummy.com">
+  <wsdl:types>
+    <xs:schema>
+      <xs:import namespace="http://www.Dummy.com/Common/Types" schemaLocation="./Common.xsd"/>
+      <xs:import namespace="http://www.Dummy.com/Name/Types" schemaLocation="./Name.xsd"/>
+      <xs:import namespace="http://www.Dummy.com/Name/Types" schemaLocation="./ExtendedName.xsd"/>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="DummyRequest">
+    <wsdl:part name="DummyRequest" element="n:ExtendedDummyRequest"/>
+  </wsdl:message>
+  <wsdl:message name="DummyResponse">
+    <wsdl:part name="DummyResponse" element="n:DummyResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="DummyPortType">
+    <wsdl:operation name="Dummy">
+      <wsdl:input message="tns:DummyRequest"/>
+      <wsdl:output message="tns:DummyResponse"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="DummyBinding" type="tns:DummyPortType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="Dummy">
+      <soap:operation soapAction="http://www.Dummy.com#Dummy" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="DummySave">
+      <soap:operation soapAction="http://www.Dummy.com#DummySave" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="DummyService">
+    <wsdl:port name="DummyPortType" binding="tns:DummyBinding">
+      <soap:address location="http://www.Dummy.com/"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
When a WSDL imports more than one XSD file with the same namespace, the last imported XSD is overwriting the definitions brought by first ones. The solution I found is to deep-merge (using a lodash function) the definitions instead of overwriting it.

To ensure nothing else was broken by this change, I created a test case (see test/wsdl/include_with_duplicated_namespace.wsdl file).

Hope this pull request get merged =)
