### PR TITLE
Add ability to customize http client/request lib

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -11,7 +11,7 @@ function findKey(obj, val) {
       return n;
 }
 
-var http = require('./http'),
+var HttpClient = require('./http'),
   assert = require('assert'),
   events = require('events'),
   util = require('util'),
@@ -25,6 +25,7 @@ var Client = function(wsdl, endpoint, options) {
   this.wsdl = wsdl;
   this._initializeOptions(options);
   this._initializeServices(endpoint);
+  this.httpClient = options.httpClient || new HttpClient(options);
 };
 util.inherits(Client, events.EventEmitter);
 
@@ -213,7 +214,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
   self.emit('message', message);
   self.emit('request', xml);
 
-  req = http.request(location, xml, function(err, response, body) {
+  req = self.httpClient.request(location, xml, function(err, response, body) {
     var result;
     var obj;
     self.lastResponse = body;
@@ -267,7 +268,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
 
       callback(null, result, body, obj.Header);
     }
-  }, headers, options);
+  }, headers, options, self);
 
   // Added mostly for testability, but possibly useful for debugging
   self.lastRequestHeaders = req.headers;

--- a/lib/http.js
+++ b/lib/http.js
@@ -7,10 +7,31 @@
 
 var url = require('url');
 var req = require('request');
+var debug = require('debug')('node-soap');
 
 var VERSION = require('../package.json').version;
 
