### PR TITLE
Fixed problem with converting objects inside $value

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1548,9 +1548,14 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, isFirst, xmln
       if (name === self.options.valueKey) {
         //If the value is an array or an object, go through it.
         if (typeof obj[name] === 'object')
-          return self.objectToXML(child, name, namespace, xmlns, false, null, parameterTypeObject, ancXmlns);
+        {
+          return self.objectToXML(obj[name], name, namespace, xmlns, false, null, parameterTypeObject, ancXmlns);
+        }
         //Otherwise, return it as is.
-        return xmlEscape(obj[name]);
+        else
+        {
+          return xmlEscape(obj[name]);
+        }
       }
 
       var child = obj[name];

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1544,8 +1544,12 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, isFirst, xmln
       if (name === self.options.xmlKey){
         return obj[name];
       }
-      //Its the value of an item. Return it directly.
+      //Its the value of an item.
       if (name === self.options.valueKey) {
+        //If the value is an array or an object, go through it.
+        if (typeof obj[name] === 'object')
+          return self.objectToXML(child, name, namespace, xmlns, false, null, parameterTypeObject, ancXmlns);
+        //Otherwise, return it as is.
         return xmlEscape(obj[name]);
       }
 


### PR DESCRIPTION
This is my input:
```
{
    "simpleParam1": "arp",
    "simpleParam2": "xyz",
    "arrayParam": {
        "propArray": [
            {
                "name": "prop1",
                "value": "123"
            },
            {
                "name": "prop2",
                "value": "789"
            }
        ]
    }
}
```

If I convert it as is, it works just fine. However, I want to add an attribute: ```xmlns=""```
So my input looks like this:

```
{
    "exampleAction": {
        "simpleParam1": {
            "$value": "abc",
            "attributes": {
                "xmlns": ""
            }
        },
        "simpleParam2": {
            "$value": "xyz",
            "attributes": {
                "xmlns": ""
            }
        },
        "arrayParam": {
            "$value": {
                "propArray": [
                    {
                        "name": "prop1",
                        "value": "123"
                    },
                    {
                        "name": "prop2",
                        "value": "789"
                    }
                ]
            },
            "attributes": {
                "xmlns": ""
            }
        }
    }
}
```

Before: would convert to:
```
<exampleAction xmlns="http://ws.example.net/">
	<simpleParam1 xmlns="">abc</simpleParam1>
	<simpleParam2 xmlns="">xyz</simpleParam2>
	<arrayParam xmlns="">
		[object Object]
	</arrayParam>
</exampleAction>
```

Fixed: would convert to (as expected)
```
<exampleAction xmlns="http://ws.example.net/">
	<simpleParam1 xmlns="">abc</simpleParam1>
	<simpleParam2 xmlns="">xyz</simpleParam2>
	<arrayParam xmlns="">
		<propArray>
			<name>prop1</name>
			<value>123</value>
		</propArray>
		<propArray>
			<name>prop2</name>
			<value>789</value>
		</propArray>
	</arrayParam>
</exampleAction>
```