### PR TITLE
SOAP Headers for server response

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -32,7 +32,17 @@ Client.prototype.addSoapHeader = function(soapHeader, name, namespace, xmlns) {
   if (typeof soapHeader === 'object') {
     soapHeader = this.wsdl.objectToXML(soapHeader, name, namespace, xmlns, true);
   }
-  this.soapHeaders.push(soapHeader);
+  return this.soapHeaders.push(soapHeader) - 1;
+};
+
+Client.prototype.changeSoapHeader = function(index, soapHeader, name, namespace, xmlns) {
+  if (!this.soapHeaders) {
+    this.soapHeaders = [];
+  }
+  if (typeof soapHeader === 'object') {
+    soapHeader = this.wsdl.objectToXML(soapHeader, name, namespace, xmlns, true);
+  }
+  this.soapHeaders[index] = soapHeader;
 };
 
 Client.prototype.getSoapHeaders = function() {

--- a/lib/server.js
+++ b/lib/server.js
@@ -68,6 +68,34 @@ var Server = function(server, path, services, wsdl, options) {
 };
 util.inherits(Server, events.EventEmitter);
 
+Server.prototype.addSoapHeader = function(soapHeader, name, namespace, xmlns) {
+  if (!this.soapHeaders) {
+    this.soapHeaders = [];
+  }
+  if (typeof soapHeader === 'object') {
+    soapHeader = this.wsdl.objectToXML(soapHeader, name, namespace, xmlns, true);
+  }
+  return this.soapHeaders.push(soapHeader) - 1;
+};
+
+Server.prototype.changeSoapHeader = function(index, soapHeader, name, namespace, xmlns) {
+  if (!this.soapHeaders) {
+    this.soapHeaders = [];
+  }
+  if (typeof soapHeader === 'object') {
+    soapHeader = this.wsdl.objectToXML(soapHeader, name, namespace, xmlns, true);
+  }
+  this.soapHeaders[index] = soapHeader;
+};
+
+Server.prototype.getSoapHeaders = function() {
+  return this.soapHeaders;
+};
+
+Server.prototype.clearSoapHeaders = function() {
+  this.soapHeaders = null;
+};
+
 Server.prototype._initializeOptions = function(options) {
   this.wsdl.options.attributesKey = options.attributesKey || 'attributes';
 };
@@ -306,22 +334,31 @@ Server.prototype._envelope = function(body, includeTimestamp) {
     "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" " +
     encoding +
     this.wsdl.xmlnsInEnvelope + '>';
+  var headers = '';
+
   if (includeTimestamp) {
     var now = new Date();
     var created = getDateString(now);
     var expires = getDateString(new Date(now.getTime() + (1000 * 600)));
 
-    xml += "<soap:Header>" +
-    "  <o:Security soap:mustUnderstand=\"1\" " +
+    headers += "<o:Security soap:mustUnderstand=\"1\" " +
     "xmlns:o=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\" " +
     "xmlns:u=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\">" +
     "    <u:Timestamp u:Id=\"_0\">" +
     "      <u:Created>" + created + "</u:Created>" +
     "      <u:Expires>" + expires + "</u:Expires>" +
     "    </u:Timestamp>" +
-    "  </o:Security>" +
-    "</soap:Header>";
+    "  </o:Security>\n";
   }
+
+  if(this.soapHeaders) {
+    headers += this.soapHeaders.join("\n");
+  }
+
+  if(headers !== '') {
+    xml += "<soap:Header>" + headers + "</soap:Header>";
+  }
+
   xml += "<soap:Body>" +
     body +
     "</soap:Body>" +

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -18,10 +18,15 @@ describe('SOAP Client', function() {
       assert.ok(client);
       assert.ok(!client.getSoapHeaders());
 
-      client.addSoapHeader('header1');
-      client.addSoapHeader('header2');
+      var i1 = client.addSoapHeader('about-to-change-1');
+      var i2 = client.addSoapHeader('about-to-change-2');
 
+      assert.ok(i1 === 0);
+      assert.ok(i2 === 1);
       assert.ok(client.getSoapHeaders().length === 2);
+
+      client.changeSoapHeader(0, 'header1');
+      client.changeSoapHeader(1, 'header2');
       assert.ok(client.getSoapHeaders()[0] === 'header1');
       assert.ok(client.getSoapHeaders()[1] === 'header2');
 

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -116,6 +116,39 @@ describe('SOAP Server', function() {
   });
 
 
+  it('should add and clear response soap headers', function(done) {
+    assert.ok(!test.soapServer.getSoapHeaders());
+
+    var i1 = test.soapServer.addSoapHeader('about-to-change-1');
+    var i2 = test.soapServer.addSoapHeader('about-to-change-2');
+
+    assert.ok(i1 === 0);
+    assert.ok(i2 === 1);
+    assert.ok(test.soapServer.getSoapHeaders().length === 2);
+
+    test.soapServer.changeSoapHeader(0, 'header1');
+    test.soapServer.changeSoapHeader(1, 'header2');
+    assert.ok(test.soapServer.getSoapHeaders()[0] === 'header1');
+    assert.ok(test.soapServer.getSoapHeaders()[1] === 'header2');
+
+    test.soapServer.clearSoapHeaders();
+    assert.ok(!test.soapServer.getSoapHeaders());
+    done();
+  });
+
+  it('should return predefined headers in response', function(done) {
+    soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
+      assert.ok(!err);
+      test.soapServer.addSoapHeader('<header1>ONE</header1>');
+      test.soapServer.changeSoapHeader(1, { header2: 'TWO' });
+      client.GetLastTradePrice({ tickerSymbol: 'AAPL'}, function(err, result, raw, headers) {
+        assert.ok(!err);
+        assert.deepEqual(headers, { header1: 'ONE', header2: 'TWO' });
+        done();
+      });
+    });
+  });
+
   it('should be running', function(done) {
     request(test.baseUrl, function(err, res, body) {
       assert.ok(!err);


### PR DESCRIPTION
I copied the client methods that handle SOAP headers to be able to also put headers in server replies.
I also created a method to be able to change an existing header (without having to purge all others and recreate everything).

And I re-organized a bit the readme.