### PR TITLE
Client instances emit 'soapError' event when error is detected

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -221,6 +221,8 @@ Client instances emit the following events:
 entire Soap request (Envelope) including headers.
 * message - Emitted before a request is sent. The event handler receives the 
 Soap body contents. Useful if you don't want to log /store Soap headers.
+* soapError - Emitted when an erroneous response is received.
+  Useful if you want to globally log errors.
 
 
 ## WSSecurity

--- a/lib/client.js
+++ b/lib/client.js
@@ -201,6 +201,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
       } catch (error) {
         error.response = response;
         error.body = body;
+        self.emit('soapError', error);
         return callback(error, response, body);
       }
 

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -292,6 +292,17 @@ describe('SOAP Client', function() {
         });
       }, baseUrl);
     });
+
+    it('should emit a \'soapError\' event', function (done) {
+      soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', function (err, client) {
+        client.on('soapError', function(err) {
+          assert.ok(err);
+        });
+        client.MyOperation({}, function(err, result) {
+          done();
+        });
+      }, baseUrl);
+    });
   });
 
   describe('Client Events', function () {
@@ -303,8 +314,7 @@ describe('SOAP Client', function() {
     before(function(done) {
       server = http.createServer(function (req, res) {
         res.statusCode = 200;
-        res.write(JSON.stringify({tempResponse: "temp"}), 'utf8');
-        res.end();
+        fs.createReadStream(__dirname + '/soap-failure.xml').pipe(res);
       }).listen(port, hostname, done);
     });
 
@@ -338,6 +348,17 @@ describe('SOAP Client', function() {
         });
 
         client.MyOperation({}, function() {
+          done();
+        });
+      }, baseUrl);
+    });
+
+    it('should emit a \'soapError\' event', function (done) {
+      soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', function (err, client) {
+        client.on('soapError', function(err) {
+          assert.ok(err.root.Envelope.Body.Fault);
+        });
+        client.MyOperation({}, function(err, result) {
           done();
         });
       }, baseUrl);

--- a/test/soap-failure.xml
+++ b/test/soap-failure.xml
@@ -1,0 +1,26 @@
+<?xml version='1.0' ?>
+<!-- http://www.w3.org/TR/2003/REC-soap12-part0-20030624/#L11549 -->
+<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"
+            xmlns:rpc='http://www.w3.org/2003/05/soap-rpc'>
+  <env:Body>
+   <env:Fault>
+     <env:Code>
+       <env:Value>env:Sender</env:Value>
+       <env:Subcode>
+        <env:Value>rpc:BadArguments</env:Value>
+       </env:Subcode>
+     </env:Code>
+     <env:Reason>
+      <env:Text xml:lang="en-US">Processing error</env:Text>
+      <env:Text xml:lang="cs">Chyba zpracování</env:Text>
+     </env:Reason>
+     <env:Detail>
+      <e:myFaultDetails 
+        xmlns:e="http://travelcompany.example.org/faults">
+        <e:message>Name does not match card number</e:message>
+        <e:errorcode>999</e:errorcode>
+      </e:myFaultDetails>
+     </env:Detail>
+   </env:Fault>
+ </env:Body>
+</env:Envelope>


### PR DESCRIPTION
Now that the client can send events, it was really easy to add that one. I spent more time writing the tests!

Note: First, I chose the simpler 'error' event. But that one has a special meaning in node and that broke backward compatibility.