### PR TITLE
Prevent sending Object prototype methods as XML

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1451,6 +1451,7 @@ WSDL.prototype.objectToRpcXML = function(name, params, namespace, xmlns) {
   parts.push(['<', namespace, name, '>'].join(''));
 
   for (var key in params) {
+    if (!params.hasOwnProperty(key)) continue;
     if (key !== nsAttrName) {
       var value = params[key];
       parts.push(['<', key, '>'].join(''));
@@ -1513,6 +1514,7 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, first, xmlnsA
     }
   } else if (typeof obj === 'object') {
     for (name in obj) {
+      if (!obj.hasOwnProperty(name)) continue;
       //don't process attributes as element
       if (name === self.options.attributesKey) {
         continue;


### PR DESCRIPTION
Adds `Object.prototype.hasOwnProperty` check in `WSDL.prototype.objectToRpcXML` and `WSDL.prototype.objectToXML`.

This prevents sending arbitrary Javascript as XML nodes when working with Classes (`var clientArgs = new Order(ordNum, qty)`).