### PR TITLE
Removes automatic port appending to "Host" header.

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -14,7 +14,7 @@ exports.request = function(rurl, data, callback, exheaders, exoptions) {
   var curl = url.parse(rurl);
   var secure = curl.protocol === 'https:';
   var host = curl.hostname;
-  var port = parseInt(curl.port || (secure ? 443 : false));
+  var port = parseInt(curl.port, 10);
   var path = [curl.pathname || '/', curl.search || '', curl.hash || ''].join('');
   var method = data ? "POST" : "GET";
   var headers = {
@@ -23,7 +23,7 @@ exports.request = function(rurl, data, callback, exheaders, exoptions) {
     "Accept-Encoding": "none",
     "Accept-Charset": "utf-8",
     "Connection": "close",
-    "Host" : host + (port ? ":"+port : "")
+    "Host": host + (isNaN(port) ? "" : ":" + port)
   };
   var attr;
 

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -101,6 +101,30 @@ describe('SOAP Client', function() {
       }, 'http://127.0.0.1');
     });
 
+    it('should not append `:443` to the Host header if endpoints runs on `https`', function (done) {
+      soap.createClient(__dirname+'/wsdl/default_namespace.wsdl', function(err, client) {
+        assert.ok(client);
+        assert.ok(!err);
+
+        client.MyOperation({}, function() {
+          assert.equal(client.lastRequestHeaders.Host.indexOf(':443'), -1);
+          done();
+        }, null, {"test-header": 'test'});
+      }, 'https://127.0.0.1');
+    });
+
+    it('should append a port to the Host header if explicitly defined', function (done) {
+      soap.createClient(__dirname+'/wsdl/default_namespace.wsdl', function(err, client) {
+        assert.ok(client);
+        assert.ok(!err);
+
+        client.MyOperation({}, function() {
+          assert.ok(client.lastRequestHeaders.Host.indexOf(':443') > -1);
+          done();
+        }, null, {"test-header": 'test'});
+      }, 'https://127.0.0.1:443');
+    });
+
     it('should have the correct extra header in the request', function(done) {
       soap.createClient(__dirname+'/wsdl/default_namespace.wsdl', function(err, client) {
         assert.ok(client);


### PR DESCRIPTION
Previously, a `port` (443) was appended automatically to the "Host" header if the given `endpoint` URL is a secure URL (starts with "https://"). With this Pull Request a port is only appended if it is also present in the `endpoint` URL.
