### PR TITLE
Taking ignoredNamespaces into account for objectToXML

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1483,7 +1483,7 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsA
   var xmlnsAttrib = '';
   if (xmlns && first) {
 
-    if (prefixNamespace && (!isNamespaceIgnored || this.ignoredNamespaces.indexOf(namespace) === -1)) {
+    if (prefixNamespace && (!isNamespaceIgnored || this.options.ignoredNamespaces.indexOf(namespace) === -1)) {
       // resolve the prefix namespace
       xmlnsAttrib += ' xmlns:' + namespace + '="' + xmlns + '"';
     }
@@ -1499,7 +1499,7 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsA
   }
 
   var ns = '';
-  if (prefixNamespace && ((qualified || first) || soapHeader) && (!isNamespaceIgnored || this.ignoredNamespaces.indexOf(namespace) === -1)) {
+  if (prefixNamespace && ((qualified || first) || soapHeader) && (!isNamespaceIgnored || this.options.ignoredNamespaces.indexOf(namespace) === -1)) {
     // prefix element
     ns = namespace.indexOf(":") === -1 ? namespace + ':' : namespace;
   }


### PR DESCRIPTION
If an object is converted into an xml representation (in wsdl.js, objectToXML) the element will never be prefixed with the namespace, even if one provided the corresponding option to createClient. The function only compares the given namespace with the constant property of wsdl.js.

This commit fixes that by comparing this.options.ignoredNamespaces, which is the overridden/concatenated version of this.ignoredNamespaces and the corresponding option, provided to createClient.