### PR TITLE
Server 'request' event

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -205,6 +205,7 @@ Server.prototype._process = function(input, URL, callback) {
     if (binding.style === 'rpc') {
       methodName = Object.keys(body)[0];
 
+      self.emit('request', obj, methodName);
       if (headers)
         self.emit('headers', headers, methodName);
 
@@ -221,6 +222,7 @@ Server.prototype._process = function(input, URL, callback) {
       var messageElemName = (Object.keys(body)[0] === 'attributes' ? Object.keys(body)[1] : Object.keys(body)[0]);
       var pair = binding.topElements[messageElemName];
 
+      self.emit('request', obj, pair.methodName);
       if (headers)
         self.emit('headers', headers, pair.methodName);
 

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -144,6 +144,17 @@ describe('SOAP Server', function() {
     });
   });
 
+  it('should emit \'request\' event', function(done) {
+    test.soapServer.on('request', function requestManager(request, methodName) {
+      assert.equal(methodName, 'GetLastTradePrice');
+      done();
+    });
+    soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
+      assert.ok(!err);
+      client.GetLastTradePrice({ tickerSymbol: 'AAPL'}, function() {});
+    });
+  });
+
   it('should emit \'headers\' event', function(done) {
     test.soapServer.on('headers', function headersManager(headers, methodName) {
       assert.equal(methodName, 'GetLastTradePrice');


### PR DESCRIPTION
The server emits a "request" event for every received message.

(I needed it to easily handle the case where a client doesn't send a mandatory header…)