### PR TITLE
Overriding the namespace prefix with empty prefix

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -302,6 +302,13 @@ as default request options to the constructor:
   }, {timeout: 5000})
 ```
 
+- Remove namespace prefix of param
+
+```javascript
+  client.MyService.MyPort.MyFunction({':name': 'value'}, function(err, result) {
+      // request body sent with `<name`, regardless of what the namespace should have been.
+  }, {timeout: 5000})
+```
 
 #### Options (optional)
  - Accepts any option that the request module accepts, see [here.](https://github.com/mikeal/request)

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1599,11 +1599,15 @@ WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlns
 
       var value = '';
       var nonSubNameSpace = '';
+      var emptyNonSubNameSpace = false;
 
       var nameWithNsRegex = /^([^:]+):([^:]+)$/.exec(name);
       if (nameWithNsRegex) {
         nonSubNameSpace = nameWithNsRegex[1] + ':';
         name = nameWithNsRegex[2];
+      } else if(name[0] === ':'){
+        emptyNonSubNameSpace = true;
+        name = name.substr(1);
       }
 
       if (isFirst) {
@@ -1729,13 +1733,13 @@ WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlns
       }
 
       if (!Array.isArray(child)) {
-        parts.push(['<', nonSubNameSpace || ns, name, attr, xmlnsAttrib,
+        parts.push(['<', emptyNonSubNameSpace ? '' : nonSubNameSpace || ns, name, attr, xmlnsAttrib,
           (child === null ? ' xsi:nil="true"' : ''), '>'].join(''));
       }
 
       parts.push(value);
       if (!Array.isArray(child)) {
-        parts.push(['</', nonSubNameSpace || ns, name, '>'].join(''));
+        parts.push(['</', emptyNonSubNameSpace ? '' : nonSubNameSpace || ns, name, '>'].join(''));
       }
     }
   } else if (obj !== undefined) {

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -101,6 +101,24 @@ wsdlStrictTests['should handle type ref'] = function(done) {
   });
 };
 
+wsdlStrictTests['should get empty namespace prefix'] = function(done) {
+  var expectedMsg = '<ns1:fooRq xmlns:ns1="http://example.com/bar/xsd"' +
+    ' xmlns="http://example.com/bar/xsd"><bar1:paymentRq' +
+    ' xmlns:bar1="http://example.com/bar1/xsd">' +
+    '<bar1:bankSvcRq>' +
+    '<requestUID>001</requestUID></bar1:bankSvcRq>' +
+    '</bar1:paymentRq></ns1:fooRq>';
+  // var expectedMsg = 'gg';
+
+  soap.createClient(__dirname + '/wsdl/elementref/foo.wsdl', {strict: true}, function(err, client) {
+    assert.ok(!err);
+    client.fooOp({paymentRq: {bankSvcRq: {':requestUID': '001'}}}, function(err, result) {
+      assert.equal(client.lastMessage, expectedMsg);
+      done();
+    });
+  });
+};
+
 module.exports = {
   'WSDL Parser (strict)': wsdlStrictTests,
   'WSDL Parser (non-strict)': wsdlNonStrictTests


### PR DESCRIPTION
In some cases, we need to remove namespace prefix for generating valid soap request message.
I encountered this problem with complex WSDL.

- Remove namespace prefix of param

```javascript
  client.MyService.MyPort.MyFunction({':name': 'value',}, function(err, result) {
      // request body sent with `<name`, regardless of what the namespace should have been.
  }, {timeout: 5000})
```