### PR TITLE
Allows calling methods with callback as last param

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -348,28 +348,12 @@ as default request options to the constructor:
       // soapHeader is the response soap header as a javascript object
   })
 ```
-### Client.*service*.*port*.*method*(args, callback[, options]) - call a *method* using a specific *service* and *port*
+### Client.*service*.*port*.*method*(args, callback[, options[, extraHeaders]]) - call a *method* using a specific *service* and *port*
 
 ``` javascript
   client.MyService.MyPort.MyFunction({name: 'value'}, function(err, result) {
       // result is a javascript object
   })
-```
-###Overriding the namespace prefix
-`node-soap` is still working out some kinks regarding namespaces.  If you find that an element is given the wrong namespace prefix in the request body, you can add the prefix to it's name in the containing object.  I.E.:
-
-```javascript
-  client.MyService.MyPort.MyFunction({'ns1:name': 'value'}, function(err, result) {
-      // request body sent with `<ns1:name`, regardless of what the namespace should have been.
-  }, {timeout: 5000})
-```
-
-- Remove namespace prefix of param
-
-```javascript
-  client.MyService.MyPort.MyFunction({':name': 'value'}, function(err, result) {
-      // request body sent with `<name`, regardless of what the namespace should have been.
-  }, {timeout: 5000})
 ```
 
 #### Options (optional)
@@ -386,6 +370,41 @@ as default request options to the constructor:
   client.MyService.MyPort.MyFunction({name: 'value'}, function(err, result) {
       // client.lastElapsedTime - the elapsed time of the last request in milliseconds
   }, {time: true})
+```
+
+#### Extra Headers (optional)
+
+Object properties define extra HTTP headers to be sent on the request.
+
+#### Alternative method call using callback-last pattern
+
+To align method call signature with node' standard callback-last patter and event allow promisification of method calls, the following method signatures are also supported:
+
+```javascript
+client.MyService.MyPort.MyFunction({name: 'value'}, options, function (err, result) {
+  // result is a javascript object
+})
+
+client.MyService.MyPort.MyFunction({name: 'value'}, options, extraHeaders, function (err, result) {
+  // result is a javascript object
+})
+```
+
+###Overriding the namespace prefix
+`node-soap` is still working out some kinks regarding namespaces.  If you find that an element is given the wrong namespace prefix in the request body, you can add the prefix to it's name in the containing object.  I.E.:
+
+```javascript
+  client.MyService.MyPort.MyFunction({'ns1:name': 'value'}, function(err, result) {
+      // request body sent with `<ns1:name`, regardless of what the namespace should have been.
+  }, {timeout: 5000})
+```
+
+- Remove namespace prefix of param
+
+```javascript
+  client.MyService.MyPort.MyFunction({':name': 'value'}, function(err, result) {
+      // request body sent with `<name`, regardless of what the namespace should have been.
+  }, {timeout: 5000})
 ```
 
 ### Client.*lastRequest* - the property that contains last full soap request for client logging

--- a/lib/client.js
+++ b/lib/client.js
@@ -146,10 +146,20 @@ Client.prototype._definePort = function(port, endpoint) {
 
 Client.prototype._defineMethod = function(method, location) {
   var self = this;
+  var temp;
   return function(args, callback, options, extraHeaders) {
     if (typeof args === 'function') {
       callback = args;
       args = {};
+    } else if (typeof options === 'function') {
+      temp = callback;
+      callback = options;
+      options = temp;
+    } else if (typeof extraHeaders === 'function') {
+      temp = callback;
+      callback = extraHeaders;
+      extraHeaders = options;
+      options = temp;
     }
     self._invoke(method, args, location, function(error, result, raw, soapHeader) {
       callback(error, result, raw, soapHeader);

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -263,6 +263,73 @@ describe('SOAP Client', function() {
         }, null, {'test-header': 'test'});
       }, baseUrl);
     });
+
+    it('should allow calling the method with args, callback, options and extra headers', function(done) {
+      soap.createClient(__dirname+'/wsdl/json_response.wsdl', function(err, client) {
+        assert.ok(client);
+        assert.ok(!err);
+
+        client.MyOperation({}, function(err, result, body) {
+          assert.ok(!err);
+          assert.ok(result);
+          assert.ok(body.tempResponse === 'temp');
+          assert.ok(client.lastResponseHeaders.status === 'pass');
+          assert.ok(client.lastRequestHeaders['options-test-header'] === 'test');
+
+          done();
+        }, {headers: {'options-test-header': 'test'}}, {'test-header': 'test'});
+      }, baseUrl);
+    });
+
+    it('should allow calling the method with only a callback', function(done) {
+      soap.createClient(__dirname+'/wsdl/json_response.wsdl', function(err, client) {
+        assert.ok(client);
+        assert.ok(!err);
+
+        client.MyOperation(function(err, result, body) {
+          assert.ok(!err);
+          assert.ok(result);
+          assert.ok(body.tempResponse === 'temp');
+          assert.ok(client.lastResponseHeaders.status === 'fail');
+
+          done();
+        });
+      }, baseUrl);
+    });
+
+    it('should allow calling the method with args, options and callback last', function(done) {
+      soap.createClient(__dirname+'/wsdl/json_response.wsdl', function(err, client) {
+        assert.ok(client);
+        assert.ok(!err);
+
+        client.MyOperation({}, {headers: {'options-test-header': 'test'}}, function(err, result, body) {
+          assert.ok(!err);
+          assert.ok(result);
+          assert.ok(body.tempResponse === 'temp');
+          assert.ok(client.lastResponseHeaders.status === 'fail');
+          assert.ok(client.lastRequestHeaders['options-test-header'] === 'test');
+
+          done();
+        });
+      }, baseUrl);
+    });
+
+    it('should allow calling the method with args, options, extra headers and callback last', function(done) {
+      soap.createClient(__dirname+'/wsdl/json_response.wsdl', function(err, client) {
+        assert.ok(client);
+        assert.ok(!err);
+
+        client.MyOperation({}, {headers: {'options-test-header': 'test'}}, {'test-header': 'test'}, function(err, result, body) {
+          assert.ok(!err);
+          assert.ok(result);
+          assert.ok(body.tempResponse === 'temp');
+          assert.ok(client.lastResponseHeaders.status === 'pass');
+          assert.ok(client.lastRequestHeaders['options-test-header'] === 'test');
+
+          done();
+        });
+      }, baseUrl);
+    });
   });
 
   it('should add soap headers', function (done) {


### PR DESCRIPTION
The main motivation behind this PR is to allow using a promise-based interface on top of this module.

The most common tools to promisify the async calls expect the callback to be the last argument but the SOAP methods are built with it in the second position, allowing a third and fourth optional params (`options`, and `extraHeaders`).

The proposed change allows more flexibility in method calls in order to support the following signatures:

```javascript
// standard and documented method signatures
client.MyFunction(args, callback)
client.MyFunction(args, callback, options)
client.MyFunction(args, callback, options, extraHeaders)

// non-documented but supported signature
client.MyFunction(callback)

// new supported signatures with callback as last param
client.MyFunction(args, options, callback)
client.MyFunction(args, options, extraHeaders, callback)
```

Documentation has been updated and tests added.
