### PR TITLE
[Proposal] Generic XML string transformation before request

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,6 +40,9 @@ The `options` argument allows you to customize the client with the following pro
 - endpoint: to override the SOAP service's host specified in the `.wsdl` file.
 - request: to override the [request](https://github.com/request/request) module.
 - httpClient: to provide your own http client that implements `request(rurl, data, callback, exheaders, exoptions)`.
+- xmlTransform: to perform custom editing of the request XML **before** is sent to the server. You can specify a function that implements`function (xml)`. This function will be executed just before the request XML is sent to the server and let you perform arbitrary modification to the XML string ( using string modification functions like RegExp or similar ).  
+`xml` argument is the XML request _string_.  
+The xmlTransform function specified **must** returns the transformed XML string.
 
 ### soap.listen(*server*, *path*, *services*, *wsdl*) - create a new SOAP server that listens on *path* and provides *services*.
 *wsdl* is an xml string that defines the service.

--- a/lib/client.js
+++ b/lib/client.js
@@ -208,6 +208,10 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
     "</soap:Body>" +
     "</soap:Envelope>";
 
+  if (typeof this.options.xmlTransform === 'function') {
+    xml = this.options.xmlTransform(xml);
+  }
+
   self.lastMessage = message;
   self.lastRequest = xml;
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -208,8 +208,19 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
     "</soap:Body>" +
     "</soap:Envelope>";
 
+  // if xmlTransform is defined as a function
   if (typeof this.options.xmlTransform === 'function') {
-    xml = this.options.xmlTransform(xml);
+    // run it and store return value
+    var tmpXml = this.options.xmlTransform(xml);
+    // check for undefined, which means that the function didn't have explicit return
+    if (typeof tmpXml === 'undefined') {
+      return callback(new Error('xmlTransform returned undefined, please return the transformed XML'));
+    } else if (typeof tmpXml !== 'string') {
+      return callback(new Error('xmlTransform returned a non-string value, please return the transformed XML'));
+    } else {
+      // if everything was ok overwrite xml
+      xml = tmpXml;
+    }
   }
 
   self.lastMessage = message;

--- a/lib/client.js
+++ b/lib/client.js
@@ -21,7 +21,7 @@ var HttpClient = require('./http'),
 var Client = function(wsdl, endpoint, options) {
   events.EventEmitter.call(this);
 
-  options = options || {};
+  this.options = options || {};
   this.wsdl = wsdl;
   this._initializeOptions(options);
   this._initializeServices(endpoint);

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -79,6 +79,13 @@ describe('SOAP Client', function() {
     });
   });
 
+  it('should save per instance options', function () {
+    var options = { test: true };
+    soap.createClient(__dirname+'/wsdl/binding_document.wsdl', options, function (err, client) {
+      assert.deepEqual(client.options, options);
+    });
+  });
+
   describe('Headers in request and last response', function() {
     var server = null;
     var hostname = '127.0.0.1';


### PR DESCRIPTION
Hello! First of all thanks for this library.

I had a problem using it due to a "strange" constrain in the SOAP API I have to use. Strange because I wasn't able to find information about a `ent` namespace in SOAP requests...
I'm a SOAP noob, so please forgive incorrectness or silly errors :)

For some reason the API instead of using `tns` ( I guess this is a xml namespace ) uses `ent`. This is in conflict with the generated request XML. I tried to dig in `node-soap` source code to find a way to change this but wasn't able to find one. My solution is a generic callback function to edit the XML before is sent ( simple RegExp search&replace ). It seems that `xmlns:tns` is taken from the `WSDL` definition ( so it is actually "expected" but the request returns an error without `ent` ).

I thought that maybe this could be useful, so here is this PR. Is more a proposal than a feature request.  
If there is already a way to perform this that I missed, please let me know.

Thank you.

PS: I wasn't able to create tests for this feature, but if you like the proposal and explain me how to create them, I will.