### PR TITLE
custom NS on a request

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -183,7 +183,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
   } else {
     assert.ok(!style || style === 'document', 'invalid message definition for rpc style binding');
     // pass `input.$lookupType` if `input.$type` could not be found
-    message = self.wsdl.objectToDocumentXML(input.$name, args, input.targetNSAlias, input.targetNamespace, (input.$type || input.$lookupType));
+    message = self.wsdl.objectToDocumentXML((options.name||input.$name), args, (options.skipNS?'':input.targetNSAlias), (options.skipNS?'':input.targetNamespace), (input.$type || input.$lookupType));
   }
   xml = "<soap:Envelope " +
     "xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" " +

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -274,6 +274,55 @@ describe('SOAP Client', function() {
         });
       }, baseUrl);
     });
+
+    it('should be able to set my own namespaces in the request', function (done) {
+      soap.createClient(__dirname + '/wsdl/extended_element.wsdl', function (err, client) {
+        assert.ok(client);
+        client.wsdl.definitions.xmlns.sec="http://www.owasp.com/service/1";
+        client.wsdl.xmlnsInEnvelope = client.wsdl._xmlnsMap();
+        var data = {
+          'sec:username':'very secure',
+          'sec:password':'password'
+        };
+
+        var message = '<ExtendedDummyRequest><sec:username>very secure</sec:username><sec:password>password</sec:password></ExtendedDummyRequest>';
+
+        client.on('message',function(xml){
+          xml.should.equal(message)
+          done();
+        })
+        client.Dummy(data, function(err, result) {},
+          {
+            skipNS:true
+          }
+        );
+      }, baseUrl);
+    });
+
+    it('should be able to set my own method name', function (done) {
+      soap.createClient(__dirname + '/wsdl/extended_element.wsdl', function (err, client) {
+        assert.ok(client);
+        client.wsdl.definitions.xmlns.sec="http://www.owasp.com/service/1";
+        client.wsdl.xmlnsInEnvelope = client.wsdl._xmlnsMap();
+        var data = {
+          'sec0:username':'very secure',
+          'sec:password':'password'
+        };
+
+        var message = '<sec0:ExtendedDummyRequest><sec0:username>very secure</sec0:username><sec:password>password</sec:password></sec0:ExtendedDummyRequest>';
+
+        client.on('message',function(xml){
+          xml.should.equal(message)
+          done();
+        })
+        client.Dummy(data, function(err, result) {},
+          {
+            skipNS:true,
+            name:'sec0:ExtendedDummyRequest'
+          }
+        );
+      }, baseUrl);
+    });
   });
 
   describe('Follow even non-standard redirects', function() {


### PR DESCRIPTION
The idea behind this simple modification is to optionally let the developer define custom NS for the message of the request through the name of the request object properties. it also uses a name attribute in so the method can be renamed t will