### PR TITLE
add SOAP v1.2 support for client

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,6 +40,7 @@ The `options` argument allows you to customize the client with the following pro
 - endpoint: to override the SOAP service's host specified in the `.wsdl` file.
 - request: to override the [request](https://github.com/request/request) module.
 - httpClient: to provide your own http client that implements `request(rurl, data, callback, exheaders, exoptions)`.
+- forceSoap12Headers: to set proper headers for SOAP v1.2
 
 ### soap.listen(*server*, *path*, *services*, *wsdl*) - create a new SOAP server that listens on *path* and provides *services*.
 *wsdl* is an xml string that defines the service.

--- a/lib/client.js
+++ b/lib/client.js
@@ -99,6 +99,7 @@ Client.prototype._initializeServices = function(endpoint) {
 
 Client.prototype._initializeOptions = function(options) {
   this.wsdl.options.attributesKey = options.attributesKey || 'attributes';
+  this.wsdl.options.forceSoap12Headers = !!options.forceSoap12Headers;
 };
 
 Client.prototype._defineService = function(service, endpoint) {
@@ -150,8 +151,14 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
     soapAction,
     alias = findKey(defs.xmlns, ns),
     headers = {
-      'Content-Type': "text/xml; charset=utf-8"
-    };
+      "Content-Type": "text/xml; charset=utf-8"
+    },
+    xmlnsSoap = "xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\"";
+
+  if (this.wsdl.options.forceSoap12Headers) {
+    headers["Content-Type"] = "application/soap+xml; charset=utf-8";
+    xmlnsSoap = "xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"";
+  }
 
   if (this.SOAPAction) {
     soapAction = this.SOAPAction;
@@ -186,7 +193,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
     message = self.wsdl.objectToDocumentXML(input.$name, args, input.targetNSAlias, input.targetNamespace, (input.$type || input.$lookupType));
   }
   xml = "<soap:Envelope " +
-    "xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" " +
+    xmlnsSoap + " " +
     "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
     encoding +
     this.wsdl.xmlnsInEnvelope + '>' +

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1109,6 +1109,9 @@ WSDL.prototype._initializeOptions = function (options) {
   else
     this.options.ignoreBaseNameSpaces = this.ignoreBaseNameSpaces;
 
+  // Works only in client
+  this.options.forceSoap12Headers = options.forceSoap12Headers;
+
 };
 
 WSDL.prototype.onReady = function(callback) {

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -210,6 +210,23 @@ describe('SOAP Client', function() {
         }, null, {"test-header": 'test'});
       }, baseUrl);
     });
+
+    it('should add proper headers for soap12', function(done) {
+      soap.createClient(__dirname+'/wsdl/default_namespace_soap12.wsdl', {forceSoap12Headers: true}, function(err, client) {
+        assert.ok(client);
+        assert.ok(!err);
+
+        client.MyOperation({}, function(err, result) {
+          assert.ok(result);
+          assert.ok(client.lastRequestHeaders);
+          assert.ok(client.lastRequest);
+          assert.equal(client.lastRequestHeaders['Content-Type'], 'application/soap+xml; charset=utf-8');
+          assert.notEqual(client.lastRequest.indexOf('xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"'), -1);
+
+          done();
+        }, null, {'test-header': 'test'});
+      }, baseUrl);
+    });
   });
 
   it('should add soap headers', function (done) {

--- a/test/wsdl/default_namespace_soap12.wsdl
+++ b/test/wsdl/default_namespace_soap12.wsdl
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="MyService" targetNamespace="http://www.example.com/v1" xmlns="http://www.example.com/v1" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/">
+  <wsdl:types>
+    <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://www.example.com/v1" xmlns="http://www.example.com/v1">
+		<xs:element name="Request">
+		</xs:element>
+		<xs:element name="Response">
+		</xs:element>
+    </xs:schema>
+    </wsdl:types>
+    <wsdl:message name="InputMessage">
+    <wsdl:part name="parameter" element="Request">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="OutputMessage">
+    <wsdl:part name="parameter" element="Response">
+    </wsdl:part>
+  </wsdl:message>
+
+  <wsdl:portType name="MyServicePortType">
+    <wsdl:operation name="MyOperation">
+      <wsdl:input message="InputMessage">
+    </wsdl:input>
+      <wsdl:output message="OutputMessage">
+    </wsdl:output>
+    </wsdl:operation>
+  </wsdl:portType>
+
+  <wsdl:binding name="MyServiceBinding" type="MyServicePortType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="MyOperation">
+      <soap:operation soapAction="MyOperation"/>
+      <wsdl:input>
+        <soap:body use="literal" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+
+  <wsdl:service name="MyService">
+    <wsdl:port name="MyServicePort" binding="MyServiceBinding">
+      <soap:address location="http://www.example.com/v1"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
related with #721, #720, #719, #627 
It's really hard to automatically determine SOAP version by WSDL ([stackoverflow thread](http://stackoverflow.com/questions/736845/can-a-wsdl-indicate-the-soap-version-1-1-or-1-2-of-the-web-service)) and when I tried it, almost all request-response-samples tests fails, so I'm just adding forceSoap12 option for the client