### PR TITLE
Update http.js

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -67,9 +67,9 @@ HttpClient.prototype.buildRequest = function(rurl, data, exheaders, exoptions) {
     followAllRedirects: true
   };
 
-  if (headers.Connection === 'keep-alive') {
-    options.body = data;
-  }
+ 
+  options.body = data;
+  
 
   exoptions = exoptions || {};
   for (attr in exoptions) {
@@ -116,9 +116,7 @@ HttpClient.prototype.request = function(rurl, data, callback, exheaders, exoptio
     body = self.handleResponse(req, res, body);
     callback(null, res, body);
   });
-  if (headers.Connection !== 'keep-alive') {
-    req.end(data);
-  }
+  
   return req;
 };
 


### PR DESCRIPTION


by removing the streaming to request in the code (req.end() )
the request can be completly controlled by overwriting the request module

This is important for supporting file up- and downloading through soap

options.body can be replaced by multipart-body,
the xml in options.body can be split and streaming of base64 data included
without req.end() in the code.

so req.write(), piping to and from request and request.end() can be done
in the overwritten function and then the request module be called which will
give control back to soap through the callback

In the moment this works only if I set "keep-alive" in the header.
