### PR TITLE
Ignore the `.idea` folder when pushing to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 /test/
+.idea


### PR DESCRIPTION
The `node-soap@0.8.0` package on npm contains an `.idea` folder with a bunch of files that are not needed to use the `soap` module.