### PR TITLE
Support async server errors

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -267,10 +267,19 @@ Server.prototype._executeMethod = function(options, callback, includeTimestamp) 
     return callback(this._envelope('', includeTimestamp));
   }
 
-  function handleResult(result) {
+  function handleResult(error, result) {
     if (handled)
       return;
     handled = true;
+
+    if (error && error.Fault !== undefined) {
+      var fault = self.wsdl.objectToDocumentXML("Fault", error.Fault, "soap");
+      return callback(self._envelope(fault, includeTimestamp));
+    }
+    else if (result === undefined) {
+      // Backward compatibility to support one argument callback style
+      result = error;
+    }
 
     if (style === 'rpc') {
       body = self.wsdl.objectToRpcXML(outputName, result, '', self.wsdl.definitions.$targetNamespace);

--- a/test/wsdl/strict/stockquote.wsdl
+++ b/test/wsdl/strict/stockquote.wsdl
@@ -31,6 +31,7 @@
                    </xsd:all>
                </xsd:complexType>
            </xsd:element>
+           <xsd:element name="valid" type="boolean"/>
        </xsd:schema>
     </wsdl:types>
 
@@ -46,6 +47,14 @@
         <wsdl:part name="body" element="xsd1:TradePriceSubmit"/>
     </wsdl:message>
 
+    <wsdl:message name="IsValidPriceInput">
+        <wsdl:part name="body" element="xsd1:TradePrice"/>
+    </wsdl:message>
+
+    <wsdl:message name="IsValidPriceOutput">
+        <wsdl:part name="body" element="xsd1:valid"/>
+    </wsdl:message>
+
     <wsdl:portType name="StockQuotePortType">
         <wsdl:operation name="GetLastTradePrice">
            <wsdl:input message="tns:GetLastTradePriceInput"/>
@@ -53,6 +62,10 @@
         </wsdl:operation>
         <wsdl:operation name="SetTradePrice">
             <wsdl:input message="tns:SetTradePriceInput"/>
+        </wsdl:operation>
+        <wsdl:operation name="IsValidPrice">
+            <wsdl:input message="tns:IsValidPriceInput"/>
+            <wsdl:output message="tns:IsValidPriceOutput"/>
         </wsdl:operation>
     </wsdl:portType>
 
@@ -69,6 +82,12 @@
         </wsdl:operation>
         <wsdl:operation name="SetTradePrice">
             <soap:operation soapAction="http://example.com/SetTradePrice"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="IsValidPrice">
+            <soap:operation soapAction="http://example.com/IsValidPrice"/>
             <wsdl:input>
                 <soap:body use="literal"/>
             </wsdl:input>


### PR DESCRIPTION
This will add the possibility to send async errors back as a response from the server handler while staying backwards compatible with the current callback style. To get the test working I fixed a current bug where the tests in `request-response-samples-test.js` exposed its before/after/beforeEach hooks in a way which applied them to every other test in the suite.