### PR TITLE
correct merging multiple XSDs from the same url namespace

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -21,7 +21,7 @@ var selectn = require('selectn');
 var merge = require('merge');
 
 //shim defaultsDeep (it's not in lodash 2.x but is in lodash 3.x)
-var defaultsDeep = _.partialRight(_.merge, _.defaults);
+var defaultsDeep = _.partialRight(_.merge, _.default);
 
 var mergeMethod = merge.recursive;
 function set_merge_method(method) {

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -20,6 +20,16 @@ var _ = require('lodash');
 var selectn = require('selectn');
 var merge = require('merge');
 
+var mergeMethod = merge.recursive;
+function set_merge_method(method) {
+  if (method === 'lodash') {
+    mergeMethod = _.merge;
+  } else if (method === 'merge') {
+    mergeMethod = merge.recursive;
+  }
+}
+
+
 var Primitives = {
   string: 1,
   boolean: 1,
@@ -1136,7 +1146,7 @@ WSDL.prototype._processNextInclude = function(includes, callback) {
       return callback(err);
     }
     if(wsdl.definitions instanceof DefinitionsElement){
-      merge.recursive(self.definitions, wsdl.definitions);
+      mergeMethod(self.definitions, wsdl.definitions);
     }else{
       self.definitions.schemas[include.namespace || wsdl.definitions.$targetNamespace] = deepMerge(self.definitions.schemas[include.namespace || wsdl.definitions.$targetNamespace], wsdl.definitions);
     }
@@ -1958,5 +1968,13 @@ function open_wsdl(uri, options, callback) {
   return wsdl;
 }
 
+function clear_cache() {
+  WSDL_CACHE = {};
+}
+
 exports.open_wsdl = open_wsdl;
 exports.WSDL = WSDL;
+exports.clear_cache = clear_cache;
+
+//for test purpose only, should be removed
+exports.set_merge_method = set_merge_method;

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -18,6 +18,7 @@ var stripBom = require('strip-bom');
 var debug = require('debug')('node-soap');
 var _ = require('lodash');
 var selectn = require('selectn');
+var merge = require('merge');
 
 var Primitives = {
   string: 1,
@@ -1135,7 +1136,7 @@ WSDL.prototype._processNextInclude = function(includes, callback) {
       return callback(err);
     }
     if(wsdl.definitions instanceof DefinitionsElement){
-      _.merge(self.definitions, wsdl.definitions);
+      merge.recursive(self.definitions, wsdl.definitions);
     }else{
       self.definitions.schemas[include.namespace || wsdl.definitions.$targetNamespace] = deepMerge(self.definitions.schemas[include.namespace || wsdl.definitions.$targetNamespace], wsdl.definitions);
     }

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -28,7 +28,7 @@ function set_merge_method(method) {
   if (method === 'lodash.merge') {
     mergeMethod = _.merge;
   } else if (method === 'lodash.defaults') {
-    mergeMethod = _.defaults;
+    mergeMethod = _.default;
   } else if (method === 'lodash.defaultsDeep') {
     mergeMethod = defaultsDeep;
   }else if (method === 'merge') {

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -20,11 +20,18 @@ var _ = require('lodash');
 var selectn = require('selectn');
 var merge = require('merge');
 
+//shim defaultsDeep (it's not in lodash 2.x but is in lodash 3.x)
+var defaultsDeep = _.partialRight(_.merge, _.defaults);
+
 var mergeMethod = merge.recursive;
 function set_merge_method(method) {
-  if (method === 'lodash') {
+  if (method === 'lodash.merge') {
     mergeMethod = _.merge;
-  } else if (method === 'merge') {
+  } else if (method === 'lodash.defaults') {
+    mergeMethod = _.defaults;
+  } else if (method === 'lodash.defaultsDeep') {
+    mergeMethod = defaultsDeep;
+  }else if (method === 'merge') {
     mergeMethod = merge.recursive;
   }
 }

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1976,7 +1976,9 @@ function open_wsdl(uri, options, callback) {
 }
 
 function clear_cache() {
-  WSDL_CACHE = {};
+  Object.keys(WSDL_CACHE).forEach(function(key) {
+    delete WSDL_CACHE[key];
+  });
 }
 
 exports.open_wsdl = open_wsdl;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "debug": "~0.7.4",
     "lodash": "~2.4.1",
+    "merge": "^1.2.0",
     "request": ">=2.9.0",
     "sax": ">=0.6",
     "selectn": "^0.9.6",

--- a/test/wsdl-parse-test.js
+++ b/test/wsdl-parse-test.js
@@ -1,10 +1,16 @@
 'use strict';
 
+var _ = require('lodash');
 var path = require('path');
+var wsdl = require('../lib/wsdl');
 var open_wsdl = require('../lib/wsdl').open_wsdl;
 var assert = require('assert');
 
 describe(__filename, function () {
+  beforeEach(function() {
+    wsdl.clear_cache();
+  });
+
   it('should parse recursive elements', function (done) {
     open_wsdl(path.resolve(__dirname, 'wsdl/recursive.wsdl'), function (err, def) {
       assert.equal(def.definitions.messages.operationRequest.parts['constraint[]'].expression,
@@ -18,6 +24,32 @@ describe(__filename, function () {
   it('should parse recursive wsdls', function (done) {
     open_wsdl(path.resolve(__dirname, 'wsdl/recursive/file.wsdl'), function (err, def) {
       // If we get here then we succeeded 
+      done( err );
+    });
+  });
+
+  it('should parse multiple xsd files with the same namespace using lodash merge', function (done) {
+    wsdl.set_merge_method('lodash');
+    open_wsdl(path.resolve(__dirname, 'wsdl/split-xsd/foo.wsdl'), function (err, def) {
+      var elementNames = _.keys(def.definitions.schemas['http://example.com/bar/xsd'].elements);
+
+      //will fail - is missing elements from bar1.xsd
+      assert.deepEqual(elementNames, ['fooRq', 'fooRs', 'paymentRq', 'paymentRs', 'requestUID']);
+
+      // If we get here then we succeeded
+      done( err );
+    });
+  });
+
+  it('should parse multiple xsd files with the same namespace using merge.recursive', function (done) {
+    wsdl.set_merge_method('merge');
+    open_wsdl(path.resolve(__dirname, 'wsdl/split-xsd/foo.wsdl'), function (err, def) {
+      var elementNames = _.keys(def.definitions.schemas['http://example.com/bar/xsd'].elements);
+
+      //contains all 5 elements
+      assert.deepEqual(elementNames, ['fooRq', 'fooRs', 'paymentRq', 'paymentRs', 'requestUID']);
+
+      // If we get here then we succeeded
       done( err );
     });
   });

--- a/test/wsdl-parse-test.js
+++ b/test/wsdl-parse-test.js
@@ -29,7 +29,46 @@ describe(__filename, function () {
   });
 
   it('should parse multiple xsd files with the same namespace using lodash merge', function (done) {
-    wsdl.set_merge_method('lodash');
+    wsdl.set_merge_method('lodash.default');
+    open_wsdl(path.resolve(__dirname, 'wsdl/split-xsd/foo.wsdl'), function (err, def) {
+      var elementNames = _.keys(def.definitions.schemas['http://example.com/bar/xsd'].elements);
+
+      //will fail - is missing elements from bar1.xsd
+      assert.deepEqual(elementNames, ['fooRq', 'fooRs', 'paymentRq', 'paymentRs', 'requestUID']);
+
+      // If we get here then we succeeded
+      done( err );
+    });
+  });
+
+  it('should parse multiple xsd files with the same namespace using lodash defaults', function (done) {
+    wsdl.set_merge_method('lodash.merge');
+    open_wsdl(path.resolve(__dirname, 'wsdl/split-xsd/foo.wsdl'), function (err, def) {
+      var elementNames = _.keys(def.definitions.schemas['http://example.com/bar/xsd'].elements);
+
+      //will fail - is missing elements from bar1.xsd
+      assert.deepEqual(elementNames, ['fooRq', 'fooRs', 'paymentRq', 'paymentRs', 'requestUID']);
+
+      // If we get here then we succeeded
+      done( err );
+    });
+  });
+
+  it('should parse multiple xsd files with the same namespace using lodash defaultsDeep', function (done) {
+    wsdl.set_merge_method('lodash.defaultsDeep');
+    open_wsdl(path.resolve(__dirname, 'wsdl/split-xsd/foo.wsdl'), function (err, def) {
+      var elementNames = _.keys(def.definitions.schemas['http://example.com/bar/xsd'].elements);
+
+      //will fail - is missing elements from bar1.xsd
+      assert.deepEqual(elementNames, ['fooRq', 'fooRs', 'paymentRq', 'paymentRs', 'requestUID']);
+
+      // If we get here then we succeeded
+      done( err );
+    });
+  });
+
+  it('should parse multiple xsd files with the same namespace using lodash defaults', function (done) {
+    wsdl.set_merge_method('lodash.merge');
     open_wsdl(path.resolve(__dirname, 'wsdl/split-xsd/foo.wsdl'), function (err, def) {
       var elementNames = _.keys(def.definitions.schemas['http://example.com/bar/xsd'].elements);
 

--- a/test/wsdl-parse-test.js
+++ b/test/wsdl-parse-test.js
@@ -29,7 +29,7 @@ describe(__filename, function () {
   });
 
   it('should parse multiple xsd files with the same namespace using lodash merge', function (done) {
-    wsdl.set_merge_method('lodash.default');
+    wsdl.set_merge_method('lodash.merge');
     open_wsdl(path.resolve(__dirname, 'wsdl/split-xsd/foo.wsdl'), function (err, def) {
       var elementNames = _.keys(def.definitions.schemas['http://example.com/bar/xsd'].elements);
 
@@ -42,7 +42,7 @@ describe(__filename, function () {
   });
 
   it('should parse multiple xsd files with the same namespace using lodash defaults', function (done) {
-    wsdl.set_merge_method('lodash.merge');
+    wsdl.set_merge_method('lodash.defaults');
     open_wsdl(path.resolve(__dirname, 'wsdl/split-xsd/foo.wsdl'), function (err, def) {
       var elementNames = _.keys(def.definitions.schemas['http://example.com/bar/xsd'].elements);
 

--- a/test/wsdl-parse-test.js
+++ b/test/wsdl-parse-test.js
@@ -67,19 +67,6 @@ describe(__filename, function () {
     });
   });
 
-  it('should parse multiple xsd files with the same namespace using lodash defaults', function (done) {
-    wsdl.set_merge_method('lodash.merge');
-    open_wsdl(path.resolve(__dirname, 'wsdl/split-xsd/foo.wsdl'), function (err, def) {
-      var elementNames = _.keys(def.definitions.schemas['http://example.com/bar/xsd'].elements);
-
-      //will fail - is missing elements from bar1.xsd
-      assert.deepEqual(elementNames, ['fooRq', 'fooRs', 'paymentRq', 'paymentRs', 'requestUID']);
-
-      // If we get here then we succeeded
-      done( err );
-    });
-  });
-
   it('should parse multiple xsd files with the same namespace using merge.recursive', function (done) {
     wsdl.set_merge_method('merge');
     open_wsdl(path.resolve(__dirname, 'wsdl/split-xsd/foo.wsdl'), function (err, def) {

--- a/test/wsdl/split-xsd/bar.xsd
+++ b/test/wsdl/split-xsd/bar.xsd
@@ -1,0 +1,27 @@
+<xsd:schema targetNamespace="http://example.com/bar/xsd"
+            elementFormDefault="qualified"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:bar="http://example.com/bar/xsd">
+    <xsd:import namespace="http://example.com/bar/xsd"
+                schemaLocation="bar1.xsd"/>
+    <xsd:element name="fooRq">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element ref="bar:paymentRq" minOccurs="0"
+                             maxOccurs="unbounded">
+                </xsd:element>
+            </xsd:sequence>
+            <xsd:attribute name="id" type="xsd:ID"/>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="fooRs">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element ref="bar:paymentRs" minOccurs="0"
+                             maxOccurs="unbounded">
+                </xsd:element>
+            </xsd:sequence>
+            <xsd:attribute name="id" type="xsd:ID"/>
+        </xsd:complexType>
+    </xsd:element>
+</xsd:schema>

--- a/test/wsdl/split-xsd/bar1.xsd
+++ b/test/wsdl/split-xsd/bar1.xsd
@@ -1,0 +1,40 @@
+<xsd:schema targetNamespace="http://example.com/bar/xsd"
+            elementFormDefault="qualified" version="2.1.4"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:bar="http://example.com/bar/xsd">
+    <xsd:element name="paymentRq">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:sequence>
+                    <xsd:element name="bankSvcRq" minOccurs="0"
+                                 maxOccurs="unbounded">
+                        <xsd:complexType>
+                            <xsd:sequence>
+                                <xsd:element ref="bar:requestUID"/>
+                            </xsd:sequence>
+                            <xsd:attribute name="Id" type="xsd:ID"/>
+                        </xsd:complexType>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="paymentRs">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:sequence>
+                    <xsd:element name="bankSvcRs" minOccurs="0"
+                                 maxOccurs="unbounded">
+                        <xsd:complexType>
+                            <xsd:sequence>
+                                <xsd:element ref="bar:requestUID"/>
+                            </xsd:sequence>
+                            <xsd:attribute name="Id" type="xsd:ID"/>
+                        </xsd:complexType>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="requestUID" type="xsd:string"/>
+</xsd:schema>

--- a/test/wsdl/split-xsd/foo.wsdl
+++ b/test/wsdl/split-xsd/foo.wsdl
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="foo"
+                  targetNamespace="http://example.com/foo/wsdl"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:ns1="http://example.com/bar/xsd"
+                  xmlns:tns="http://example.com/foo/wsdl"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/">
+    <wsdl:types>
+        <xsd:schema>
+            <xsd:import
+                    namespace="http://example.com/bar/xsd"
+                    schemaLocation="bar.xsd"/>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="fooRs">
+        <wsdl:part name="fooRs" element="ns1:fooRs">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="fooRq">
+        <wsdl:part name="fooRq" element="ns1:fooRq">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:portType name="foo_PortType">
+        <wsdl:operation name="fooOp">
+            <wsdl:input message="tns:fooRq">
+            </wsdl:input>
+            <wsdl:output message="tns:fooRs">
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="foo_Binding" type="tns:foo_PortType">
+        <soap:binding style="document"
+                      transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="fooOp">
+            <soap:operation soapAction="fooPayment"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="foo">
+        <wsdl:port name="payment_Port"
+                   binding="tns:foo_Binding">
+            <soap:address
+                    location="http://localhost:8888/mockfoo_Binding"/>
+        </wsdl:port>
+    </wsdl:service>
+    <xsd:attriute fixed="2.1.4" name="version"/>
+</wsdl:definitions>


### PR DESCRIPTION
This resolves an issue I'm having with XSDs that import other XSDs with the same namespace url.  Using _.merge results in some values getting overwritten and the final wsdl definitions missing types.  Switching to the merge module's merge.recursive resolved the issue for me.  Sorry I don't have any test cases to demonstrate the problem/resolution.