### PR TITLE
Add support for importing external wsdl

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1093,8 +1093,11 @@ WSDL.prototype._processNextInclude = function(includes, callback) {
     if (err) {
       return callback(err);
     }
-
-    self.definitions.schemas[include.namespace || wsdl.definitions.$targetNamespace] = deepMerge(self.definitions.schemas[include.namespace || wsdl.definitions.$targetNamespace], wsdl.definitions);
+    if(wsdl.definitions instanceof DefinitionsElement){
+      _.merge(self.definitions, wsdl.definitions);
+    }else{
+      self.definitions.schemas[include.namespace || wsdl.definitions.$targetNamespace] = deepMerge(self.definitions.schemas[include.namespace || wsdl.definitions.$targetNamespace], wsdl.definitions);
+    }
     self._processNextInclude(includes, function(err) {
       callback(err);
     });

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -44,8 +44,16 @@ wsdlNonStrictTests['should catch parse error'] = function(done) {
 };
 
 wsdlStrictTests['should catch parse error'] = function(done) {
-  soap.createClient(__dirname+'/wsdl/bad.txt', function(err) {
+  soap.createClient(__dirname+'/wsdl/bad.txt', {strict: true}, function(err) {
     assert.notEqual(err, null);
+    done();
+  });
+};
+
+wsdlStrictTests['should parse external wsdl'] = function(done) {
+  soap.createClient(__dirname+'/wsdl/wsdlImport/main.wsdl', {strict: true}, function(err, client){
+    assert.ok(!err);
+    assert.equal(typeof client.getLatestVersion, 'function');
     done();
   });
 };

--- a/test/wsdl/wsdlImport/main.wsdl
+++ b/test/wsdl/wsdlImport/main.wsdl
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions name="UserRemoteServiceImplService" targetNamespace="http://base.example.com" xmlns:ns1="http://example.com/" xmlns:ns2="http://cxf.apache.org/bindings/xformat" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://base.example.com" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:import location="sub.wsdl" namespace="http://example.com/">
+    </wsdl:import>
+  <wsdl:binding name="UserRemoteServiceImplServiceSoapBinding" type="ns1:IUserRemoteService">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+    <wsdl:operation name="getLatestVersion">
+      <soap:operation soapAction="" style="document" />
+      <wsdl:input name="getLatestVersion">
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output name="getLatestVersionResponse">
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    
+  </wsdl:binding>
+  <wsdl:service name="UserRemoteServiceImplService">
+    <wsdl:port binding="tns:UserRemoteServiceImplServiceSoapBinding" name="UserRemoteServiceImplPort">
+      <soap:address location="http://example.com/ws/UserRemoteService" />
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/test/wsdl/wsdlImport/sub.wsdl
+++ b/test/wsdl/wsdlImport/sub.wsdl
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions name="IUserRemoteService" targetNamespace="http://example.com/" xmlns:ns1="http://example.com/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+<xs:schema elementFormDefault="unqualified" targetNamespace="http://example.com/" version="1.0" xmlns:tns="http://example.com/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+<xs:element name="getLatestVersion" type="tns:getLatestVersion" />
+<xs:element name="getLatestVersionResponse" type="tns:getLatestVersionResponse" />
+
+<xs:complexType name="getLatestVersion">
+<xs:sequence />
+</xs:complexType>
+<xs:complexType name="getLatestVersionResponse">
+<xs:sequence>
+<xs:element minOccurs="0" name="return" type="xs:long" />
+</xs:sequence>
+</xs:complexType>
+
+</xs:schema>
+  </wsdl:types>
+  <wsdl:message name="getLatestVersion">
+    <wsdl:part element="ns1:getLatestVersion" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getLatestVersionResponse">
+<wsdl:part element="ns1:getLatestVersionResponse" name="parameters"></wsdl:part>
+</wsdl:message>
+  <wsdl:portType name="IUserRemoteService">
+    <wsdl:operation name="getLatestVersion">
+      <wsdl:input message="ns1:getLatestVersion" name="getLatestVersion">
+    </wsdl:input>
+      <wsdl:output message="ns1:getLatestVersionResponse" name="getLatestVersionResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    
+  </wsdl:portType>
+</wsdl:definitions>


### PR DESCRIPTION
Recently I have to deal with `wsdl:import` element which specify another wsdl file to be imported. 
The mechanism could be found [here](http://www.w3.org/TR/wsdl20-primer/#adv-import-and-authoring)

So I make a patch to get things work.
test files attached.
