### PR TITLE
XSD import in WSDL files and relative path (server creation)

### DIFF
--- a/lib/soap.js
+++ b/lib/soap.js
@@ -53,16 +53,18 @@ function createClient(url, options, callback, endpoint) {
 
 function listen(server, pathOrOptions, services, xml) {
   var options = {},
-    path = pathOrOptions;
+    path = pathOrOptions,
+      uri = null;
 
   if (typeof pathOrOptions === 'object') {
     options = pathOrOptions;
     path = options.path;
     services = options.services;
     xml = options.xml;
+    uri = options.uri;
   }
 
-  var wsdl = new WSDL(xml || services, null, options);
+  var wsdl = new WSDL(xml || services, uri, options);
   return new Server(server, path, services, wsdl);
 }
 


### PR DESCRIPTION
I recently faced an issue creating a new SOAP service using a WSDL file in which XSD in included with relative path.
XSD loading is done from NodeJS working dir, instead of WSDL directory.

With this patch and setting uri option in "listen" function arguments everything is OK.
