### PR TITLE
added in addressing ns

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1072,7 +1072,7 @@ var WSDL = function(definition, uri, options) {
 
       // prepare soap envelope xmlns definition string
       self.xmlnsInEnvelope = self._xmlnsMap();
-
+      self.xmlnsInEnvelope = self.xmlnsInEnvelope + " xmlns:a=\"http://www.w3.org/2005/08/addressing\"";
       self.callback(err, self);
     });
 


### PR DESCRIPTION
I was having trouble connecting to a .Net WCF WsHTTP endpoint until i added the following namespace to the xmlns Envelope

```
" xmlns:a=\"http://www.w3.org/2005/08/addressing\"";
```

I cannot get the code correct or find a solution online so i'm using this as a means of publishing a feature request. 

Apologies if i am breaking etiquette.
