### PR TITLE
Increasing mocha test timeout to 10 seconds.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "pretest": "jshint index.js lib test",
-    "test": "mocha test/*-test.js test/security/*.js"
+    "test": "mocha --timeout 10000 test/*-test.js test/security/*.js"
   },
   "keywords": [
     "soap"


### PR DESCRIPTION
* I believe garbage collection was causing some of the request response sample tests to take a long time.  This happened randomly.