### PR TITLE
Use easysax as dep for SAX parsing

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -7,7 +7,7 @@
 
 "use strict";
 
-var sax = require('sax');
+var EasySax = require('easysax');
 var inherits = require('util').inherits;
 var HttpClient = require('./http');
 var NamespaceContext = require('./nscontext');
@@ -1208,7 +1208,7 @@ WSDL.prototype.toXML = function() {
 
 WSDL.prototype.xmlToObject = function(xml) {
   var self = this;
-  var p = sax.parser(true);
+  var p = new EasySax();
   var objectName = null;
   var root = {};
   var schema = {
@@ -1235,11 +1235,9 @@ WSDL.prototype.xmlToObject = function(xml) {
 
   var refs = {}, id; // {id:{hrefs:[],obj:}, ...}
 
-  p.onopentag = function(node) {
-    var nsName = node.name;
-    var attrs  = node.attributes;
-
+  p.on('startNode', function(nsName, attr) {
     var name = splitQName(nsName).name,
+      attrs = attr(),
       attributeName,
       top = stack[stack.length - 1],
       topSchema = top.schema,
@@ -1337,9 +1335,9 @@ WSDL.prototype.xmlToObject = function(xml) {
     if (topSchema && topSchema[name + '[]'])
       name = name + '[]';
     stack.push({name: originalName, object: obj, schema: (xsiTypeSchema || (topSchema && topSchema[name])), id: attrs.id, nil: hasNilAttribute});
-  };
+  });
 
-  p.onclosetag = function(nsName) {
+  p.on('endNode', function(nsName) {
     var cur = stack.pop(),
       obj = cur.object,
       top = stack[stack.length - 1],
@@ -1375,27 +1373,9 @@ WSDL.prototype.xmlToObject = function(xml) {
     if (cur.id) {
       refs[cur.id].obj = obj;
     }
-  };
+  });
 
-  p.oncdata = function (text) {
-    text = trim(text);
-    if (!text.length)
-      return;
-
-    if (/<\?xml[\s\S]+\?>/.test(text)) {
-      var top = stack[stack.length - 1];
-      var value = self.xmlToObject(text);
-      if (top.object[self.options.attributesKey]) {
-        top.object[self.options.valueKey] = value;
-      } else {
-        top.object = value;
-      }
-    } else {
-      p.ontext(text);
-    }
-  };
-
-  p.ontext = function(text) {
+  p.on('textNode', function(text) {
     text = trim(text);
     if (!text.length)
       return;
@@ -1423,9 +1403,13 @@ WSDL.prototype.xmlToObject = function(xml) {
     } else {
       top.object = value;
     }
-  };
+  });
 
-  p.write(xml).close();
+  p.on('error', function(msg) {
+    throw new Error(msg);
+  });
+
+  p.parse(xml, false);
 
   // merge obj with href
   var merge = function(href, obj) {
@@ -1940,18 +1924,16 @@ WSDL.prototype.findChildSchemaObject = function(parameterTypeObj, childName) {
 
 WSDL.prototype._parse = function(xml) {
   var self = this,
-    p = sax.parser(true),
+    p = new EasySax(),
     stack = [],
     root = null,
     types = null,
     schema = null,
       options = self.options;
 
-  p.onopentag = function(node) {
-    var nsName = node.name;
-    var attrs  = node.attributes;
-
+  p.on('startNode', function(nsName, attr) {
     var top = stack[stack.length - 1];
+    var attrs = attr();
     var name;
     if (top) {
       try {
@@ -1980,16 +1962,20 @@ WSDL.prototype._parse = function(xml) {
         throw new Error('Unexpected root element of WSDL or include');
       }
     }
-  };
+  });
 
-  p.onclosetag = function(name) {
+  p.on('endNode', function(name) {
     var top = stack[stack.length - 1];
     assert(top, 'Unmatched close tag: ' + name);
 
     top.endElement(stack, name);
-  };
+  });
 
-  p.write(xml).close();
+  p.on('error', function(msg) {
+    throw new Error(msg);
+  });
+
+  p.parse(xml, false);
 
   return root;
 };

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "dependencies": {
     "debug": "~0.7.4",
     "lodash": "3.x.x",
+    "easysax": "^0.1.14",
     "request": ">=2.9.0",
-    "sax": ">=0.6",
     "selectn": "^0.9.6",
     "strip-bom": "~0.3.1",
     "ursa": "0.8.5 || >=0.9.3",


### PR DESCRIPTION
On a ~100KB XML file the following improvements were seen

`xmlToObject`
saxjs: ~98.2ms
node-expat: ~29.9ms
easysax: ~17.1ms
easysax-with-attrs: ~30.7ms

I removed the cdata, not sure if thats still needed?

refs https://github.com/vpulim/node-soap/pull/246#issuecomment-211424614
