### PR TITLE
Issue #386 This fix adds support for attributes in body element

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -45,6 +45,29 @@ Client.prototype.clearSoapHeaders = function() {
   this.soapHeaders = null;
 };
 
+Client.prototype.addBodyAttribute = function(bodyAttribute, name, namespace, xmlns) {
+  if (!this.bodyAttributes) {
+    this.bodyAttributes = [];
+  }
+  if (typeof bodyAttribute === 'object') {
+    var composition = '';
+    Object.getOwnPropertyNames(bodyAttribute).forEach(function(prop, idx, array) {
+      composition += ' ' + prop + '="' + bodyAttribute[prop] + '"';
+    });
+    bodyAttribute = composition;
+  }
+  if (bodyAttribute.substr(0, 1) !== ' ') bodyAttribute = ' ' + bodyAttribute;
+  this.bodyAttributes.push(bodyAttribute);
+};
+
+Client.prototype.getBodyAttributes = function() {
+  return this.bodyAttributes;
+};
+
+Client.prototype.clearBodyAttributes = function() {
+  this.bodyAttributes = null;
+};
+
 Client.prototype.setEndpoint = function(endpoint) {
   this.endpoint = endpoint;
   this._initializeServices(endpoint);
@@ -176,7 +199,9 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
       :
         ''
       ) +
-    "<soap:Body>" +
+    "<soap:Body" +
+    (self.bodyAttributes ? self.bodyAttributes.join(' ') : '') +
+    ">" +
     message +
     "</soap:Body>" +
     "</soap:Envelope>";

--- a/lib/server.js
+++ b/lib/server.js
@@ -175,7 +175,7 @@ Server.prototype._process = function(input, URL, callback) {
         if (portPathname === pathname)
           return port.binding;
 
-        // The port path is almost always wrong for genrated WSDLs
+        // The port path is almost always wrong for generated WSDLs
         if (!firstPort) {
           firstPort = port;
         }
@@ -205,7 +205,7 @@ Server.prototype._process = function(input, URL, callback) {
         style: 'rpc'
       }, callback);
     } else {
-      var messageElemName = Object.keys(body)[0];
+      var messageElemName = (Object.keys(body)[0] === 'attributes' ? Object.keys(body)[1] : Object.keys(body)[0]);
       var pair = binding.topElements[messageElemName];
 
       if (headers)

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -208,6 +208,29 @@ describe('SOAP Server', function() {
     });
   });
 
+  it('should accept attributes as a string on the body element', function(done) {
+    soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
+      assert.ok(!err);
+      client.addBodyAttribute('xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="######################"');
+      client.GetLastTradePrice({ tickerSymbol: 'AAPL' }, function(err, response, body) {
+        assert.ok(!err);
+        done();
+      });
+    });
+  });
+
+  it('should accept attributes as an object on the body element', function(done) {
+    soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
+      assert.ok(!err);
+      var attributes = { 'xmlns:wsu': 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd', 'wsu:Id': '######################' };
+      client.addBodyAttribute(attributes);
+      client.GetLastTradePrice({ tickerSymbol: 'AAPL' }, function(err, response, body) {
+        assert.ok(!err);
+        done();
+      });
+    });
+  });
+
 // NOTE: this is actually a -client- test
 /*
 it('should return a valid error if the server stops responding': function(done) {


### PR DESCRIPTION
There are specific use cases, for instance with wss security, where attributes are added to the soap body element. This fix adds support for the server to parse them and for the client to add them.