### PR TITLE
Allow WSDL to be passed directly to createClient method.

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1777,7 +1777,11 @@ function open_wsdl(uri, options, callback) {
   delete options.wsdl_options;
 
   var wsdl;
-  if (!/^http/.test(uri)) {
+  if (/^<\?xml/.test(uri)) {
+    wsdl = new WSDL(uri, null, options);
+    wsdl.onReady(callback);
+  }
+  else if (!/^http/.test(uri)) {
     fs.readFile(uri, 'utf8', function(err, definition) {
       if (err) {
         callback(err);


### PR DESCRIPTION
Useful in situations where you may not have access to WSDL locally and WSDL is not exposed with a URI.

Example: Web server on Host A queues a request into Database A. Node script running on Host B processes requests in Database A. If the WSDL is not downloadable and is stored locally on Host A, then the Node script has no way of parsing the WSDL without first writing the WSDL to a local file on Host B. For a large number of requests this will create much unnecessary filesystem I/O.