### PR TITLE
Resolve element references when other types are referenced

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1724,7 +1724,7 @@ WSDL.prototype.findChildParameterObject = function(parameterTypeObj, childName) 
       child,
       ref;
 
-  if(parameterTypeObj.$lookupTypes && Array.isArray(parameterTypeObj.$lookupTypes) && parameterTypeObj.$lookupTypes.length) {
+  if(Array.isArray(parameterTypeObj.$lookupTypes) && parameterTypeObj.$lookupTypes.length) {
     var types = parameterTypeObj.$lookupTypes;
 
     for(i = 0; i < types.length; i++) {
@@ -1734,51 +1734,45 @@ WSDL.prototype.findChildParameterObject = function(parameterTypeObj, childName) 
         found = typeObj;
         break;
       }
-      if(typeObj.$ref) {
-        ref = splitNSName(typeObj.$ref);
-        if (ref.name === childName) {
-          found = typeObj;
-          break;
-        }
-      }
     }
-  } else {
-    var object = parameterTypeObj;
-    if (object.$name === childName) {
+  }
+
+  var object = parameterTypeObj;
+  if (object.$name === childName) {
+    return object;
+  }
+  if (object.$ref) {
+    ref = splitNSName(object.$ref);
+    if (ref.name === childName) {
       return object;
     }
-    if (object.$ref) {
-      ref = splitNSName(object.$ref);
-      if (ref.name === childName) {
-        return object;
+  }
+
+  if (object.children) {
+    for (i = 0, child; child = object.children[i]; i++) {
+      found = this.findChildParameterObject(child, childName);
+      if (found) {
+        break;
       }
-    }
 
-    if (object.children) {
-      for (i = 0, child; child = object.children[i]; i++) {
-        found = this.findChildParameterObject(child, childName);
-        if (found) {
-          break;
-        }
+      if (child.$base) {
+        var childNameSpace = child.$base.substr(0, child.$base.indexOf(':')),
+          childXmlns = this.definitions.xmlns[childNameSpace];
 
-        if(child.$base) {
-          var childNameSpace = child.$base.substr(0, child.$base.indexOf(':')),
-            childXmlns = this.definitions.xmlns[childNameSpace];
+        var foundBase = this.findChildParameterObjectFromSchema(child.$base.substr(child.$base.indexOf(':') + 1), childXmlns);
 
-          var foundBase = this.findChildParameterObjectFromSchema(child.$base.substr(child.$base.indexOf(':') + 1), childXmlns);
+        if (foundBase) {
+          found = this.findChildParameterObject(foundBase, childName);
 
-          if (foundBase) {
-            found = this.findChildParameterObject(foundBase, childName);
-
-            if (found) {
-              found.$baseNameSpace = childNameSpace;
-              found.$type = childNameSpace + ':' + childName;
-              break;
-            }
+          if (found) {
+            found.$baseNameSpace = childNameSpace;
+            found.$type = childNameSpace + ':' + childName;
+            break;
           }
         }
       }
     }
+
   }
 
   return found;

--- a/test/wsdl/elementref/bar.xsd
+++ b/test/wsdl/elementref/bar.xsd
@@ -12,6 +12,7 @@
                              maxOccurs="unbounded">
                 </xsd:element>
             </xsd:sequence>
+            <xsd:attribute name="id" type="xsd:ID"/>
         </xsd:complexType>
     </xsd:element>
     <xsd:element name="fooRs">
@@ -21,6 +22,7 @@
                              maxOccurs="unbounded">
                 </xsd:element>
             </xsd:sequence>
+            <xsd:attribute name="id" type="xsd:ID"/>
         </xsd:complexType>
     </xsd:element>
 </xsd:schema>


### PR DESCRIPTION
This is a follow-up to https://github.com/vpulim/node-soap/pull/700. It fixes the case where the element is defined with a complexType that references other types.