### PR TITLE
ClientSSLSecurity should be able to take a Buffer as `key` and `cert` parameter

### DIFF
--- a/lib/security/ClientSSLSecurity.js
+++ b/lib/security/ClientSSLSecurity.js
@@ -4,9 +4,35 @@ var fs = require('fs')
   , https = require('https')
   , _ = require('lodash');
 
-function ClientSSLSecurity(keyPath, certPath, defaults) {
-  this.key = fs.readFileSync(keyPath);
-  this.cert = fs.readFileSync(certPath);
+function ClientSSLSecurity(key, cert, defaults) {
+  if (key) {
+    if(Buffer.isBuffer(key)) {
+      this.key = key;
+    } else if (typeof key === 'string') {
+      this.key = fs.readFileSync(key);
+    } else {
+      throw new Error('key should be a buffer or a string!');
+    }
+
+    if(this.key.toString().lastIndexOf('-----BEGIN RSA PRIVATE KEY-----', 0) !== 0) {
+      throw new Error('key should start with -----BEGIN RSA PRIVATE KEY-----');
+    }
+  }
+
+  if (cert) {
+    if(Buffer.isBuffer(cert)) {
+      this.cert = cert;
+    } else if (typeof cert === 'string') {
+      this.cert = fs.readFileSync(cert);
+    } else {
+      throw new Error('cert should be a buffer or a string!');
+    }
+
+    if(this.cert.toString().lastIndexOf('-----BEGIN CERTIFICATE-----', 0) !== 0) {
+      throw new Error('cert should start with -----BEGIN CERTIFICATE-----');
+    }
+  }
+
   this.defaults = {};
   _.merge(this.defaults, defaults);
 }

--- a/test/security/ClientSSLSecurity.js
+++ b/test/security/ClientSSLSecurity.js
@@ -1,5 +1,8 @@
 'use strict';
 
+var fs = require('fs'),
+    join = require('path').join;
+
 describe('ClientSSLSecurity', function() {
   var ClientSSLSecurity = require('../../').ClientSSLSecurity;
   var cert = __filename;
@@ -11,15 +14,52 @@ describe('ClientSSLSecurity', function() {
 
   describe('defaultOption param', function() {
     it('is accepted as the third param', function() {
-      new ClientSSLSecurity(key, cert, {});
+      new ClientSSLSecurity(null, null, {});
     });
 
     it('is used in addOptions', function() {
       var options = {};
       var defaultOptions = { foo: 5 };
-      var instance = new ClientSSLSecurity(key, cert, defaultOptions);
+      var instance = new ClientSSLSecurity(null, null, defaultOptions);
       instance.addOptions(options);
       options.should.have.property("foo", 5);
     });
+  });
+
+  it('should throw if invalid cert or key is given', function () {
+    var instanceCert = null,
+        instanceKey = null;
+
+    try {
+      instanceCert = new ClientSSLSecurity(null, cert);
+    } catch (e) {
+      //should happen!
+      instanceCert = false;
+    }
+
+    try {
+      instanceKey = new ClientSSLSecurity(key, null);
+    } catch (e) {
+      //should happen!
+      instanceKey = false;
+    }
+
+    if (instanceCert !== false) {
+      throw new Error('accepted wrong cert');
+    }
+
+    if (instanceKey !== false) {
+      throw new Error('accepted wrong key');
+    }
+  });
+
+  it('should accept a Buffer as argument for the key or cert', function () {
+    var certBuffer = fs.readFileSync(join(__dirname, '..', 'certs', 'agent2-cert.pem')),
+      keyBuffer = fs.readFileSync(join(__dirname, '..', 'certs', 'agent2-key.pem')),
+      instance;
+
+    instance = new ClientSSLSecurity(keyBuffer, certBuffer);
+    instance.should.have.property("cert", certBuffer);
+    instance.should.have.property("key", keyBuffer);
   });
 });


### PR DESCRIPTION
Additionally the certificates are checked whether they are correct or not (starting with `-----BEGIN`).

Added test, and corrected another one, which is passing invalid parameters.

Regards,
Mik13