### PR TITLE
Remove SOAPAction http header in SOAP 1.2, extra header was causing s…

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -179,7 +179,9 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
     soapAction = ((ns.lastIndexOf("/") !== ns.length - 1) ? ns + "/" : ns) + name;
   }
 
-  headers.SOAPAction = '"' + soapAction + '"';
+  if (!this.wsdl.options.forceSoap12Headers) {
+    headers.SOAPAction = '"' + soapAction + '"';
+  }
 
   options = options || {};
 

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -222,7 +222,7 @@ describe('SOAP Client', function() {
           assert.ok(client.lastRequest);
           assert.equal(client.lastRequestHeaders['Content-Type'], 'application/soap+xml; charset=utf-8');
           assert.notEqual(client.lastRequest.indexOf('xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"'), -1);
-
+          assert( !client.lastRequestHeaders.SOAPAction );
           done();
         }, null, {'test-header': 'test'});
       }, baseUrl);


### PR DESCRIPTION
SOAP 1.2 request should not contain SOAPAction http header. 

Sending this header causes error on some servers (observed on .net based server) 