### PR TITLE
Update http.js for allowing multipart requests

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -101,6 +101,10 @@ HttpClient.prototype.request = function(rurl, data, callback, exheaders, exoptio
   var self = this;
   var options = self.buildRequest(rurl, data, exheaders, exoptions);
   var headers = options.headers;
+  
+  if ( "multipart" in options ){
+    options.multipart[0].body=data;
+  }
   var req = self._request(options, function(err, res, body) {
     if (err) {
       return callback(err);
@@ -108,7 +112,7 @@ HttpClient.prototype.request = function(rurl, data, callback, exheaders, exoptio
     body = self.handleResponse(req, res, body);
     callback(null, res, body);
   });
-  if (headers.Connection !== 'keep-alive') {
+  if (headers.Connection !== 'keep-alive'  && !( "multipart" in options )) {
     req.end(data);
   }
   return req;


### PR DESCRIPTION
Hi,

this is a very small change. Almost all work is done  by pushing the multipart body into the
request-options.
The only problem is placing the xml into the first mulitpart body. This cannot be done from
outside.

With multipart support it is possible to use soap for uploading files to soap-based services.

The other possibility would be providing a callback function which allows to set the xml into
the body.
