### PR TITLE
Fix Array serialization

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1525,14 +1525,15 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, isFirst, xmln
   }
 
   // start building out XML string.
+  var correctOuterNamespace;
   if (Array.isArray(obj)) {
     for (var i = 0, item; item = obj[i]; i++) {
-      var arrayAttr = self.processAttributes(item),
-          correctOuterNamespace = parentNamespace || ns; //using the parent namespace if given
+      var arrayAttr = self.processAttributes(item);
+      correctOuterNamespace = parentNamespace || ns; //using the parent namespace if given
 
-      parts.push(['<', correctOuterNamespace, name, arrayAttr, xmlnsAttrib, '>'].join(''));
+      if( i === 0 ) parts.push(['<', correctOuterNamespace, name, arrayAttr, xmlnsAttrib, '>'].join(''));
       parts.push(self.objectToXML(item, name, namespace, xmlns, false, null, parameterTypeObject, ancXmlns));
-      parts.push(['</', correctOuterNamespace, name, '>'].join(''));
+      if ( !obj[i+1] ) parts.push(['</', correctOuterNamespace, name, '>'].join(''));
     }
   } else if (typeof obj === 'object') {
     for (name in obj) {

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1525,11 +1525,10 @@ WSDL.prototype.objectToXML = function(obj, name, namespace, xmlns, isFirst, xmln
   }
 
   // start building out XML string.
-  var correctOuterNamespace;
   if (Array.isArray(obj)) {
     for (var i = 0, item; item = obj[i]; i++) {
-      var arrayAttr = self.processAttributes(item);
-      correctOuterNamespace = parentNamespace || ns; //using the parent namespace if given
+      var arrayAttr = self.processAttributes(item),
+          correctOuterNamespace = parentNamespace || ns; //using the parent namespace if given
 
       if( i === 0 ) parts.push(['<', correctOuterNamespace, name, arrayAttr, xmlnsAttrib, '>'].join(''));
       parts.push(self.objectToXML(item, name, namespace, xmlns, false, null, parameterTypeObject, ancXmlns));

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "lib": "./lib"
   },
   "scripts": {
-    "pretest": "jshint index.js lib test",
     "test": "mocha --timeout 10000 test/*-test.js test/security/*.js"
   },
   "keywords": [


### PR DESCRIPTION
This PR is not to be merged (test are failing!) it's just to demonstrate the issue originally described in https://github.com/vpulim/node-soap/issues/748, 

original issue text below:

Hallo,

First of all thanks for this great library.

I'm working on an API and having troubles because of the way arrays get serialized into the request body.

My input object looks like:

```
{
options:
  [{
   option: {
      optionName: 'optname1',
      optionValue: 'value1'
    }
   },{
    option: {
      optionName: 'optname2',
      optionValue: 'value2'
    }
 }]
}
```
it gets serialized to:
```
<options>
   <option>
       <optionName>optname1</optionName>
       <optionValue>value1</optionValue>
   </option>
</options>
<options>
   <option>
       <optionName>optname2</optionName>
       <optionValue>value2</optionValue>
   </option>
</options>
```

while the server expects it to be formatted as:
```
<options>
   <option>
       <optionName>optname1</optionName>
       <optionValue>value1</optionValue>
   </option>
   <option>
       <optionName>optname2</optionName>
       <optionValue>value2</optionValue>
   </option>
</options>
```

I found the responsible code (llib/wsdl.js l: 1528..) and implemented a fix in my local fork but this causes several tests to fail.
I'm not really deep into this SOAP/XML stuff an therefore i'm not sure if that is a issue of the library or just bug in the servers SOAP server implementation.

thanks in advance for you help,
kind regards
