### PR TITLE
Issue 537: Take namespaces configured to be ignored into account

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1063,7 +1063,6 @@ var WSDL = function(definition, uri, options) {
 };
 
 WSDL.prototype.ignoredNamespaces = ['tns', 'targetNamespace', 'typedNamespace'];
-WSDL.prototype._ignoredSchemaNamespaces = ['tns', 'xs', 'xsd'];
 
 WSDL.prototype.valueKey = '$value';
 WSDL.prototype.xmlKey = '$xml';
@@ -1145,37 +1144,6 @@ WSDL.prototype.describeServices = function() {
     services[name] = service.description(this.definitions);
   }
   return services;
-};
-
-/**
- * Returns true if a schema namespace needs to be ignored.
- * 
- * @method shouldIgnoreNamespace
- * @param {Object} schema   The parsed WSDL Schema object.
- */
-WSDL.prototype.shouldIgnoreNamespace = function(schema) {
-  if (schema && typeof schema.xmlns === 'object') {
-    // get the keys from schema.xmlns object (something like xs, xsd or custom)
-    var schemaXmlns = Object.keys(schema.xmlns);
-    var schemaXmlnsLength = schemaXmlns.length;
-    if (schemaXmlnsLength > 0) {
-      var count = 0;
-      // loop through the keys
-      for (var key in schemaXmlns) {
-        var xmlns = schemaXmlns[key];
-        // if the key exists in the default ignoredSchemaNamespaces, add it to the count
-        if (this._ignoredSchemaNamespaces.indexOf(xmlns) > -1) {
-          count++;
-        }
-      }
-      // if the count is equal to the length, don't add the namespace
-      if(count === schemaXmlnsLength) {
-        return true;
-      }
-    }
-  }
-
-  return false;
 };
 
 WSDL.prototype.toXML = function() {
@@ -1490,12 +1458,11 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsA
   var qualified = schema && schema.$elementFormDefault === 'qualified';
   var parts = [];
   var prefixNamespace = (namespace || qualified) && namespace !== 'xmlns';
-  var isNamespaceIgnored = this.shouldIgnoreNamespace(schema);
 
   var xmlnsAttrib = '';
   if (xmlns && first) {
 
-    if (prefixNamespace && (!isNamespaceIgnored || this.ignoredNamespaces.indexOf(namespace) === -1)) {
+    if (prefixNamespace && this.options.ignoredNamespaces.indexOf(namespace) === -1) {
       // resolve the prefix namespace
       xmlnsAttrib += ' xmlns:' + namespace + '="' + xmlns + '"';
     }
@@ -1511,7 +1478,7 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsA
   }
 
   var ns = '';
-  if (prefixNamespace && ((qualified || first) || soapHeader) && (!isNamespaceIgnored || this.ignoredNamespaces.indexOf(namespace) === -1)) {
+  if (prefixNamespace && ((qualified || first) || soapHeader) && this.options.ignoredNamespaces.indexOf(namespace) === -1) {
     // prefix element
     ns = namespace.indexOf(":") === -1 ? namespace + ':' : namespace;
   }

--- a/test/request-response-samples/GetAccountXml__non_xmlns_attributes_should_be_returned/wsdl_options.json
+++ b/test/request-response-samples/GetAccountXml__non_xmlns_attributes_should_be_returned/wsdl_options.json
@@ -1,0 +1,6 @@
+{
+  "ignoredNamespaces": {
+    "namespaces": ["targetNamespace", "typedNamespace"],
+    "override": "true"
+  }
+}

--- a/test/request-response-samples/GetNodes__complex_self_referencing/wsdl_options.json
+++ b/test/request-response-samples/GetNodes__complex_self_referencing/wsdl_options.json
@@ -1,0 +1,6 @@
+{
+  "ignoredNamespaces": {
+    "namespaces": ["targetNamespace", "typedNamespace"],
+    "override": "true"
+  }
+}

--- a/test/request-response-samples/readMetadata__should_respect_xsi_type_attribute/wsdl_options.json
+++ b/test/request-response-samples/readMetadata__should_respect_xsi_type_attribute/wsdl_options.json
@@ -1,0 +1,6 @@
+{
+  "ignoredNamespaces": {
+    "namespaces": ["targetNamespace", "typedNamespace"],
+    "override": "true"
+  }
+}


### PR DESCRIPTION
Please take a thorough look into the code because I had to fix 3 tests after I changed the wsdl.js. Those three tests are at the same time the tests to proof my commit works as expected. I do not understand the purpose of the shouldIgnoreNamespace method that I deleted in this commit. The reason I deleted it is described below. 

Although one can provide an array of namespaces that shall be ignored to createClient(), they are not used in objectToXml(). This commit fixes that.

Moreover it removes the shouldIgnoreNamespace() method because it makes no sense to explicitly configure namespaces to be ignored and than let some weird logic calculate if a given namespace is going to be ignored.