### PR TITLE
Avoids overwriting request headers with options in method invocation

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -47,6 +47,8 @@ HttpClient.prototype.buildRequest = function(rurl, data, exheaders, exoptions) {
     'Host': host + (isNaN(port) ? '' : ':' + port)
   };
   var attr;
+  var header;
+  var mergeOptions = ['headers'];
 
   if (typeof data === 'string') {
     headers['Content-Length'] = Buffer.byteLength(data, 'utf8');
@@ -71,7 +73,13 @@ HttpClient.prototype.buildRequest = function(rurl, data, exheaders, exoptions) {
 
   exoptions = exoptions || {};
   for (attr in exoptions) {
-    options[attr] = exoptions[attr];
+    if (mergeOptions.indexOf(attr) !== -1) {
+      for (header in exoptions[attr]) {
+        options[attr][header] = exoptions[attr][header];
+      }
+    } else {
+      options[attr] = exoptions[attr];
+    }
   }
   debug('Http request: %j', options);
   return options;

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -218,6 +218,21 @@ describe('SOAP Client', function() {
       }, baseUrl);
     });
 
+    it('should add http headers in method call options', function(done) {
+      soap.createClient(__dirname+'/wsdl/default_namespace.wsdl', function(err, client) {
+        assert.ok(client);
+        assert.ok(!err);
+
+        client.MyOperation({}, function(err, result) {
+          assert.ok(result);
+          assert.ok(client.lastRequestHeaders['test-header']);
+          assert.ok(client.lastRequestHeaders['options-test-header']);
+
+          done();
+        }, {headers: {'options-test-header': 'test'}}, {'test-header': 'test'});
+      }, baseUrl);
+    });
+
     it('should not return error in the call and return the json in body', function(done) {
       soap.createClient(__dirname+'/wsdl/json_response.wsdl', function(err, client) {
         assert.ok(client);


### PR DESCRIPTION
When specifying `options` during a method invocation, those options will be added to the set of options already defined to invoke `request` and call an endpoint as specified in the [docs](https://github.com/vpulim/node-soap#options-optional).

But if a `headers` option is specified, it will overwrite all the already-set request headers including, for instance, any auth header previously set:

```javascript
client.MyService.MyPort.MyFunction({}, function(err, result) {
  // the HTTP request will **only** have 'my-header' header!!
}, {headers: {'my-header': 'header value'})
```

This PR takes into consideration `headers` is a special case and, instead of overwriting the `headers` property, it will merge the properties into the existing request headers:

```javascript
client.MyService.MyPort.MyFunction({}, function(err, result) {
  // the HTTP request will have 'my-header' in addition to any other existing header
}, {headers: {'my-header': 'header value'})
```