### PR TITLE
Make request comparisons in request-response-samples-test.js easier to work with

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "colors": "^1.1.2",
     "coveralls": "^2.11.6",
+    "diff": "^2.2.1",
     "duplexer": "~0.1.1",
     "glob": "~3.2.8",
     "istanbul": "^0.4.1",


### PR DESCRIPTION
Specifically, ignore whitespace only differences and make differences easier to spot.
In addition to the expected vs actual output as generated by the assert, add a colorized difference line adjacent to the test case in the list.
