### PR TITLE
If response is json embedded in soap, then error should not be thrown. Fix issue #580

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -15,6 +15,7 @@ var http = require('./http'),
   assert = require('assert'),
   events = require('events'),
   util = require('util'),
+  debug = require('debug')('node-soap'),
   url = require('url');
 
 var Client = function(wsdl, endpoint, options) {
@@ -224,6 +225,12 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
       try {
         obj = self.wsdl.xmlToObject(body);
       } catch (error) {
+        //When the output element cannot be looked up in the wsdl,
+        //Then instead of sending the error, We pass the body in the response.
+        if(!output.$lookupTypes) {
+          debug('Response element is not present. Unable to convert response xml to json.');
+          return callback(null,response,body);
+        }
         error.response = response;
         error.body = body;
         self.emit('soapError', error);

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -15,6 +15,7 @@ var url = require('url');
 var path = require('path');
 var assert = require('assert').ok;
 var stripBom = require('strip-bom');
+var debug = require('debug')('node-soap');
 var _ = require('lodash');
 
 var Primitives = {
@@ -483,7 +484,7 @@ MessageElement.prototype.postProcess = function(definitions) {
     var schema = definitions.schemas[definitions.xmlns[ns]];
     this.element = schema.elements[nsName.name];
     if(!this.element) {
-      console.log(nsName.name + " is not present in wsdl and cannot be processed correctly.");
+      debug(nsName.name + " is not present in wsdl and cannot be processed correctly.");
       return;
     }
     this.element.targetNSAlias = ns;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lodash": "~2.4.1",
     "request": ">=2.9.0",
     "sax": ">=0.6",
-    "strip-bom": "~0.3.1"
+    "strip-bom": "~0.3.1",
+    "debug": "~0.7.4"
   },
   "repository": {
     "type": "git",

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -169,6 +169,20 @@ describe('SOAP Client', function() {
         }, null, {'test-header': 'test'});
       }, baseUrl);
     });
+
+    it('should not return error in the call and return the json in body', function(done) {
+      soap.createClient(__dirname+'/wsdl/json_response.wsdl', function(err, client) {
+        assert.ok(client);
+        assert.ok(!err);
+
+        client.MyOperation({}, function(err, result, body) {
+          assert.ok(result);
+          assert.ok(!err);
+          assert.ok(body);
+          done();
+        }, null, {"test-header": 'test'});
+      }, baseUrl);
+    });
   });
 
   it('should add soap headers', function (done) {

--- a/test/wsdl/json_response.wsdl
+++ b/test/wsdl/json_response.wsdl
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="MyService" targetNamespace="http://www.example.com/v1" xmlns="http://www.example.com/v1" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/">
+  <wsdl:types>
+    <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://www.example.com/v1" xmlns="http://www.example.com/v1">
+		<xs:element name="Request">
+		</xs:element>
+    </xs:schema>
+    </wsdl:types>
+    <wsdl:message name="InputMessage">
+    <wsdl:part name="parameter" element="Request">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="OutputMessage">
+    <wsdl:part name="parameter" element="Response">
+    </wsdl:part>
+  </wsdl:message>
+
+  <wsdl:portType name="MyServicePortType">
+    <wsdl:operation name="MyOperation">
+      <wsdl:input message="InputMessage">
+    </wsdl:input>
+      <wsdl:output message="OutputMessage">
+    </wsdl:output>
+    </wsdl:operation>
+  </wsdl:portType>
+
+  <wsdl:binding name="MyServiceBinding" type="MyServicePortType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="MyOperation">
+      <soap:operation soapAction="MyOperation"/>
+      <wsdl:input>
+        <soap:body use="literal" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+
+  <wsdl:service name="MyService">
+    <wsdl:port name="MyServicePort" binding="MyServiceBinding">
+      <soap:address location="http://www.example.com/v1"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
Changes included:
1. Changed console.log to debug when soap response is json to avoid unnecessary logs.
2. Fix for issue #580 . When json is embedded in soap body, then currently it throws error. We won't return the error and send the response in body param. That way, it would be a cleaner approach for the client to distinguish it from other errors like "http error"/"soap error".