### PR TITLE
added enhancement for new wsdl option useJsonNamespace

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1028,7 +1028,7 @@ var WSDL = function(definition, uri, options) {
 };
 
 WSDL.prototype.ignoredNamespaces = ['tns', 'targetNamespace', 'typedNamespace'];
-
+WSDL.prototype.useJsonNamespace = false;
 WSDL.prototype.valueKey = '$value';
 
 WSDL.prototype._initializeOptions = function (options) {
@@ -1046,7 +1046,7 @@ WSDL.prototype._initializeOptions = function (options) {
   } else {
     this.options.ignoredNamespaces = this.ignoredNamespaces;
   }
-
+  this.options.useJsonNamespace = options.useJsonNamespace || this.useJsonNamespace;
   this.options.valueKey = options.valueKey || this.valueKey;
 };
 
@@ -1398,8 +1398,8 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsA
 
   var ns = '';
   if (prefixNamespace && ((qualified || first) || soapHeader)) {
-    // prefix element
-    ns = namespace.indexOf(":") === -1 ? namespace + ':' : namespace;
+    // prefix element.  if useJsonNamespace is set to true, set ns to a blank string to use the hard coded prefix in the json.
+    ns = (self.options.useJsonNamespace && name) ? '' : namespace.indexOf(":") === -1 ? namespace + ':' : namespace;
   }
 
   if (Array.isArray(obj)) {


### PR DESCRIPTION
by setting the option of useJsonNamespace: true for options passed in to
createClient the wsdl function objectToXml will not add a namespace to
the xml elements.  this way you can hard code the namespace into your
json.  if you don't set useJsonNamespace, it will default to false and
run as normal.