### PR TITLE
Override default namespace for xmlns:soap and set Content-Type as application/soap+xml (Issue #719, #720)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -186,7 +186,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
     message = self.wsdl.objectToDocumentXML(input.$name, args, input.targetNSAlias, input.targetNamespace, (input.$type || input.$lookupType));
   }
   xml = "<soap:Envelope " +
-    "xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" " +
+    "xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" " +
     "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
     encoding +
     this.wsdl.xmlnsInEnvelope + '>' +

--- a/lib/client.js
+++ b/lib/client.js
@@ -186,7 +186,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
     message = self.wsdl.objectToDocumentXML(input.$name, args, input.targetNSAlias, input.targetNamespace, (input.$type || input.$lookupType));
   }
   xml = "<soap:Envelope " +
-    "xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" " +
+    ((this.wsdl.xmlnsInEnvelope.indexOf("xmlns:soap") === -1) ? "xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" " : '') +
     "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
     encoding +
     this.wsdl.xmlnsInEnvelope + '>' +

--- a/lib/client.js
+++ b/lib/client.js
@@ -150,7 +150,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
     soapAction,
     alias = findKey(defs.xmlns, ns),
     headers = {
-      'Content-Type': "text/xml; charset=utf-8"
+      'Content-Type': "application/soap+xml; charset=utf-8"
     };
 
   if (this.SOAPAction) {


### PR DESCRIPTION
I have compared for namespace 'xmlns:soap'. If it is already there in 'this.wsdl.xmlnsInEnvelope', then that will be used in place of default one. Also, since SOAP 1.2 applications require Content-Type as 'application/soap+xml', I have changed the content type. Please let me know if there are issues with that.