### PR TITLE
added options object to cache hash

### DIFF
--- a/lib/soap.js
+++ b/lib/soap.js
@@ -21,7 +21,7 @@ function _requestWSDL(url, options, callback) {
     options = {};
   }
 
-  var wsdl = _wsdlCache[url];
+  var wsdl = _wsdlCache[url + JSON.stringify(options)];
   if (wsdl) {
     process.nextTick(function() {
       callback(null, wsdl);
@@ -32,7 +32,7 @@ function _requestWSDL(url, options, callback) {
       if (err)
         return callback(err);
       else
-        _wsdlCache[url] = wsdl;
+        _wsdlCache[url + JSON.stringify(options)] = wsdl;
       callback(null, wsdl);
     });
   }


### PR DESCRIPTION
Currently different options (like different authentication details) are being cached as long as they have the same URL. This is bad. This is a fix to make sure that the options object is also taken into consideration when caching objects.