### PR TITLE
Allow wsdl:documentation element under wsdl:message

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -543,6 +543,10 @@ MessageElement.prototype.postProcess = function(definitions) {
     this.parts = {};
     delete this.element;
     for (i = 0; part = this.children[i]; i++) {
+      if (part.name === 'documentation') {
+        // <wsdl:documentation can be present under <wsdl:message>
+        continue;
+      }
       assert(part.name === 'part', 'Expected part element');
       nsName = splitNSName(part.$type);
       ns = definitions.xmlns[nsName.namespace];

--- a/test/wsdl/rpcexample.wsdl
+++ b/test/wsdl/rpcexample.wsdl
@@ -120,6 +120,7 @@
 		</schema>
 	</types>
 	<message name="pullFileRequest">
+        <documentation>This is doc</documentation>
 		<part name="params" type="RpcExample:pullFileParams"/>
 	</message>
 	<message name="pullFileResponse">


### PR DESCRIPTION
It will fix https://github.com/vpulim/node-soap/issues/507
