### PR TITLE
Make sure wsdl:import is not overwritten by xsd:import

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -428,7 +428,8 @@ PortElement.prototype.addChild = function(child) {
 DefinitionsElement.prototype.addChild = function(child) {
   var self = this;
   if (child instanceof TypesElement) {
-    self.schemas = child.schemas;
+    // Merge types.schemas into definitions.schemas
+    _.merge(self.schemas, child.schemas);
   }
   else if (child instanceof MessageElement) {
     self.messages[child.$name] = child;
@@ -1803,6 +1804,7 @@ WSDL.prototype._xmlnsMap = function() {
       case "http://xml.apache.org/xml-soap" : // apachesoap
       case "http://schemas.xmlsoap.org/wsdl/" : // wsdl
       case "http://schemas.xmlsoap.org/wsdl/soap/" : // wsdlsoap
+      case "http://schemas.xmlsoap.org/wsdl/soap12/": // wsdlsoap12
       case "http://schemas.xmlsoap.org/soap/encoding/" : // soapenc
       case "http://www.w3.org/2001/XMLSchema" : // xsd
         continue;
@@ -1829,6 +1831,7 @@ function open_wsdl(uri, options, callback) {
 
   var wsdl;
   if (!/^http/.test(uri)) {
+    debug('Reading file: %s', uri);
     fs.readFile(uri, 'utf8', function(err, definition) {
       if (err) {
         callback(err);
@@ -1840,6 +1843,7 @@ function open_wsdl(uri, options, callback) {
     });
   }
   else {
+    debug('Reading url: %s', uri);
     http.request(uri, null /* options */, function(err, response, definition) {
       if (err) {
         callback(err);

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -53,6 +53,8 @@ wsdlStrictTests['should catch parse error'] = function(done) {
 wsdlStrictTests['should parse external wsdl'] = function(done) {
   soap.createClient(__dirname+'/wsdl/wsdlImport/main.wsdl', {strict: true}, function(err, client){
     assert.ok(!err);
+    assert.deepEqual(Object.keys(client.wsdl.definitions.schemas),
+      ['http://example.com/', 'http://schemas.microsoft.com/2003/10/Serialization/Arrays']);
     assert.equal(typeof client.getLatestVersion, 'function');
     done();
   });

--- a/test/wsdl/connection/econnrefused.wsdl
+++ b/test/wsdl/connection/econnrefused.wsdl
@@ -9,7 +9,7 @@
 
     <types>
       <xsd:schema>
-        <xsd:import namespace="http://web.strongkeylite.strongauth.com/" schemaLocation="https://sa.dev.recurly.net:443/strongkeyliteWAR/EncryptionService?xsd=1"></xsd:import>
+        <xsd:import namespace="http://web.strongkeylite.strongauth.com/" schemaLocation="http://localhost:1?xsd=1"></xsd:import>
       </xsd:schema>
     </types>
 

--- a/test/wsdl/wsdlImport/sub.wsdl
+++ b/test/wsdl/wsdlImport/sub.wsdl
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?><wsdl:definitions name="IUserRemoteService" targetNamespace="http://example.com/" xmlns:ns1="http://example.com/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <wsdl:types>
 <xs:schema elementFormDefault="unqualified" targetNamespace="http://example.com/" version="1.0" xmlns:tns="http://example.com/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:import schemaLocation="./xsd.xsd" namespace="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
 
 <xs:element name="getLatestVersion" type="tns:getLatestVersion" />
 <xs:element name="getLatestVersionResponse" type="tns:getLatestVersionResponse" />

--- a/test/wsdl/wsdlImport/xsd.xsd
+++ b/test/wsdl/wsdlImport/xsd.xsd
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema elementFormDefault="qualified"
+           targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/Arrays"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+    <xs:complexType name="ArrayOfstring">
+        <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="string"
+                        nillable="true" type="xs:string"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:element name="ArrayOfstring" nillable="true" type="tns:ArrayOfstring"/>
+</xs:schema>


### PR DESCRIPTION
This PR fixes an issue in the WSDL parsing where wsdl:import was overwritten by xsd imports.