-var httpRequest = function httpRequest(rurl, data, callback, exheaders, exoptions) {
+/**
+ * A class representing the http client
+ * @param {Object} [options] Options object. It allows the customization of
+ * `request` module
+ *
+ * @constructor
+ */
+function HttpClient(options) {
+  options = options || {};
+  this._request = options.request || req;
+}
+
+/**
+ * Build the HTTP request (method, uri, headers, ...)
+ * @param {String} rurl The resource url
+ * @param {Object|String} data The payload
+ * @param {Object} exheaders Extra http headers
+ * @param {Object} exoptions Extra options
+ * @returns {Object} The http request object for the `request` module
+ */
+HttpClient.prototype.buildRequest = function(rurl, data, exheaders, exoptions) {
   var curl = url.parse(rurl);
   var secure = curl.protocol === 'https:';
   var host = curl.hostname;
@@ -19,7 +40,7 @@ var httpRequest = function httpRequest(rurl, data, callback, exheaders, exoption
   var method = data ? 'POST' : 'GET';
   var headers = {
     'User-Agent': 'node-soap/' + VERSION,
-    'Accept' : 'text/html,application/xhtml+xml,application/xml,text/xml;q=0.9,*/*;q=0.8',
+    'Accept': 'text/html,application/xhtml+xml,application/xml,text/xml;q=0.9,*/*;q=0.8',
     'Accept-Encoding': 'none',
     'Accept-Charset': 'utf-8',
     'Connection': 'close',
@@ -33,7 +54,9 @@ var httpRequest = function httpRequest(rurl, data, callback, exheaders, exoption
   }
 
   exheaders = exheaders || {};
-  for (attr in exheaders) { headers[attr] = exheaders[attr]; }
+  for (attr in exheaders) {
+    headers[attr] = exheaders[attr];
+  }
 
   var options = {
     uri: curl,
@@ -41,36 +64,54 @@ var httpRequest = function httpRequest(rurl, data, callback, exheaders, exoption
     headers: headers,
     followAllRedirects: true
   };
-  
+
   if (headers.Connection === 'keep-alive') {
     options.body = data;
   }
 
   exoptions = exoptions || {};
-  for (attr in exoptions) { options[attr] = exoptions[attr]; }
-
-  var request = req(options, function (error, res, body) {
-    if (error) {
-      callback(error);
-    } else {
-      if (typeof body === 'string') {
-        // Remove any extra characters that appear before or after the SOAP
-        // envelope.
-        var match = body.match(/(?:<\?[^?]*\?>[\s]*)?<([^:]*):Envelope([\S\s]*)<\/\1:Envelope>/i);
-        if (match) {
-          body = match[0];
-        }
-      }
-      request.on('error', callback);
-      callback(null, res, body);
-    }
-  });
-  
-  if (headers.Connection !== 'keep-alive') {
-    request.end(data);
+  for (attr in exoptions) {
+    options[attr] = exoptions[attr];
   }
-  
-  return request;
+  debug('Http request: %j', options);
+  return options;
 };
 
-exports.request = httpRequest;
+/**
+ * Handle the http response
+ * @param {Object} The req object
+ * @param {Object} res The res object
+ * @param {Object} body The http body
+ * @param {Object} The parsed body
+ */
+HttpClient.prototype.handleResponse = function(req, res, body) {
+  debug('Http response body: %j', body);
+  if (typeof body === 'string') {
+    // Remove any extra characters that appear before or after the SOAP
+    // envelope.
+    var match = body.match(/(?:<\?[^?]*\?>[\s]*)?<([^:]*):Envelope([\S\s]*)<\/\1:Envelope>/i);
+    if (match) {
+      body = match[0];
+    }
+  }
+  return body;
+};
+
+HttpClient.prototype.request = function(rurl, data, callback, exheaders, exoptions) {
+  var self = this;
+  var options = self.buildRequest(rurl, data, exheaders, exoptions);
+  var headers = options.headers;
+  var req = self._request(options, function(err, res, body) {
+    if (err) {
+      return callback(err);
+    }
+    body = self.handleResponse(req, res, body);
+    callback(null, res, body);
+  });
+  if (headers.Connection !== 'keep-alive') {
+    req.end(data);
+  }
+  return req;
+};
+
+module.exports = HttpClient;

--- a/lib/soap.js
+++ b/lib/soap.js
@@ -7,6 +7,7 @@
 
 var Client = require('./client').Client,
   Server = require('./server').Server,
+  HttpClient = require('./http'),
   security = require('./security'),
   passwordDigest = require('./utils').passwordDigest,
   open_wsdl = require('./wsdl').open_wsdl,
@@ -74,3 +75,8 @@ exports.createClient = createClient;
 exports.passwordDigest = passwordDigest;
 exports.listen = listen;
 exports.WSDL = WSDL;
+
+// Export Client and Server to allow customization
+exports.Server = Server;
+exports.Client = Client;
+exports.HttpClient = HttpClient;

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -9,7 +9,7 @@
 
 var sax = require('sax');
 var inherits = require('util').inherits;
-var http = require('./http');
+var HttpClient = require('./http');
 var fs = require('fs');
 var url = require('url');
 var path = require('path');
@@ -1844,7 +1844,8 @@ function open_wsdl(uri, options, callback) {
   }
   else {
     debug('Reading url: %s', uri);
-    http.request(uri, null /* options */, function(err, response, definition) {
+    var httpClient = new HttpClient(options);
+    httpClient.request(uri, null /* options */, function(err, response, definition) {
       if (err) {
         callback(err);
       } else if (response && response.statusCode === 200) {

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -42,6 +42,33 @@ describe('SOAP Client', function() {
     assert(!called);
   });
 
+  it('should allow customization of httpClient', function(done) {
+    var myHttpClient =  {
+      request: function() {}
+    };
+    soap.createClient(__dirname + '/wsdl/default_namespace.wsdl',
+      {httpClient: myHttpClient},
+      function(err, client) {
+        assert.ok(client);
+        assert.ok(!err);
+        assert.equal(client.httpClient, myHttpClient);
+        done();
+      });
+  });
+
+  it('should allow customization of request for http client', function(done) {
+    var myRequest = function() {
+    };
+    soap.createClient(__dirname + '/wsdl/default_namespace.wsdl',
+      {request: myRequest},
+      function(err, client) {
+        assert.ok(client);
+        assert.ok(!err);
+        assert.equal(client.httpClient._request, myRequest);
+        done();
+      });
+  });
+
   it('should set binding style to "document" by default if not explicitly set in WSDL, per SOAP spec', function (done) {
     soap.createClient(__dirname+'/wsdl/binding_document.wsdl', function(err, client) {
       assert.ok(client);


### PR DESCRIPTION
This PR refactors the http client into a class and add options to customize the `httpClient` or `request`. It makes the module extensible.  In my case, I need this change for two purposes:

- Be able to mock up the soap req/res over http
- Be able to register async hooks to the http calls to allow custom handling of http related security, dynamic headers and other mediations. 