### PR TITLE
Fixing fault handling

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -170,8 +170,6 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
 
     if (err) {
       callback(err);
-    } else if (response.statusCode !== 200) {
-      callback(new Error('Invalid response: ' + response.statusCode + '\nBody: ' + body));
     } else {
       try {
         obj = self.wsdl.xmlToObject(body);

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -262,7 +262,8 @@ describe('SOAP Client', function() {
       soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', function (err, client) {
         client.MyOperation({}, function(err, result) {
           assert.ok(err);
-          assert.ok(err.message.indexOf('Invalid response: 401') === 0);
+          assert.ok(err.response);
+          assert.ok(err.body);
           done();
         });
       }, baseUrl);


### PR DESCRIPTION
Sometimes, the SOAP endpoint responds a Fault body with HTTP status not equal to 200 (500 for example). This way, the node-soap library was unable to parse the body, replying an string thats not very useful to the client code. This PR fixes the fault handling, always replying the parsed body.
