### PR TITLE
Fixed an issue with port being added to Host.

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -23,7 +23,7 @@ exports.request = function(rurl, data, callback, exheaders, exoptions) {
     "Accept-Encoding": "none",
     "Accept-Charset": "utf-8",
     "Connection": "close",
-    "Host" : host + (port ? ":"+port : "")
+    "Host" : host + (curl.port ? ":"+port : "")
   };
   var attr;
 


### PR DESCRIPTION
When using the http module to make a request to a url without a port,
port 80 or 443 would always be added to the Host. This doesn't play nice
with some server setups. Changed this, so that if no port is specified,
none is added to the Host header either.

Check the code in lib/http.js: The 'port' variable is always set, so the ternary operator construct is useless. This commit fixes this.

The fix doesn't affect any of the tests.
