### PR TITLE
Respect empty soap actions in operations

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -121,12 +121,21 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
     message = '',
     xml = null,
     req = null,
-    soapAction = this.SOAPAction ? this.SOAPAction(ns, name) : (method.soapAction || (((ns.lastIndexOf("/") !== ns.length - 1) ? ns + "/" : ns) + name)),
+    soapAction,
+    alias = findKey(defs.xmlns, ns),
     headers = {
-      SOAPAction: '"' + soapAction + '"',
       'Content-Type': "text/xml; charset=utf-8"
-    },
-    alias = findKey(defs.xmlns, ns);
+    };
+
+  if (this.SOAPAction) {
+    soapAction = this.SOAPAction;
+  } else if (method.soapAction !== undefined && method.soapAction !== null) {
+    soapAction = method.soapAction;
+  } else {
+    soapAction = ((ns.lastIndexOf("/") !== ns.length - 1) ? ns + "/" : ns) + name;
+  }
+
+  headers.SOAPAction = '"' + soapAction + '"';
 
   options = options || {};
 


### PR DESCRIPTION
I had a nasty situation in which the soapActions were empty in wsdl. I suggest we respect those cases and not force a soap action there. It leads to `The given SOAPAction http://abc.xsd/myaction does not match an operation` situation.