### PR TITLE
Fix a typo in WSDL#findChildParameterObject

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1673,7 +1673,7 @@ WSDL.prototype.findChildParameterObject = function(parameterTypeObj, childName) 
       i = 0,
       child;
 
-  if(parameterTypeObj.$lookupTypes && Array.isArray(parameterTypeObj.$lookupTypes && parameterTypeObj.$lookupTypes.length)) {
+  if(parameterTypeObj.$lookupTypes && Array.isArray(parameterTypeObj.$lookupTypes) && parameterTypeObj.$lookupTypes.length) {
     var types = parameterTypeObj.$lookupTypes;
 
     for(i = 0; i < types.length; i++) {


### PR DESCRIPTION
I'm not quite sure what impact this typo had, but it's obviously wrong.

I stumbled over this when reviewing the code changes between 0.6.0 and 0.6.1.