### PR TITLE
Add Support for HTTP Authentication type Bearer

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -164,6 +164,12 @@ as default request options to the constructor:
   client.setSecurity(new soap.WSSecurity('username', 'password'))
 ```
 
+####BearerSecurity
+
+``` javascript
+  client.setSecurity(new soap.BearerSecurity('token'));
+```
+
 ### Client.*method*(args, callback) - call *method* on the SOAP service.
 
 ``` javascript
@@ -286,13 +292,13 @@ If an Element in a `schema` definition depends on an Element which is present in
 namespace prefix is used to identify this Element. This is not much of a problem as long as you have just one `schema` defined
 (inline or in a separate file). If there are more `schema` files, the `tns:` in the generated `soap` file resolved mostly to the parent `wsdl` file,
  which was obviously wrong.
- 
+
  `node-soap` now handles namespace prefixes which shouldn't be resolved (because it's not necessary) as so called `ignoredNamespaces`
  which default to an Array of 3 Strings (`['tns', 'targetNamespace', 'typedNamespace']`).
- 
+
  If this is not sufficient for your purpose you can easily add more namespace prefixes to this Array, or override it in its entirety
  by passing an `ignoredNamespaces` object within the `options` you pass in `soap.createClient()` method.
-  
+
  A simple `ignoredNamespaces` object, which only adds certain namespaces could look like this:
  ```
  var options = {
@@ -302,7 +308,7 @@ namespace prefix is used to identify this Element. This is not much of a problem
  }
  ```
  This would extend the `ignoredNamespaces` of the `WSDL` processor to `['tns', 'targetNamespace', 'typedNamespace', 'namespaceToIgnore', 'someOtherNamespace']`.
- 
+
  If you want to override the default ignored namespaces you would simply pass the following `ignoredNamespaces` object within the `options`:
  ```
  var options = {

--- a/lib/security/BearerSecurity.js
+++ b/lib/security/BearerSecurity.js
@@ -1,0 +1,23 @@
+"use strict";
+
+var _ = require('lodash');
+
+function BearerSecurity(token, defaults) {
+	this._token = token;
+	this.defaults = {};
+	_.merge(this.defaults, defaults);
+}
+
+BearerSecurity.prototype.addHeaders = function(headers) {
+	headers.Authorization = "Bearer " + this._token;
+};
+
+BearerSecurity.prototype.toXML = function() {
+	return '';
+};
+
+BearerSecurity.prototype.addOptions = function(options) {
+  _.merge(options, this.defaults);
+};
+
+module.exports = BearerSecurity;

--- a/lib/security/index.js
+++ b/lib/security/index.js
@@ -4,4 +4,5 @@ module.exports = {
   BasicAuthSecurity: require('./BasicAuthSecurity')
 , ClientSSLSecurity: require('./ClientSSLSecurity')
 , WSSecurity: require('./WSSecurity')
+, BearerSecurity: require('./BearerSecurity')
 };

--- a/lib/soap.js
+++ b/lib/soap.js
@@ -69,6 +69,7 @@ exports.security = security;
 exports.BasicAuthSecurity = security.BasicAuthSecurity;
 exports.WSSecurity = security.WSSecurity;
 exports.ClientSSLSecurity = security.ClientSSLSecurity;
+exports.BearerSecurity = security.BearerSecurity;
 exports.createClient = createClient;
 exports.passwordDigest = passwordDigest;
 exports.listen = listen;

--- a/test/security/BearerSecurity.js
+++ b/test/security/BearerSecurity.js
@@ -1,0 +1,24 @@
+'use strict';
+
+describe('BearerSecurity', function() {
+  var BearerSecurity = require('../../').BearerSecurity;
+  var token = "token";
+
+  it('is a function', function() {
+    BearerSecurity.should.be.type('function');
+  });
+
+  describe('defaultOption param', function() {
+    it('is accepted as the second param', function() {
+      new BearerSecurity(token, {});
+    });
+
+    it('is used in addOptions', function() {
+      var options = {};
+      var defaultOptions = { foo: 2 };
+      var instance = new BearerSecurity(token, defaultOptions);
+      instance.addOptions(options);
+      options.should.have.property("foo", 2);
+    });
+  });
+});


### PR DESCRIPTION
There are a number of web services that require authentication using a Bearer token in the OAuth2 format. This adds a security type to support interfacing with these services.
