### PR TITLE
give complete control to overwritten request module

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -102,19 +102,14 @@ HttpClient.prototype.request = function(rurl, data, callback, exheaders, exoptio
   var options = self.buildRequest(rurl, data, exheaders, exoptions);
   var headers = options.headers;
   
-  if ( "multipart" in options ){
-    options.multipart[0].body=data;
-  }
-  var req = self._request(options, function(err, res, body) {
+    var req = self._request(options, function(err, res, body) {
     if (err) {
       return callback(err);
     }
     body = self.handleResponse(req, res, body);
     callback(null, res, body);
   });
-  if (headers.Connection !== 'keep-alive'  && !( "multipart" in options )) {
-    req.end(data);
-  }
+  
   return req;
 };
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -65,9 +65,9 @@ HttpClient.prototype.buildRequest = function(rurl, data, exheaders, exoptions) {
     followAllRedirects: true
   };
 
-  if (headers.Connection === 'keep-alive') {
+  
     options.body = data;
-  }
+
 
   exoptions = exoptions || {};
   for (attr in exoptions) {

--- a/lib/http.js
+++ b/lib/http.js
@@ -101,6 +101,10 @@ HttpClient.prototype.request = function(rurl, data, callback, exheaders, exoptio
   var self = this;
   var options = self.buildRequest(rurl, data, exheaders, exoptions);
   var headers = options.headers;
+  
+  if ( "multipart" in options ){
+    options.multipart[0].body=data;
+  }
   var req = self._request(options, function(err, res, body) {
     if (err) {
       return callback(err);
@@ -108,7 +112,7 @@ HttpClient.prototype.request = function(rurl, data, callback, exheaders, exoptio
     body = self.handleResponse(req, res, body);
     callback(null, res, body);
   });
-  if (headers.Connection !== 'keep-alive') {
+  if (headers.Connection !== 'keep-alive'  && !( "multipart" in options )) {
     req.end(data);
   }
   return req;


### PR DESCRIPTION
by removing the streaming to request in the code (req.end() )
the request can be completly controlled by overwriting the request module

This is important for supporting file  up- and downloading through soap

options.body can be replaced by multipart-body,
the xml in options.body can be split and streaming of base64 data included
without req.end() in the code.

so req.write(), piping to and from request and request.end() can be done
in the overwritten function and then the request module be called which will
give control back to soap through the callback

In the moment this works only if I set "keep-alive" in the header.


