### PR TITLE
Add support for message and request events as per issue #545

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+npm-debug.log
 
 .idea
 *.iml

--- a/Readme.md
+++ b/Readme.md
@@ -207,6 +207,15 @@ as default request options to the constructor:
 
 ### Client.*lastRequest* - the property that contains last full soap request for client logging
 
+### Client Events
+Client instances emit the following events:
+
+* request - Emitted before a request is sent. The event handler receives the 
+entire Soap request (Envelope) including headers.
+* message - Emitted before a request is sent. The event handler receives the 
+Soap body contents. Useful if you don't want to log /store Soap headers.
+
+
 ## WSSecurity
 
 WSSecurity implements WS-Security.  UsernameToken and PasswordText/PasswordDigest is supported. An instance of WSSecurity is passed to Client.setSecurity.

--- a/lib/client.js
+++ b/lib/client.js
@@ -13,14 +13,19 @@ function findKey(obj, val) {
 
 var http = require('./http'),
   assert = require('assert'),
+  events = require('events'),
+  util = require('util'),
   url = require('url');
 
 var Client = function(wsdl, endpoint, options) {
+  events.EventEmitter.call(this);
+
   options = options || {};
   this.wsdl = wsdl;
   this._initializeOptions(options);
   this._initializeServices(endpoint);
 };
+util.inherits(Client, events.EventEmitter);
 
 Client.prototype.addSoapHeader = function(soapHeader, name, namespace, xmlns) {
   if (!this.soapHeaders) {
@@ -169,6 +174,9 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
 
   self.lastMessage = message;
   self.lastRequest = xml;
+
+  self.emit('message', message);
+  self.emit('request', xml);
 
   req = http.request(location, xml, function(err, response, body) {
     var result;

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -293,4 +293,55 @@ describe('SOAP Client', function() {
       }, baseUrl);
     });
   });
+
+  describe('Client Events', function () {
+    var server = null;
+    var hostname = '127.0.0.1';
+    var port = 15099;
+    var baseUrl = 'http://' + hostname + ":" + port;
+
+    before(function(done) {
+      server = http.createServer(function (req, res) {
+        res.statusCode = 200;
+        res.write(JSON.stringify({tempResponse: "temp"}), 'utf8');
+        res.end();
+      }).listen(port, hostname, done);
+    });
+
+    after(function(done) {
+      server.close();
+      server = null;
+      done();
+    });
+
+
+    it('Should emit the "message" event with Soap Body string', function (done) {
+      soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', function (err, client) {
+        client.on('message', function (xml) {
+          // Should contain only message body
+          assert.equal(typeof xml, 'string');
+          assert.equal(xml.indexOf('soap:Envelope'), -1);
+        });
+
+        client.MyOperation({}, function() {
+          done();
+        });
+      }, baseUrl);
+    });
+
+    it('Should emit the "request" event with entire XML message', function (done) {
+      soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', function (err, client) {
+        client.on('request', function (xml) {
+          // Should contain entire soap message
+          assert.equal(typeof xml, 'string');
+          assert.notEqual(xml.indexOf('soap:Envelope'), -1);
+        });
+
+        client.MyOperation({}, function() {
+          done();
+        });
+      }, baseUrl);
+    });
+
+  });
 });


### PR DESCRIPTION
Added in two events that are emitted by Client instances; "message" and :"request". Both are emitted immediately before the SOAP request is sent.

"message" contains the Soap Body contents.

"request" contains the entire Soap request contents.

"message" is useful if you need to log requests but have username/password info in the header etc.

Tests updated also.