### PR TITLE
ClientSSLSecurity now accepts a `ca`-certificate.

### DIFF
--- a/lib/security/ClientSSLSecurity.js
+++ b/lib/security/ClientSSLSecurity.js
@@ -4,7 +4,17 @@ var fs = require('fs')
   , https = require('https')
   , _ = require('lodash');
 
-function ClientSSLSecurity(key, cert, defaults) {
+/**
+ * activates SSL for an already existing client
+ *
+ * @module ClientSSLSecurity
+ * @param {Buffer|String}   key
+ * @param {Buffer|String}   cert
+ * @param {Buffer|String}   [ca]
+ * @param {Object}          [defaults]
+ * @constructor
+ */
+function ClientSSLSecurity(key, cert, ca, defaults) {
   if (key) {
     if(Buffer.isBuffer(key)) {
       this.key = key;
@@ -33,6 +43,21 @@ function ClientSSLSecurity(key, cert, defaults) {
     }
   }
 
+  if (ca) {
+    if(Buffer.isBuffer(ca)) {
+      this.ca = ca;
+    } else if (typeof ca === 'string') {
+      this.ca = fs.readFileSync(ca);
+    } else {
+      defaults = ca;
+      this.ca = null;
+    }
+
+    if(this.ca && this.ca.toString().lastIndexOf('-----BEGIN CERTIFICATE-----', 0) !== 0) {
+      throw new Error('ca should start with -----BEGIN CERTIFICATE-----');
+    }
+  }
+
   this.defaults = {};
   _.merge(this.defaults, defaults);
 }
@@ -44,6 +69,7 @@ ClientSSLSecurity.prototype.toXML = function(headers) {
 ClientSSLSecurity.prototype.addOptions = function(options) {
   options.key = this.key;
   options.cert = this.cert;
+  options.ca = this.ca;
   _.merge(options, this.defaults);
   options.agent = new https.Agent(options);
 };

--- a/test/security/ClientSSLSecurity.js
+++ b/test/security/ClientSSLSecurity.js
@@ -26,9 +26,10 @@ describe('ClientSSLSecurity', function() {
     });
   });
 
-  it('should throw if invalid cert or key is given', function () {
+  it('should throw if invalid (ca or client) cert or key is given', function () {
     var instanceCert = null,
-        instanceKey = null;
+      instanceKey = null,
+      instanceCA = null;
 
     try {
       instanceCert = new ClientSSLSecurity(null, cert);
@@ -44,12 +45,23 @@ describe('ClientSSLSecurity', function() {
       instanceKey = false;
     }
 
+    try {
+      instanceCA = new ClientSSLSecurity(null, null, cert);
+    } catch (e) {
+      //should happen!
+      instanceCA = false;
+    }
+
     if (instanceCert !== false) {
       throw new Error('accepted wrong cert');
     }
 
     if (instanceKey !== false) {
       throw new Error('accepted wrong key');
+    }
+
+    if (instanceCA !== false) {
+      throw new Error('accepted wrong CA cert');
     }
   });
 
@@ -58,7 +70,8 @@ describe('ClientSSLSecurity', function() {
       keyBuffer = fs.readFileSync(join(__dirname, '..', 'certs', 'agent2-key.pem')),
       instance;
 
-    instance = new ClientSSLSecurity(keyBuffer, certBuffer);
+    instance = new ClientSSLSecurity(keyBuffer, certBuffer, certBuffer);
+    instance.should.have.property("ca", certBuffer);
     instance.should.have.property("cert", certBuffer);
     instance.should.have.property("key", keyBuffer);
   });


### PR DESCRIPTION
This is necessary if the server uses a self-signed certificate, which we want to trust, by setting it as the CA-certificate of our client.

+Test