### PR TITLE
Make elapsedTime available on Client

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -381,6 +381,13 @@ as default request options to the constructor:
   }, {timeout: 5000})
 ```
 
+- You can measure the elapsed time on the request by passing the time option:
+``` javascript
+  client.MyService.MyPort.MyFunction({name: 'value'}, function(err, result) {
+      // client.lastElapsedTime - the elapsed time of the last request in milliseconds
+  }, {time: true})
+```
+
 ### Client.*lastRequest* - the property that contains last full soap request for client logging
 
 ### Client Events

--- a/lib/client.js
+++ b/lib/client.js
@@ -265,6 +265,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
     var obj;
     self.lastResponse = body;
     self.lastResponseHeaders = response && response.headers;
+    self.lastElapsedTime = response && response.elapsedTime;
     self.emit('response', body);
 
     if (err) {

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -202,6 +202,22 @@ describe('SOAP Client', function() {
       }, baseUrl);
     });
 
+    it('should have lastElapsedTime after a call with the time option passed', function(done) {
+      soap.createClient(__dirname+'/wsdl/default_namespace.wsdl', function(err, client) {
+        assert.ok(client);
+        assert.ok(!err);
+
+        client.MyOperation({}, function(err, result) {
+          assert.ok(result);
+          assert.ok(client.lastResponse);
+          assert.ok(client.lastResponseHeaders);
+          assert.ok(client.lastElapsedTime);
+
+          done();
+        }, {time: true}, {'test-header': 'test'});
+      }, baseUrl);
+    });
+
     it('should not return error in the call and return the json in body', function(done) {
       soap.createClient(__dirname+'/wsdl/json_response.wsdl', function(err, client) {
         assert.ok(client);


### PR DESCRIPTION
If {time: true} is passed as an option to request module, make elapsedTime from response available as Client.lastElapsedTime