### PR TITLE
SOAP 1.2 Headers and HTTP Content-Type - Q&D Fix

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -83,7 +83,7 @@ Client.prototype.setSOAPVersion12 = function(soapversion12) {
   this.SOAPVersion12 = soapversion12;
 };
 
-Client.prototype.getSOAPVersion12 = function(soapversion12) {
+Client.prototype.getSOAPVersion12 = function() {
   var soap12 = (this.SOAPVersion12 ? true : false);
   return soap12;
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -79,6 +79,15 @@ Client.prototype.describe = function() {
   return this.wsdl.describeServices();
 };
 
+Client.prototype.setSOAPVersion12 = function(soapversion12) {
+  this.SOAPVersion12 = soapversion12;
+};
+
+Client.prototype.getSOAPVersion12 = function(soapversion12) {
+  var soap12 = (this.SOAPVersion12 ? true : false);
+  return soap12;
+};
+
 Client.prototype.setSecurity = function(security) {
   this.security = security;
 };
@@ -185,9 +194,21 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
     // pass `input.$lookupType` if `input.$type` could not be found
     message = self.wsdl.objectToDocumentXML(input.$name, args, input.targetNSAlias, input.targetNamespace, (input.$type || input.$lookupType));
   }
+
+  var SOAP_VERSION_HEADERS = "";
+  headers = headers || {};
+
+  if (self.SOAPVersion12) {
+    headers["Content-Type"] = "application/soap+xml; charset=utf-8";
+    SOAP_VERSION_HEADERS = "xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" ";
+  } else {
+    SOAP_VERSION_HEADERS = "xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" " +
+    "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" ";
+    headers["Content-Type"] = "text/xml; charset=utf-8";
+  }
+
   xml = "<soap:Envelope " +
-    "xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" " +
-    "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+    SOAP_VERSION_HEADERS + " " + 
     encoding +
     this.wsdl.xmlnsInEnvelope + '>' +
     ((self.soapHeaders || self.security) ?


### PR DESCRIPTION
Even if its a Quick and Dirty fix, it helps to work with my SOAP12 Service flawless.
Theres a new function setSOAPVersion12 for the client (true | false) implemented to set the SOAP12 Headers and Content-Type. As well it can be determined by getSOAPVersion12 to see if Soap12 is enabled.
