### PR TITLE
improved 'https' pattern matching for local paths with name starting with 'http'

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1133,7 +1133,7 @@ WSDL.prototype._processNextInclude = function(includes, callback) {
     return callback();
 
   var includePath;
-  if (!/^https?/.test(self.uri) && !/^https?/.test(include.location)) {
+  if (!/^https?:/.test(self.uri) && !/^https?:/.test(include.location)) {
     includePath = path.resolve(path.dirname(self.uri), include.location);
   } else {
     includePath = url.resolve(self.uri, include.location);
@@ -2024,7 +2024,7 @@ function open_wsdl(uri, options, callback) {
   var request_options = options.wsdl_options;
 
   var wsdl;
-  if (!/^https?/.test(uri)) {
+  if (!/^https?:/.test(uri)) {
     debug('Reading file: %s', uri);
     fs.readFile(uri, 'utf8', function(err, definition) {
       if (err) {


### PR DESCRIPTION
Just ran into an issue yesterday when a local file at path 'http/something.wsdl' was not picked up with a misleading message