### PR TITLE
Adding gitter badge in preparation of disabling issues.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,5 @@
-# Soap [![NPM version][npm-image]][npm-url] [![Downloads][downloads-image]][npm-url] [![Build Status][travis-image]][travis-url]
+# Soap [![NPM version][npm-image]][npm-url] [![Downloads][downloads-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Gitter chat][gitter-image]][gitter-url]
+
 > A SOAP client and server for node.js.
 
 This module lets you connect to web services using SOAP.  It also provides a server that allows you to run your own SOAP services.
@@ -18,6 +19,15 @@ Install with [npm](http://github.com/isaacs/npm):
 ```
   npm install soap
 ```
+
+## Where can I file an issue?
+
+We've disabled issues in the repository and are now solely reviewing pull requests.  The reasons why we disabled issues can be found here [#731](https://github.com/vpulim/node-soap/pull/731).
+
+If you're in need of support we encourage you to join us and other `node-soap` users on gitter:
+
+[![Gitter chat][gitter-image]][gitter-url]
+
 ## Module
 
 ### soap.createClient(url[, options], callback) - create a new SOAP client from a WSDL url. Also supports a local filesystem path.
@@ -505,3 +515,6 @@ ignoredNamespaces: true
 
 [travis-url]: https://travis-ci.org/vpulim/node-soap
 [travis-image]: http://img.shields.io/travis/vpulim/node-soap.svg
+
+[gitter-url]: https://gitter.im/vpulim/node-soap
+[gitter-image]: https://badges.gitter.im/vpulim/node-soap.png


### PR DESCRIPTION
Here are the main reasons we're doing this:

* We get lots of issues from users that are of the 'Hey debug this for me' type.
* The amount of issues we get prevents us from adequately addressing PRs.
* If we solely focused our efforts on PRs, we'd likely get more PRs in and advance the library faster.
* Given the volume of issues we receive and the number of open issues we have open, users are less inclined to use  in the fear that is is overly buggy.
* We have so many open issues it's almost impossible to know which ones are still valid.
* Github issues aren't the best mechanism for community support.  Something like Google Groups or Gitter would best serve the interests of most issues we receive.