### PR TITLE
Fix for null in array

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1503,11 +1503,12 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsA
   }
 
   if (Array.isArray(obj)) {
-    for (var i = 0, item; item = obj[i]; i++) {
+    for (var i = 0, item; i < obj.length; i++) {
+      item = obj[i];
       var arrayAttr = self.processAttributes(item),
           correctOuterNamespace = parentNamespace || ns; //using the parent namespace if given
 
-      parts.push(['<', correctOuterNamespace, name, arrayAttr, xmlnsAttrib, '>'].join(''));
+      parts.push(['<', correctOuterNamespace, name, arrayAttr, xmlnsAttrib, (item === null ? ' xsi:nil="true"' : ''), '>'].join(''));
       parts.push(self.objectToXML(item, name, namespace, xmlns, false, null, parameterTypeObject, ancXmlns));
       parts.push(['</', correctOuterNamespace, name, '>'].join(''));
     }


### PR DESCRIPTION
Hello,

I found a problem when the module receives null in array.

https://gist.github.com/allancarvalho/6a3e0cb0efecc883bf19

I need to generate the xml like soap.xml (gist).
In line 21 has a empty tag and the module remove this like soap_generated.xml (gist).

The part of my javascript object that generated the problem is:
var records = [['allan_tk@msn.com', null, 'I', '0'], ['fulano@test.com', 'FULANO', 'I', '0']];

In line 36 the module generated the correct tag when it receives null. 
The problem occurred when I send null in array.

This pull request resolve this.






