### PR TITLE
Fixed issue when an error was undefined: undefined

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1418,9 +1418,9 @@ WSDL.prototype.xmlToObject = function(xml) {
   if (root.Envelope) {
     var body = root.Envelope.Body;
     if (body.Fault) {
-      var code = selectn('faultcode.$value', body.Fault);
-      var string = selectn('faultstring.$value', body.Fault);
-      var detail = selectn('detail.$value', body.Fault);
+      var code = selectn('faultcode.$value', body.Fault) || selectn('faultcode', body.Fault);
+      var string = selectn('faultstring.$value', body.Fault) || selectn('faultstring', body.Fault);
+      var detail = selectn('detail.$value', body.Fault) || selectn('detail.message', body.Fault);
       var error = new Error(code + ': ' + string + (detail ? ': ' + detail : ''));
       error.root = root;
       throw error;

--- a/test/request-response-samples-test.js
+++ b/test/request-response-samples-test.js
@@ -110,6 +110,7 @@ function generateTest(name, methodName, wsdlPath, headerJSON, securityJSON, requ
       client[methodName](requestJSON, function(err, json, body, soapHeader){
         if(requestJSON){
           if (err) {
+            assert.notEqual('undefined: undefined', err.message);
             assert.deepEqual(err.root, responseJSON);
           } else {
             // assert.deepEqual(json, responseJSON);

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -290,6 +290,7 @@ describe('SOAP Server', function() {
       client.GetLastTradePrice({ tickerSymbol: 'SOAP Fault v1.2' }, function(err, response, body) {
         assert.ok(err);
         var fault = err.root.Envelope.Body.Fault;
+        assert.equal(err.message, fault.faultcode + ': ' + fault.faultstring);
         assert.equal(fault.Code.Value, "soap:Sender");
         assert.equal(fault.Reason.Text, "Processing Error");
         // Verify namespace on elements set according to fault spec 1.2
@@ -309,6 +310,7 @@ describe('SOAP Server', function() {
       client.GetLastTradePrice({ tickerSymbol: 'SOAP Fault v1.1' }, function(err, response, body) {
         assert.ok(err);
         var fault = err.root.Envelope.Body.Fault;
+        assert.equal(err.message, fault.faultcode + ': ' + fault.faultstring);
         assert.equal(fault.faultcode, "soap:Client.BadArguments");
         assert.equal(fault.faultstring, "Error while processing arguments");
         // Verify namespace on elements set according to fault spec 1.1


### PR DESCRIPTION
This occurs on responses that from what I can tell do not have an
xsi:type of string, Thus these objects would not have an internal $value
and would return undefined.

This commit keeps backwards compatibility and falls back to assuming the
error was a string.