### PR TITLE
In http.js, do not end request for keep-alive connections

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -41,6 +41,10 @@ var httpRequest = function httpRequest(rurl, data, callback, exheaders, exoption
     headers: headers,
     followAllRedirects: true
   };
+  
+  if (headers.Connection === 'keep-alive') {
+    options.body = data;
+  }
 
   exoptions = exoptions || {};
   for (attr in exoptions) { options[attr] = exoptions[attr]; }
@@ -61,8 +65,11 @@ var httpRequest = function httpRequest(rurl, data, callback, exheaders, exoption
       callback(null, res, body);
     }
   });
-  request.end(data);
-
+  
+  if (headers.Connection !== 'keep-alive') {
+    request.end(data);
+  }
+  
   return request;
 };
 


### PR DESCRIPTION
The request.end(data) line was preempting maintaining a persistent connection, even when Connection: 'keep-alive' was specified. My proposal is to handle the data via the body option, and only end the request when keep-alive is not specified.