### PR TITLE
Operation names with "Request", "Response", or "Sollicit" suffixes

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1232,20 +1232,15 @@ WSDL.prototype.xmlToObject = function(xml) {
         // Determine if this is request or response
         var isInput = false;
         var isOutput = false;
-        if (!self.definitions.messages[name + 'Request']
-            && !self.definitions.messages[name + 'Response']
-            && !self.definitions.messages[name + 'Solicit'])
-        {
-          if ((/Response$/).test(name)) {
-            isOutput = true;
-            name = name.replace(/Response$/, '');
-          } else if ((/Request$/).test(name)) {
-            isInput = true;
-            name = name.replace(/Request$/, '');
-          } else if ((/Solicit$/).test(name)) {
-            isInput = true;
-            name = name.replace(/Solicit$/, '');
-          }
+        if ((/Response$/).test(name) && !self.definitions.messages[name + 'Response']) {
+          isOutput = true;
+          name = name.replace(/Response$/, '');
+        } else if ((/Request$/).test(name) && !self.definitions.messages[name + 'Request']) {
+          isInput = true;
+          name = name.replace(/Request$/, '');
+        } else if ((/Solicit$/).test(name) && !self.definitions.messages[name + 'Solicit']) {
+          isInput = true;
+          name = name.replace(/Solicit$/, '');
         }
         // Look up the appropriate message as given in the portType's operations
         var portTypes = self.definitions.portTypes;

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1232,7 +1232,7 @@ WSDL.prototype.xmlToObject = function(xml) {
         // Determine if this is request or response
         var isInput = false;
         var isOutput = false;
-	if (! self.definitions.messages[name + 'Request']
+	if (!self.definitions.messages[name + 'Request']
 	    && !self.definitions.messages[name + 'Response']
 	    && !self.definitions.messages[name + 'Solicit'])
 	{

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1232,21 +1232,21 @@ WSDL.prototype.xmlToObject = function(xml) {
         // Determine if this is request or response
         var isInput = false;
         var isOutput = false;
-	if (!self.definitions.messages[name + 'Request']
-	    && !self.definitions.messages[name + 'Response']
-	    && !self.definitions.messages[name + 'Solicit'])
-	{
-            if ((/Response$/).test(name)) {
-		isOutput = true;
-		name = name.replace(/Response$/, '');
-            } else if ((/Request$/).test(name)) {
-		isInput = true;
-		name = name.replace(/Request$/, '');
-            } else if ((/Solicit$/).test(name)) {
-		isInput = true;
-		name = name.replace(/Solicit$/, '');
-            }
-	}
+        if (!self.definitions.messages[name + 'Request']
+            && !self.definitions.messages[name + 'Response']
+            && !self.definitions.messages[name + 'Solicit'])
+        {
+          if ((/Response$/).test(name)) {
+            isOutput = true;
+            name = name.replace(/Response$/, '');
+          } else if ((/Request$/).test(name)) {
+            isInput = true;
+            name = name.replace(/Request$/, '');
+          } else if ((/Solicit$/).test(name)) {
+            isInput = true;
+            name = name.replace(/Solicit$/, '');
+          }
+        }
         // Look up the appropriate message as given in the portType's operations
         var portTypes = self.definitions.portTypes;
         var portTypeNames = Object.keys(portTypes);

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1232,16 +1232,21 @@ WSDL.prototype.xmlToObject = function(xml) {
         // Determine if this is request or response
         var isInput = false;
         var isOutput = false;
-        if ((/Response$/).test(name)) {
-          isOutput = true;
-          name = name.replace(/Response$/, '');
-        } else if ((/Request$/).test(name)) {
-          isInput = true;
-          name = name.replace(/Request$/, '');
-        } else if ((/Solicit$/).test(name)) {
-          isInput = true;
-          name = name.replace(/Solicit$/, '');
-        }
+	if (! self.definitions.messages[name + 'Request']
+	    && !self.definitions.messages[name + 'Response']
+	    && !self.definitions.messages[name + 'Solicit'])
+	{
+            if ((/Response$/).test(name)) {
+		isOutput = true;
+		name = name.replace(/Response$/, '');
+            } else if ((/Request$/).test(name)) {
+		isInput = true;
+		name = name.replace(/Request$/, '');
+            } else if ((/Solicit$/).test(name)) {
+		isInput = true;
+		name = name.replace(/Solicit$/, '');
+            }
+	}
         // Look up the appropriate message as given in the portType's operations
         var portTypes = self.definitions.portTypes;
         var portTypeNames = Object.keys(portTypes);


### PR DESCRIPTION
I made this as a simple fix for vpulim/node-soap#518.

It may need tests for testing:

* WSDL with operation names with  "Request", "Response", or "Sollicit" suffixes
* WSDL with implicit Input and Output messages names. http://www.w3.org/TR/wsdl#_names

