### PR TITLE
Adding XMLSchema to the xmlns for the soapenvelope

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -150,6 +150,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
   xml = "<soap:Envelope " +
     "xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" " +
     "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+    "xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" " +
     encoding +
     this.wsdl.xmlnsInEnvelope + '>' +
     ((self.soapHeaders || self.security) ?


### PR DESCRIPTION
Hi I was using node-soap to consume some web service using the namespace 'xsd'
but executing queries the server was responding that it doesn't recognize that namespace,
so I just needed to add the following line in the soapenvelope in lib/client.js

I don't know it is possible include it dynamically, anyway it is just a hardcoded line:
 "xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" " +

And here is the wsdl:
https://www.integracionesqapx.com.mx/wsuniversaldummy/pxuniversal.asmx?WSDL

Thanks