### PR TITLE
only supply timestamp when a password digest is used to avoid schema validation errors

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,6 @@
+This is a freezed node-soap v0.9.1 with PR #691 accepted. This package is for personal proposes only.
+See [PR #691](https://github.com/vpulim/node-soap/pull/691) at node-soap's github for more details.
+
 # Soap [![NPM version][npm-image]][npm-url] [![Downloads][downloads-image]][npm-url] [![Build Status][travis-image]][travis-url]
 > A SOAP client and server for node.js.
 

--- a/lib/security/WSSecurity.js
+++ b/lib/security/WSSecurity.js
@@ -28,7 +28,14 @@ WSSecurity.prototype.toXML = function() {
 
   var password;
   if(this._passwordType === 'PasswordText') {
-    password = "<wsse:Password>" + this._password + "</wsse:Password>";
+    password = "<wsse:Password Type=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText\">" + this._password + "</wsse:Password>";
+
+    return  "<wsse:Security xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\" xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\">" +
+      "<wsse:UsernameToken xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\" wsu:Id=\"SecurityToken-" + created + "\">" +
+      "<wsse:Username>" + this._username + "</wsse:Username>" +
+      password +
+      "</wsse:UsernameToken>" +
+      "</wsse:Security>";
   } else {
     // nonce = base64 ( sha1 ( created + random ) )
     var nHash = crypto.createHash('sha1');
@@ -36,19 +43,19 @@ WSSecurity.prototype.toXML = function() {
     var nonce = nHash.digest('base64');
     password = "<wsse:Password Type=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest\">" + passwordDigest(nonce, created, this._password) + "</wsse:Password>" +
       "<wsse:Nonce EncodingType=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary\">" + nonce + "</wsse:Nonce>";
-  }
 
-  return  "<wsse:Security xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\" xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\">" +
-    "<wsu:Timestamp wsu:Id=\"Timestamp-" + created + "\">" +
-    "<wsu:Created>" + created + "</wsu:Created>" +
-    "<wsu:Expires>" + expires + "</wsu:Expires>" +
-    "</wsu:Timestamp>" +
-    "<wsse:UsernameToken xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\" wsu:Id=\"SecurityToken-" + created + "\">" +
-    "<wsse:Username>" + this._username + "</wsse:Username>" +
-    password +
-    "<wsu:Created>" + created + "</wsu:Created>" +
-    "</wsse:UsernameToken>" +
-    "</wsse:Security>";
+    return  "<wsse:Security xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\" xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\">" +
+      "<wsu:Timestamp wsu:Id=\"Timestamp-" + created + "\">" +
+      "<wsu:Created>" + created + "</wsu:Created>" +
+      "<wsu:Expires>" + expires + "</wsu:Expires>" +
+      "</wsu:Timestamp>" +
+      "<wsse:UsernameToken xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\" wsu:Id=\"SecurityToken-" + created + "\">" +
+      "<wsse:Username>" + this._username + "</wsse:Username>" +
+      password +
+      "<wsu:Created>" + created + "</wsu:Created>" +
+      "</wsse:UsernameToken>" +
+      "</wsse:Security>";
+  }
 };
 
 module.exports = WSSecurity;

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "soap",
-  "version": "0.9.1",
-  "description": "A minimal node SOAP client",
+  "name": "soap-passwordtext",
+  "version": "0.0.1",
+  "description": "A freezed node-soap v0.9.1 with PR #691 accepted. This package is for personal proposes only.",
   "engines": {
     "node": ">=0.8.0"
   },
-  "author": "Vinay Pulim <v@pulim.com>",
+  "author": "J. Félix Ontañón <felixonta@gmail.com>",
   "dependencies": {
     "debug": "~0.7.4",
     "lodash": "~2.4.1",
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/milewise/node-soap.git"
+    "url": "https://github.com/fontanon/node-soap.git"
   },
   "main": "./index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soap-passwordtext",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A freezed node-soap v0.9.1 with PR #691 accepted. This package is for personal proposes only.",
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
The current WSSecurity make auth requests to fail for PasswordText authentication because of wsu:Timestamp included. Find below the server response (apache cfx).

```xml
<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
    <soap:Body>
        <soap:Fault>
            <faultcode xmlns:ns1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">ns1:FailedAuthentication</faultcode>
            <faultstring>The security token could not be authenticated or authorized</faultstring>
        </soap:Fault>
    </soap:Body>
</soap:Envelope>
```