### PR TITLE
Fix schema <xsd:include> support

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -344,6 +344,18 @@ DefinitionsElement.prototype.init = function() {
 DocumentationElement.prototype.init = function() {
 };
 
+SchemaElement.prototype.merge = function(source) {
+  assert(source instanceof SchemaElement);
+  if (this.$targetNamespace === source.$targetNamespace) {
+    _.merge(this.complexTypes, source.complexTypes);
+    _.merge(this.types, source.types);
+    _.merge(this.elements, source.elements);
+    _.merge(this.xmlns, source.xmlns);
+  }
+  return this;
+};
+
+
 SchemaElement.prototype.addChild = function(child) {
   if (child.$name in Primitives)
     return;
@@ -373,12 +385,6 @@ TypesElement.prototype.addChild = function (child) {
   assert(child instanceof SchemaElement);
 
   var targetNamespace = child.$targetNamespace;
-
-  if(!targetNamespace) {
-    if(child.includes && (child.includes instanceof Array) && child.includes.length > 0) {
-      targetNamespace = child.includes[0].namespace;
-    }
-  }
 
   if(!this.schemas.hasOwnProperty(targetNamespace)) {
     this.schemas[targetNamespace] = child;
@@ -1144,7 +1150,9 @@ WSDL.prototype._processNextInclude = function(includes, callback) {
       return callback(err);
     }
     if(wsdl.definitions instanceof DefinitionsElement){
-      _.merge(self.definitions, wsdl.definitions);
+      _.merge(self.definitions, wsdl.definitions, function(a,b) {
+        return (a instanceof SchemaElement) ? a.merge(b) : undefined;
+      });
     }else{
       self.definitions.schemas[include.namespace || wsdl.definitions.$targetNamespace] = deepMerge(self.definitions.schemas[include.namespace || wsdl.definitions.$targetNamespace], wsdl.definitions);
     }

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -119,6 +119,15 @@ wsdlStrictTests['should get empty namespace prefix'] = function(done) {
   });
 };
 
+wsdlNonStrictTests['should load same namespace from included xsd'] = function(done) {
+  var expected = '{"DummyService":{"DummyPortType":{"Dummy":{"input":{"ID":"IdType|xs:string|pattern","Name":"NameType|xs:string|minLength,maxLength"},"output":{"Result":"dummy:DummyList"}}}}}';
+  soap.createClient(__dirname + '/wsdl/xsdinclude/xsd_include.wsdl', function(err, client) {
+    assert.ok(!err);
+    assert.equal(JSON.stringify(client.describe()), expected);
+    done();
+  });
+};
+
 module.exports = {
   'WSDL Parser (strict)': wsdlStrictTests,
   'WSDL Parser (non-strict)': wsdlNonStrictTests

--- a/test/wsdl/xsdinclude/types.xsd
+++ b/test/wsdl/xsdinclude/types.xsd
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://www.dummy.com/Types"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://www.dummy.com/Types"
+           elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:simpleType name="IdType">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="\d{5,15}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="NameType">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="255"/>
+        </xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="Dummy">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="language" type="xs:language" use="optional"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+    <xs:element name="DummyResult">
+		<xs:sequence>
+			<xs:element name="DummyElement" type="tns:Dummy" maxOccurs="unbounded"/>
+		</xs:sequence>
+    </xs:element>
+</xs:schema>

--- a/test/wsdl/xsdinclude/xsd_include.wsdl
+++ b/test/wsdl/xsdinclude/xsd_include.wsdl
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions targetNamespace="http://www.dummy.com"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                  xmlns:dummy="http://www.dummy.com/Types"
+                  xmlns:tns="http://www.dummy.com">
+	<wsdl:types>
+        <xs:schema targetNamespace="http://www.dummy.com/Types"
+                   xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                   xmlns:dummy="http://www.dummy.com/Types"
+                   elementFormDefault="qualified" attributeFormDefault="unqualified">
+            <xs:include schemaLocation="types.xsd"/>
+            <xs:element name="DummyRequest">
+                <xs:complexType>
+                    <xs:sequence>
+        				<xs:element name="ID" type="dummy:IdType"/>
+        				<xs:element name="Name" type="dummy:NameType"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="DummyResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="Result" type="dummy:DummyList"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:schema>
+	</wsdl:types>
+	<wsdl:message name="DummyRequest">
+		<wsdl:part name="DummyRequest" element="dummy:DummyRequest"/>
+	</wsdl:message>
+	<wsdl:message name="DummyResponse">
+		<wsdl:part name="DummyResponse" element="dummy:DummyResponse"/>
+	</wsdl:message>
+	<wsdl:portType name="DummyPortType">
+		<wsdl:operation name="Dummy">
+			<wsdl:input message="tns:DummyRequest"/>
+			<wsdl:output message="tns:DummyResponse"/>
+		</wsdl:operation>
+	</wsdl:portType>
+	<wsdl:binding name="DummyBinding" type="tns:DummyPortType">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+		<wsdl:operation name="Dummy">
+			<soap:operation soapAction="tns#Dummy" style="document"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="DummySave">
+			<soap:operation soapAction="tns#DummySave" style="document"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:service name="DummyService">
+		<wsdl:port name="DummyPortType" binding="tns:DummyBinding">
+			<soap:address location="http://www.dummy.com/"/>
+		</wsdl:port>
+	</wsdl:service>
+</wsdl:definitions>
+


### PR DESCRIPTION
node-soap has support to <xsd:import> which imports schema definitions of _other_ target namespace. But it has issue in support to <xsd:include> which refer to definitions in the _same_ target namespace. Definitions (elements, types, complexTypes) from included file will overwrite existing definitions in the same target namespace.

In below example, after include file `types.xsd` is processed, elements `DummyRequest` and `DummyResponse` will be gone.

        <xs:schema targetNamespace="http://www.dummy.com/Types"
                   xmlns:xs="http://www.w3.org/2001/XMLSchema"
                   xmlns:dummy="http://www.dummy.com/Types"
                   elementFormDefault="qualified" attributeFormDefault="unqualified">
            <xs:include schemaLocation="types.xsd"/>
            <xs:element name="DummyRequest">
                <xs:complexType>
                    <xs:sequence>
        				<xs:element name="ID" type="dummy:IdType"/>
        				<xs:element name="Name" type="dummy:NameType"/>
                    </xs:sequence>
                </xs:complexType>
            </xs:element>
            <xs:element name="DummyResponse">
                <xs:complexType>
                    <xs:sequence>
                        <xs:element name="Result" type="dummy:DummyList"/>
                    </xs:sequence>
                </xs:complexType>
            </xs:element>
        </xs:schema>

The issue is because that lodash `merge()` can only merge plain object. `SchemaElement` is not plain object so after merge it's overwritten.