### PR TITLE
Handle HTML answer from non-SOAP server

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -243,6 +243,13 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
         return callback(null, null, body, obj.Header);
       }
 
+      if( typeof obj.Body !== 'object' ) {
+        var error = new Error('Cannot parse response');
+        error.response = response;
+        error.body = body;
+        return callback(error, obj, body);
+      }
+
       result = obj.Body[output.$name];
       // RPC/literal response body may contain elements with added suffixes I.E.
       // 'Response', or 'Output', or 'Out'

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -369,6 +369,38 @@ describe('SOAP Client', function() {
     });
   });
 
+  describe('Handle HTML answer from non-SOAP server', function() {
+    var server = null;
+    var hostname = '127.0.0.1';
+    var port = 15099;
+    var baseUrl = 'http://' + hostname + ':' + port;
+
+    before(function(done) {
+      server = http.createServer(function (req, res) {
+        res.statusCode = 200;
+        res.write('<html><body></body></html>', 'utf8');
+        res.end();
+      }).listen(port, hostname, done);
+    });
+
+    after(function(done) {
+      server.close();
+      server = null;
+      done();
+    });
+
+    it('should return an error', function (done) {
+      soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', function (err, client) {
+        client.MyOperation({}, function(err, result) {
+          assert.ok(err);
+          assert.ok(err.response);
+          assert.ok(err.body);
+          done();
+        });
+      }, baseUrl);
+    });
+  });
+
   describe('Client Events', function () {
     var server = null;
     var hostname = '127.0.0.1';


### PR DESCRIPTION
I just hit the case of the attached test: a client with local WSDL and URL to an Apache server.

Because of the local WSDL, the typo in the URL isn't detected when fetching the wsdl from the remote server. And, on the first POST, it isn't a 400 error but valid HTML (saying something like "it works").
And then, the wdsl instance of the client returns the parsed html as json (instead of an XML body).