### PR TITLE
Allow logging of received XML prior to parsing and processing

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -100,11 +100,13 @@ Server.prototype._requestListener = function(req, res) {
         gunzip = null;
       }
       try {
+        if (typeof self.log === 'function') {
+          self.log("received", xml);
+        }
         self._process(xml, req.url, function(result) {
           res.write(result);
           res.end();
           if (typeof self.log === 'function') {
-            self.log("received", xml);
             self.log("replied", result);
           }
         });


### PR DESCRIPTION
While trying to debug an inbound request containing invalid xml we realized there was no way to log the raw xml since the  xml parser throws an error before the logging function is called.

This pull request breaks out the logging of the inbound request and moves it to a point before the xml parser is invoked.

Idealized by @brpvieira
