### PR TITLE
Use different namespace styles for SOAP Fault 1.1 and 1.2

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -30,7 +30,7 @@ var url = require('url'),
 
 try {
   compress = require("compress");
-} catch (e) {
+} catch (error) {
 }
 
 var Server = function(server, path, services, wsdl, options) {
@@ -237,15 +237,12 @@ Server.prototype._process = function(input, URL, callback) {
       }, callback, includeTimestamp);
     }
   }
-  catch (e) {
-    if (e.Fault !== undefined) {
-      // 3rd param is the NS prepended to all elements
-      // It must match the NS defined in the Envelope (set by the _envelope method)
-      var fault = self.wsdl.objectToDocumentXML("Fault", e.Fault, "soap");
-      callback(self._envelope(fault, includeTimestamp));
+  catch (error) {
+    if (error.Fault !== undefined) {
+      return self._sendError(error.Fault, callback, includeTimestamp);
     }
-    else
-      throw e;
+
+    throw error;
   }
 };
 
@@ -263,7 +260,7 @@ Server.prototype._executeMethod = function(options, callback, includeTimestamp) 
 
   try {
     method = this.services[serviceName][portName][methodName];
-  } catch (e) {
+  } catch (error) {
     return callback(this._envelope('', includeTimestamp));
   }
 
@@ -273,8 +270,7 @@ Server.prototype._executeMethod = function(options, callback, includeTimestamp) 
     handled = true;
 
     if (error && error.Fault !== undefined) {
-      var fault = self.wsdl.objectToDocumentXML("Fault", error.Fault, "soap");
-      return callback(self._envelope(fault, includeTimestamp));
+      return self._sendError(error.Fault, callback, includeTimestamp);
     }
     else if (result === undefined) {
       // Backward compatibility to support one argument callback style
@@ -332,6 +328,26 @@ Server.prototype._envelope = function(body, includeTimestamp) {
     "</soap:Body>" +
     "</soap:Envelope>";
   return xml;
+};
+
+Server.prototype._sendError = function(soapFault, callback, includeTimestamp) {
+  var self = this,
+    fault;
+
+  if (soapFault.faultcode) {
+    // Soap 1.1 error style
+    // Root element will be prependend with the soap NS
+    // It must match the NS defined in the Envelope (set by the _envelope method)
+    fault = self.wsdl.objectToDocumentXML("soap:Fault", soapFault, undefined);
+  }
+  else {
+    // Soap 1.2 error style.
+    // 3rd param is the NS prepended to all elements
+    // It must match the NS defined in the Envelope (set by the _envelope method)
+    fault = self.wsdl.objectToDocumentXML("Fault", soapFault, "soap");
+  }
+
+  return callback(self._envelope(fault, includeTimestamp));
 };
 
 exports.Server = Server;

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -18,7 +18,7 @@ test.service = {
           throw new Error('triggered server error');
         } else if (args.tickerSymbol === 'Async') {
           return cb({ price: 19.56 });
-        } else if (args.tickerSymbol === 'SOAP Fault') {
+        } else if (args.tickerSymbol === 'SOAP Fault v1.2') {
           throw {
             Fault: {
               Code: {
@@ -26,6 +26,13 @@ test.service = {
                 Subcode: { value: "rpc:BadArguments" }
               },
               Reason: { Text: "Processing Error" }
+            }
+          };
+        } else if (args.tickerSymbol === 'SOAP Fault v1.1') {
+          throw {
+            Fault: {
+              faultcode: "soap:Client.BadArguments",
+              faultstring: "Error while processing arguments"
             }
           };
         } else {
@@ -259,14 +266,37 @@ describe('SOAP Server', function() {
     });
   });
 
-  it('should return SOAP Fault body', function(done) {
+  it('should return SOAP Fault body for SOAP 1.2', function(done) {
     soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
       assert.ok(!err);
-      client.GetLastTradePrice({ tickerSymbol: 'SOAP Fault' }, function(err, response, body) {
+      client.GetLastTradePrice({ tickerSymbol: 'SOAP Fault v1.2' }, function(err, response, body) {
         assert.ok(err);
         var fault = err.root.Envelope.Body.Fault;
         assert.equal(fault.Code.Value, "soap:Sender");
         assert.equal(fault.Reason.Text, "Processing Error");
+        // Verify namespace on elements set according to fault spec 1.2
+        assert.ok(body.match(/<soap:Code>.*<\/soap:Code>/g),
+          "Body should contain Code-element with namespace");
+        assert.ok(body.match(/<soap:Reason>.*<\/soap:Reason>/g),
+          "Body should contain Reason-element with namespace");
+        done();
+      });
+    });
+  });
+
+  it('should return SOAP Fault body for SOAP 1.1', function(done) {
+    soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
+      assert.ok(!err);
+      client.GetLastTradePrice({ tickerSymbol: 'SOAP Fault v1.1' }, function(err, response, body) {
+        assert.ok(err);
+        var fault = err.root.Envelope.Body.Fault;
+        assert.equal(fault.faultcode, "soap:Client.BadArguments");
+        assert.equal(fault.faultstring, "Error while processing arguments");
+        // Verify namespace on elements set according to fault spec 1.1
+        assert.ok(body.match(/<faultcode>.*<\/faultcode>/g),
+          "Body should contain faultcode-element without namespace");
+        assert.ok(body.match(/<faultstring>.*<\/faultstring>/g),
+          "Body should contain faultstring-element without namespace");
         done();
       });
     });


### PR DESCRIPTION
Updated the fault handler in the server component to support both the fault style for SOAP 1.1 and SOAP 1.2. The main difference is that for soap 1.1 only the root element should have a namespace, but for 1.2 every element should have the same namespace.

## SOAP 1.1
```xml
<soap:Fault>
  <faultcode>soap:Client.BadArguments</faultcode>
</soap:Fault>
```
http://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383507

## SOAP 1.2
```xml
<soap:Fault>
  <soap:Code>
    <soap:Value>soap:Sender</soap:Value>
    <soap:Subcode>
       <soap:Value>pc:BadArguments</soap:Value>
    </soap:Subcode>
</soap:Fault>
```

http://www.w3.org/TR/soap12-part1/#soapfault