### PR TITLE
Attributes in body causes an error with RPC

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -203,7 +203,7 @@ Server.prototype._process = function(input, URL, callback) {
 
   try {
     if (binding.style === 'rpc') {
-      methodName = Object.keys(body)[0];
+      methodName = (Object.keys(body)[0] === 'attributes' ? Object.keys(body)[1] : Object.keys(body)[0]);
 
       self.emit('request', obj, methodName);
       if (headers)


### PR DESCRIPTION
In the case where the body includes some attributes the method name is wrongly picked up. Check out the example below

```
{ Header: { attributes: { 'soapenv:encodingStyle': 'http://schemas.xmlsoap.org/soap/encoding/' } },
  Body: 
   { attributes: { 'soapenv:encodingStyle': 'http://schemas.xmlsoap.org/soap/encoding/' },
     getIlmsRecords: 
      { customer_name: [Object],
        mobile_number: [Object],
        address: [Object],
        email_id: [Object],
        lead_id: [Object],
        product: [Object],
        lead_creation_time: [Object],
        lead_assginment_time: [Object],
        expected_closure_time: [Object],
        circle: [Object],
        zone: [Object],
        city: [Object],
        city_zone: [Object],
        pin_code: [Object],
        dialer_remarks: [Object],
```