### PR TITLE
Changes to schema searches to support Delphi XE 10 WSDL

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -37,7 +37,7 @@ var Primitives = {
   negativeInteger: 1,
   nonNegativeInteger: 1,
   positiveInteger: 1,
-  nonPositiveInteger:1,
+    nonPositiveInteger: 1,
   unsignedByte: 1,
   unsignedInt: 1,
   unsignedLong: 1,
@@ -1206,7 +1206,98 @@ WSDL.prototype.toXML = function() {
   return this.xml || '';
 };
 
-WSDL.prototype.xmlToObject = function(xml) {
+WSDL.prototype.findInNamespace = function (splitPrefix_Name) {
+    if (splitPrefix_Name.prefix !== 'xs') {
+        var nsName = this.definitions.xmlns[splitPrefix_Name.prefix];
+        if (splitPrefix_Name.name in this.definitions.schemas[nsName].types) {
+            return this.definitions.schemas[nsName].types[splitPrefix_Name.name];
+        } else if (splitPrefix_Name.name in this.definitions.schemas[nsName].complexTypes) {
+            return this.definitions.schemas[nsName].complexTypes[splitPrefix_Name.name];
+        } else
+            return undefined;
+    } else
+        return splitPrefix_Name.prefix + ':' + splitPrefix_Name.name;
+};
+
+WSDL.prototype.findxsiTypeSchema = function (obj) {
+    // Pick up the schema for the type specified in element's xsi:type attribute.
+    var xsiTypeSchema;
+    if (obj[this.options.attributesKey]) {
+        var xsiType = obj[this.options.attributesKey]['xsi:type'];
+        if (xsiType) {
+            var type = splitQName(xsiType);
+            var typeURI;
+            if (type.prefix === TNS_PREFIX) {
+                // In case of xsi:type = "MyType"
+                typeURI = this.xmlns[type.prefix] || this.xmlns.xmlns;
+            } else {
+                typeURI = this.xmlns[type.prefix];
+            }
+            var typeDef = this.findSchemaObject(typeURI, type.name);
+            if (typeDef) {
+                xsiTypeSchema = typeDef.description(this.definitions);
+            }
+        }
+    }
+    return xsiTypeSchema;
+};
+
+WSDL.prototype.findSchema = function (topSchema, name, originalName) {
+    var schema;
+    if (topSchema) {
+        // Find the current object's schema
+        if (topSchema[name + '[]'])
+            name = name + '[]';
+
+        if (topSchema.name) {
+            if (topSchema.name === 'complexType') {
+                schema = this.findSchema(topSchema.children[0], name, originalName);
+            } else if (topSchema.name === 'sequence') {
+                // Linear search among the elements of the sequence
+                for (var i = 0; i < topSchema.children.length; i++) {
+                    if (topSchema.children[i].$name === originalName) {
+                        schema = topSchema.children[i];
+                        break;
+                    }
+                }
+
+                if (schema && schema.name === 'element') {
+                    var splitPrefix_Name = splitQName(schema.$type);
+                    if (splitPrefix_Name.prefix !== 'xs') {
+                        schema = this.findInNamespace(splitPrefix_Name);
+                    } else {
+                        schema = schema.$type;
+                    }
+                }
+            } else if (topSchema.name === 'complexContent' && topSchema.children[0].name === 'restriction' && topSchema.children[0].$base === 'soapenc:Array') {
+                schema = topSchema.children[0].children[1];
+                if ('$ref' in schema && schema.$ref === 'soapenc:arrayType' && '$n1:arrayType' in schema) {
+                    schema = schema['$n1:arrayType'].substring(0, schema['$n1:arrayType'].length - 2);
+                    if (schema.substring(0, 2) !== 'xs') {
+                        var splitPrefix_Name = splitQName(schema);
+                        schema = this.findInNamespace(splitPrefix_Name);
+                    }
+                }
+            } else if (topSchema.name === 'complexContent' && topSchema.children[0].name === 'extension') {
+                schema = this.findSchema(topSchema.children[0].children[0], name, originalName);
+                if (!schema) {
+                    // Handle class inheritance recursively
+                    var splitPrefix_Name = splitQName(topSchema.children[0].$base);
+                    var baseSchema = this.findInNamespace(splitPrefix_Name);
+                    schema = this.findSchema(baseSchema, name, originalName);
+                }
+            } else if (typeof topSchema.xmlns === 'string') {
+                schema = this.definitions.schemas[topSchema.xmlns].complexTypes[originalName];
+            }
+        } else {
+            schema = (topSchema && topSchema[name]);
+        }
+    }
+    return(schema);
+};
+
+WSDL.prototype.xmlToObject = function (xml) {
+    //console.log(xml);
   var self = this;
   var p = sax.parser(true);
   var objectName = null;
@@ -1281,6 +1372,9 @@ WSDL.prototype.xmlToObject = function(xml) {
         self.definitions.messages[originalName] = self.definitions.messages[name];
       }
 
+            // Override message name to prevent the cached result from returning
+            // the description referenced by original name
+            message.$name = name;
       topSchema = message.description(self.definitions);
       objectName = originalName;
     }
@@ -1316,27 +1410,14 @@ WSDL.prototype.xmlToObject = function(xml) {
 
     if(hasNonXmlnsAttribute)obj[self.options.attributesKey] = elementAttributes;
 
-    // Pick up the schema for the type specified in element's xsi:type attribute.
-    var xsiTypeSchema;
-    var xsiType = elementAttributes['xsi:type'];
-    if (xsiType) {
-      var type = splitQName(xsiType);
-      var typeURI;
-      if (type.prefix === TNS_PREFIX) {
-        // In case of xsi:type = "MyType"
-        typeURI = xmlns[type.prefix] || xmlns.xmlns;
-      } else {
-        typeURI = xmlns[type.prefix];
-      }
-      var typeDef = self.findSchemaObject(typeURI, type.name);
-      if (typeDef) {
-        xsiTypeSchema = typeDef.description(self.definitions);
-      }
+    schema = self.findxsiTypeSchema(obj) || self.findSchema(topSchema, name, originalName);
+
+        // If the schema says the object is a complexType array create it as an array
+        if (schema && schema.name === 'complexType' && schema.children[0].name === 'complexContent' && schema.children[0].children[0].name === 'restriction' && schema.children[0].children[0].$base === 'soapenc:Array') {
+            obj = [];
     }
 
-    if (topSchema && topSchema[name + '[]'])
-      name = name + '[]';
-    stack.push({name: originalName, object: obj, schema: (xsiTypeSchema || (topSchema && topSchema[name])), id: attrs.id, nil: hasNilAttribute});
+        stack.push({name: originalName, object: obj, schema: schema, id: attrs.id, nil: hasNilAttribute});
   };
 
   p.onclosetag = function(nsName) {
@@ -1359,7 +1440,9 @@ WSDL.prototype.xmlToObject = function(xml) {
       obj = null;
     }
 
-    if (topSchema && topSchema[name + '[]']) {
+        if (topSchema && topSchema.name === 'complexType' && topSchema.children[0].name === 'complexContent' && topSchema.children[0].children[0].name === 'restriction' && topSchema.children[0].children[0].$base === 'soapenc:Array') {
+            topObject.push(obj);
+        } else if (topSchema && topSchema[name + '[]']) {
       if (!topObject[name])
         topObject[name] = [];
       topObject[name].push(obj);
@@ -1399,9 +1482,16 @@ WSDL.prototype.xmlToObject = function(xml) {
     text = trim(text);
     if (!text.length)
       return;
+        var top = stack[stack.length - 1];
 
-    var top = stack[stack.length - 1];
-    var name = splitQName(top.schema).name,
+        var nsName;
+        if (top && top.schema && typeof top.schema === 'object' && top.schema.nsName && top.schema.nsName === 'element') {
+            nsName = top.schema.$type;
+        } else {
+            nsName = top.schema;
+        }
+
+        var name = splitQName(nsName).name,
       value;
     if (name === 'int' || name === 'integer') {
       value = parseInt(text, 10);
@@ -1775,15 +1865,15 @@ WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlns
         }
       }
 
-      if (!Array.isArray(child)) {
+            //if (!Array.isArray(child)) {
         parts.push(['<', emptyNonSubNameSpace ? '' : nonSubNameSpace || ns, name, attr, xmlnsAttrib,
           (child === null ? ' xsi:nil="true"' : ''), '>'].join(''));
-      }
+            //}
 
       parts.push(value);
-      if (!Array.isArray(child)) {
+            //if (!Array.isArray(child)) {
         parts.push(['</', emptyNonSubNameSpace ? '' : nonSubNameSpace || ns, name, '>'].join(''));
-      }
+            //}
     }
   } else if (obj !== undefined) {
     parts.push(xmlEscape(obj));


### PR DESCRIPTION
We were having some issues trying to consume a SOAP webservice written in Delphi XE 10. I'm attaching the WSDL (renamed to TXT to be able to upload).
[IWS_DNM.txt](https://github.com/vpulim/node-soap/files/166084/IWS_DNM.txt)

The problems we had were mainly of three types:
The schemas of complexTypes, sequences, elements and complexContents were not being found in the WSDL object correctly. We've added a recursive function called findSchema in line 1245 which is able to handle these types including inherited classes, arrays of objects and arrays and objects inside other objects.

The second type of problem was that arrays received as responses were being created as objects with an array inside of them instead of just plain arrays. Say our webservice returned an array of strings named "output", the output JSON object was something like this: {"output":{string: [s1, s2, ..., sn] }}. We changed this behaviour to have it return {"output":[s1, s2, ..., sn]}.
These are the changes in lines 1416 and 1443.

The third type of problem was when sending in a request arrays inside objects. Say we had an input parameter which was an object which had an array in it: {"input":{"a":1, "b":[s1, s2, ..., sn] }}}. The produced xml would have the array like this:
<input>
tns:a1/tns:a
tns:bs1/tns:b
tns:bs2/tns:b
...
tns:bsn/tns:b
</input>

Instead of:
<input>
tns:a1/tns:a
<b>
tns:bs1/tns:b
tns:bs2/tns:b
...
tns:bsn/tns:b
</b>
</input>
There are two if's in lines 1868 and 1874 which seem to be preventing the printing of <b> and </b> but this made our server not to be able to interpret the array correctly so we've commented them. Maybe in a different case these must be excluded?

We can try to make a testing environment to try these issues if you find it's necessary.
Also, last but not least, thank you for creating this module and putting it at everyone's disposal, it has made our work a lot easier.
Best
Pablo
