### PR TITLE
Doing calls to a Soap Server need removed header

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -125,8 +125,15 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
 
   options = options || {};
 
-  //Add extra headers
-  for (var attr in extraHeaders) { headers[attr] = extraHeaders[attr]; }
+  // In weird cases you may need to remove SOAPAction
+  // Add extra headers
+  for (var attr in extraHeaders) {
+    if( typeof extraHeaders[attr] === "object" && Object.keys(extraHeaders[attr]).length === 0) {
+        delete headers[attr];
+    } else {
+      headers[attr] = extraHeaders[attr];
+    }
+  }
 
   // Allow the security object to add headers
   if (self.security && self.security.addHeaders)


### PR DESCRIPTION
There is a case that removing the SOAPAction allows the the protocols to continue though. in this action one just states ExtraHeaders = {SOAPAction:{}} and its removes the annoying header for the offended server.