### PR TITLE
Enhance executeMethod by passing SOAP headers as an argument

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -192,6 +192,7 @@ Server.prototype._process = function(input, URL, callback) {
       methodName: methodName,
       outputName: methodName + 'Response',
       args: body[methodName],
+      headers: obj.Header,
       style: 'rpc'
     }, callback);
   } else {
@@ -203,6 +204,7 @@ Server.prototype._process = function(input, URL, callback) {
       methodName: pair.methodName,
       outputName: pair.outputName,
       args: body[messageElemName],
+      headers: obj.Header,
       style: 'document'
     }, callback);
   }
@@ -217,6 +219,7 @@ Server.prototype._executeMethod = function(options, callback) {
     methodName = options.methodName,
     outputName = options.outputName,
     args = options.args,
+    headers = options.headers,
     style = options.style,
     handled = false;
 
@@ -240,7 +243,7 @@ Server.prototype._executeMethod = function(options, callback) {
     callback(self._envelope(body));
   }
 
-  var result = method(args, handleResult);
+  var result = method(args, handleResult, headers);
   if (typeof result !== 'undefined') {
     handleResult(result);
   }


### PR DESCRIPTION
For Node SOAP server, it is required for some services to get the SOAP headers from the request.
The server.js pass the headers as the 3rd argument of the method (after args and callback).