### PR TITLE
Client 'response' event

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -283,6 +283,9 @@ entire Soap request (Envelope) including headers.
 Soap body contents. Useful if you don't want to log /store Soap headers.
 * soapError - Emitted when an erroneous response is received.
   Useful if you want to globally log errors.
+* response - Emitted after a response is received. The event handler receives
+the entire response body. This is emitted for all responses (both success and
+errors).
 
 
 ## WSSecurity

--- a/lib/client.js
+++ b/lib/client.js
@@ -218,6 +218,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
     var obj;
     self.lastResponse = body;
     self.lastResponseHeaders = response && response.headers;
+    self.emit('response', body);
 
     if (err) {
       callback(err);

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -391,13 +391,16 @@ describe('SOAP Client', function() {
 
     it('Should emit the "message" event with Soap Body string', function (done) {
       soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', function (err, client) {
+        var didEmitEvent = false;
         client.on('message', function (xml) {
+          didEmitEvent = true;
           // Should contain only message body
           assert.equal(typeof xml, 'string');
           assert.equal(xml.indexOf('soap:Envelope'), -1);
         });
 
         client.MyOperation({}, function() {
+          assert.ok(didEmitEvent);
           done();
         });
       }, baseUrl);
@@ -405,13 +408,33 @@ describe('SOAP Client', function() {
 
     it('Should emit the "request" event with entire XML message', function (done) {
       soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', function (err, client) {
+        var didEmitEvent = false;
         client.on('request', function (xml) {
+          didEmitEvent = true;
           // Should contain entire soap message
           assert.equal(typeof xml, 'string');
           assert.notEqual(xml.indexOf('soap:Envelope'), -1);
         });
 
         client.MyOperation({}, function() {
+          assert.ok(didEmitEvent);
+          done();
+        });
+      }, baseUrl);
+    });
+
+    it('Should emit the "response" event with Soap Body string', function (done) {
+      soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', function (err, client) {
+        var didEmitEvent = false;
+        client.on('response', function (xml) {
+          didEmitEvent = true;
+          // Should contain entire soap message
+          assert.equal(typeof xml, 'string');
+          assert.equal(xml.indexOf('soap:Envelope'), -1);
+        });
+
+        client.MyOperation({}, function() {
+          assert.ok(didEmitEvent);
           done();
         });
       }, baseUrl);
@@ -419,10 +442,13 @@ describe('SOAP Client', function() {
 
     it('should emit a \'soapError\' event', function (done) {
       soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', function (err, client) {
+        var didEmitEvent = false;
         client.on('soapError', function(err) {
+          didEmitEvent = true;
           assert.ok(err.root.Envelope.Body.Fault);
         });
         client.MyOperation({}, function(err, result) {
+          assert.ok(didEmitEvent);
           done();
         });
       }, baseUrl);


### PR DESCRIPTION
Added a 'response' event to the client that is emitted when the SOAP response is received. Used in conjunction with the existing 'request' and 'message' events, it makes logging in one centralized place much easier. #545