### PR TITLE
Ignore default namespace declarations

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1039,6 +1039,7 @@ var WSDL = function(definition, uri, options) {
 };
 
 WSDL.prototype.ignoredNamespaces = ['tns', 'targetNamespace', 'typedNamespace'];
+WSDL.prototype._ignoredSchemaNamespaces = ['tns', 'xs', 'xsd'];
 
 WSDL.prototype.valueKey = '$value';
 WSDL.prototype.xmlKey = '$xml';
@@ -1113,6 +1114,37 @@ WSDL.prototype.describeServices = function() {
     services[name] = service.description(this.definitions);
   }
   return services;
+};
+
+/**
+ * Returns true if a schema namespace needs to be ignored.
+ * 
+ * @method shouldIgnoreNamespace
+ * @param {Object} schema   The parsed WSDL Schema object.
+ */
+WSDL.prototype.shouldIgnoreNamespace = function(schema) {
+  if (schema && typeof schema.xmlns === 'object') {
+    // get the keys from schema.xmlns object (something like xs, xsd or custom)
+    var schemaXmlns = Object.keys(schema.xmlns);
+    var schemaXmlnsLength = schemaXmlns.length;
+    if (schemaXmlnsLength > 0) {
+      var count = 0;
+      // loop through the keys
+      for (var key in schemaXmlns) {
+        var xmlns = schemaXmlns[key];
+        // if the key exists in the default ignoredSchemaNamespaces, add it to the count
+        if (this._ignoredSchemaNamespaces.indexOf(xmlns) > -1) {
+          count++;
+        }
+      }
+      // if the count is equal to the length, don't add the namespace
+      if(count === schemaXmlnsLength) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 };
 
 WSDL.prototype.toXML = function() {
@@ -1390,11 +1422,12 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsA
   var qualified = schema && schema.$elementFormDefault === 'qualified';
   var parts = [];
   var prefixNamespace = (namespace || qualified) && namespace !== 'xmlns';
+  var isNamespaceIgnored = this.shouldIgnoreNamespace(schema);
 
   var xmlnsAttrib = '';
   if (xmlns && first) {
 
-    if (prefixNamespace) {
+    if (prefixNamespace && (!isNamespaceIgnored || this.ignoredNamespaces.indexOf(namespace) === -1)) {
       // resolve the prefix namespace
       xmlnsAttrib += ' xmlns:' + namespace + '="' + xmlns + '"';
     }
@@ -1410,7 +1443,7 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsA
   }
 
   var ns = '';
-  if (prefixNamespace && ((qualified || first) || soapHeader)) {
+  if (prefixNamespace && ((qualified || first) || soapHeader) && (!isNamespaceIgnored || this.ignoredNamespaces.indexOf(namespace) === -1)) {
     // prefix element
     ns = namespace.indexOf(":") === -1 ? namespace + ':' : namespace;
   }

--- a/test/request-response-samples/GetItemInformation__should_ignore_default_namespace_from_schema/request.json
+++ b/test/request-response-samples/GetItemInformation__should_ignore_default_namespace_from_schema/request.json
@@ -1,0 +1,10 @@
+{
+	"Items": {
+		"Item": [{
+			"ItemNumber": "1234",
+			"RequestedQuantity": {
+				"Value": "1.00"
+			}
+		}]
+	}
+}

--- a/test/request-response-samples/GetItemInformation__should_ignore_default_namespace_from_schema/request.xml
+++ b/test/request-response-samples/GetItemInformation__should_ignore_default_namespace_from_schema/request.xml
@@ -1,0 +1,1 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns:tns="SAMPLE"><soap:Body><GetItemInformation xmlns="SAMPLE"><Items><Item><ItemNumber>1234</ItemNumber><RequestedQuantity><Value>1.00</Value></RequestedQuantity></Item></Items></GetItemInformation></soap:Body></soap:Envelope>

--- a/test/request-response-samples/GetItemInformation__should_ignore_default_namespace_from_schema/response.json
+++ b/test/request-response-samples/GetItemInformation__should_ignore_default_namespace_from_schema/response.json
@@ -1,0 +1,10 @@
+{
+	"Items": {
+		"Item": {
+			"ItemNumber": "1234",
+			"RequestedQuantity": {
+				"Value": "1.00"
+			}
+		}
+	}
+}

--- a/test/request-response-samples/GetItemInformation__should_ignore_default_namespace_from_schema/response.xml
+++ b/test/request-response-samples/GetItemInformation__should_ignore_default_namespace_from_schema/response.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:tns="SAMPLE">
+    <soap:Body>
+        <GetItemInformationResponse xmlns="SAMPLE">
+            <Items>
+                <Item>
+                    <ItemNumber>1234</ItemNumber>
+                    <RequestedQuantity>
+                        <Value>1.00</Value>
+                    </RequestedQuantity>
+                </Item>
+            </Items>
+        </GetItemInformationResponse>
+    </soap:Body>
+</soap:Envelope>

--- a/test/request-response-samples/GetItemInformation__should_ignore_default_namespace_from_schema/soap.wsdl
+++ b/test/request-response-samples/GetItemInformation__should_ignore_default_namespace_from_schema/soap.wsdl
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions 
+  xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" 
+  xmlns:wsa10="http://www.w3.org/2005/08/addressing" 
+  xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" 
+  xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" 
+  xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" 
+  xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" 
+  xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" 
+  xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" 
+  xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" 
+  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" 
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+  xmlns:tns="SAMPLE"
+  name="SampleService" 
+  targetNamespace="SAMPLE" >
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="SAMPLE" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:element name="GetItemInformation">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="1" name="Items" type="tns:ArrayOfItem" />
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:complexType name="ArrayOfItem">
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" name="Item" nillable="true" type="tns:Item" />
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="Item">
+        <xs:complexContent mixed="false">
+          <xs:extension base="tns:ItemBase">
+            <xs:sequence>
+              <xs:element minOccurs="0" maxOccurs="1" name="AvailState" type="tns:AvailableState" />
+              <xs:element minOccurs="0" maxOccurs="1" name="Warehouses" type="tns:ArrayOfWarehouse" />
+            </xs:sequence>
+          </xs:extension>
+        </xs:complexContent>
+      </xs:complexType>
+      <xs:complexType name="ItemBase">
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="1" name="ItemNumber" type="xs:string" />
+          <xs:element minOccurs="1" maxOccurs="1" name="SupplierId" type="xs:short" />
+          <xs:element minOccurs="0" maxOccurs="1" name="SupplierName" type="xs:string" />
+          <xs:element minOccurs="0" maxOccurs="1" name="RequestedQuantity" type="tns:Quantity" />
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="Quantity">
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="1" name="Id" type="xs:string" />
+          <xs:element minOccurs="0" maxOccurs="1" name="Description" type="xs:string" />
+          <xs:element minOccurs="0" maxOccurs="1" name="AvailState" type="tns:AvailableState" />
+          <xs:element minOccurs="1" maxOccurs="1" name="Value" type="xs:decimal" />
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="AvailableState">
+        <xs:sequence>
+          <xs:element minOccurs="1" maxOccurs="1" name="AvailState" type="xs:int" />
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="ArrayOfWarehouse">
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" name="Warehouse" nillable="true" type="tns:Warehouse" />
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="Warehouse">
+        <xs:sequence>
+          <xs:element minOccurs="1" maxOccurs="1" name="Default" type="xs:boolean" />
+          <xs:element minOccurs="0" maxOccurs="1" name="Id" type="xs:string" />
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="ArrayOfQuantity">
+        <xs:sequence>
+          <xs:element minOccurs="0" maxOccurs="unbounded" name="Quantity" nillable="true" type="tns:Quantity" />
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="GetItemInformationResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="1" name="GetItemInformationResult" type="tns:GetBackItems" />
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:complexType name="GetBackItems">
+        <xs:complexContent mixed="false">
+          <xs:extension base="tns:BaseGetBack">
+            <xs:sequence>
+              <xs:element minOccurs="0" maxOccurs="1" name="Items" type="tns:ArrayOfItem" />
+            </xs:sequence>
+          </xs:extension>
+        </xs:complexContent>
+      </xs:complexType>
+      <xs:complexType name="BaseGetBack">
+        <xs:sequence>
+          <xs:element minOccurs="1" maxOccurs="1" name="ErrorCode" type="xs:int" />
+          <xs:element minOccurs="0" maxOccurs="1" name="ErrorMessage" type="xs:string" />
+        </xs:sequence>
+      </xs:complexType>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="ISampleService_GetItemInformation_InputMessage">
+    <wsdl:part name="parameters" element="tns:GetItemInformation" />
+  </wsdl:message>
+  <wsdl:message name="ISampleService_GetItemInformation_OutputMessage">
+    <wsdl:part name="parameters" element="tns:GetItemInformationResponse" />
+  </wsdl:message>
+  <wsdl:portType name="ISampleService">
+    <wsdl:operation name="GetItemInformation">
+      <wsdl:input wsaw:Action="SAMPLE/ISampleService/GetItemInformation" message="tns:ISampleService_GetItemInformation_InputMessage" />
+      <wsdl:output wsaw:Action="SAMPLE/ISampleService/GetItemInformationResponse" message="tns:ISampleService_GetItemInformation_OutputMessage" />
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="BasicHttpBinding_ISampleService" type="tns:ISampleService">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" />
+    <wsdl:operation name="GetItemInformation">
+      <soap:operation soapAction="SAMPLE/ISampleService/GetItemInformation" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="SampleService">
+    <wsdl:port name="BasicHttpBinding_SampleService" binding="tns:BasicHttpBinding_ISampleService">
+      <soap:address location="http://example.com/v1/" />
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
I've added a function that can ignore default namespace declarations in the first element within the body element (issue #470) xmlns:tns="SAMPLE". And removed unnecessary tns: declarations in all elements when not needed.

Also build a test which checks the functionality.
