### PR TITLE
Add the incoming message object to the client 'response' event

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -422,8 +422,8 @@ Soap body contents. Useful if you don't want to log /store Soap headers.
 * soapError - Emitted when an erroneous response is received.
   Useful if you want to globally log errors.
 * response - Emitted after a response is received. The event handler receives
-the entire response body. This is emitted for all responses (both success and
-errors).
+the SOAP response body as well as the entire `IncomingMessage` response object.
+This is emitted for all responses (both success and errors).
 
 
 ## WSSecurity

--- a/lib/client.js
+++ b/lib/client.js
@@ -278,7 +278,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
     self.lastResponse = body;
     self.lastResponseHeaders = response && response.headers;
     self.lastElapsedTime = response && response.elapsedTime;
-    self.emit('response', body);
+    self.emit('response', body, response);
 
     if (err) {
       callback(err);

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -632,14 +632,15 @@ describe('SOAP Client', function() {
       }, baseUrl);
     });
 
-    it('Should emit the "response" event with Soap Body string', function (done) {
+    it('Should emit the "response" event with Soap Body string and Response object', function (done) {
       soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', function (err, client) {
         var didEmitEvent = false;
-        client.on('response', function (xml) {
+        client.on('response', function (xml, response) {
           didEmitEvent = true;
           // Should contain entire soap message
           assert.equal(typeof xml, 'string');
           assert.equal(xml.indexOf('soap:Envelope'), -1);
+          assert.ok(response);
         });
 
         client.MyOperation({}, function() {


### PR DESCRIPTION
If i really want to look at the actual response (and not only the body
that has already been stripped from everything but the actual SOAP
Envelope in lib/http.js), i need the `response` object, i.e. the
IncomingMessage object as returned from the httpClient. 
Adding it to the 'response' event gives me the
opportunity to e.g. look at the headers and/or (in my case) the actual
body and start parsing a multipart response message

Signed-off-by: Pattrick Hueper <phueper@hueper.net>