### PR TITLE
Return the soapHeader

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -98,8 +98,8 @@ Client.prototype._defineMethod = function(method, location) {
       callback = args;
       args = {};
     }
-    self._invoke(method, args, location, function(error, result, raw) {
-      callback(error, result, raw);
+    self._invoke(method, args, location, function(error, result, raw, soapHeader) {
+      callback(error, result, raw, soapHeader);
     }, options, extraHeaders);
   };
 };
@@ -202,7 +202,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
         });
       }
 
-      callback(null, result, body);
+      callback(null, result, body, obj.Header);
     }
   }, headers, options);
 


### PR DESCRIPTION
@srushti

We need to return the Response Soap Header (not http response headers)
So that we can get information like wsUsernameToken

thoughts?