### PR TITLE
Provide original `req` to Service

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -79,6 +79,14 @@ The `options` argument allows you to customize the client with the following pro
                       name: headers.Token
                   };
               }
+
+              // You can also inspect the original `req`
+              reallyDeatailedFunction: function(args, cb, headers, req) {
+                  console.log('SOAP `reallyDeatailedFunction` request from ' + req.connection.remoteAddress)
+                  return {
+                      name: headers.Token
+                  };
+              }
           }
       }
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -115,7 +115,7 @@ Server.prototype._requestListener = function(req, res) {
         if (typeof self.log === 'function') {
           self.log("received", xml);
         }
-        self._process(xml, req.url, function(result, statusCode) {
+        self._process(xml, req, function(result, statusCode) {
           if(statusCode) {
             res.statusCode = statusCode;
           }
@@ -141,9 +141,9 @@ Server.prototype._requestListener = function(req, res) {
   }
 };
 
-Server.prototype._process = function(input, URL, callback) {
+Server.prototype._process = function(input, req, callback) {
   var self = this,
-    pathname = url.parse(URL).pathname.replace(/\/$/, ''),
+    pathname = url.parse(req.url).pathname.replace(/\/$/, ''),
     obj = this.wsdl.xmlToObject(input),
     body = obj.Body,
     headers = obj.Header,
@@ -215,7 +215,7 @@ Server.prototype._process = function(input, URL, callback) {
         args: body[methodName],
         headers: headers,
         style: 'rpc'
-      }, callback);
+      }, req, callback);
     } else {
       var messageElemName = (Object.keys(body)[0] === 'attributes' ? Object.keys(body)[1] : Object.keys(body)[0]);
       var pair = binding.topElements[messageElemName];
@@ -232,7 +232,7 @@ Server.prototype._process = function(input, URL, callback) {
         args: body[messageElemName],
         headers: headers,
         style: 'document'
-      }, callback, includeTimestamp);
+      }, req, callback, includeTimestamp);
     }
   }
   catch (error) {
@@ -244,7 +244,7 @@ Server.prototype._process = function(input, URL, callback) {
   }
 };
 
-Server.prototype._executeMethod = function(options, callback, includeTimestamp) {
+Server.prototype._executeMethod = function(options, req, callback, includeTimestamp) {
   options = options || {};
   var self = this,
     method, body,
@@ -290,7 +290,7 @@ Server.prototype._executeMethod = function(options, callback, includeTimestamp) 
     callback('');
   }
 
-  var result = method(args, handleResult, options.headers);
+  var result = method(args, handleResult, options.headers, req);
   if (typeof result !== 'undefined') {
     handleResult(result);
   }


### PR DESCRIPTION
Thanks for this great project!

Sometimes you may want the original `req` passed to your service methods.  In the simplest case, you might just want to log the requestor's IP address.

This PR passes `req` to the service methods as a 4th optional param.