### PR TITLE
Mock up cork/uncork to avoid test failure

### DIFF
--- a/test/client-customHttp-test.js
+++ b/test/client-customHttp-test.js
@@ -32,13 +32,19 @@ it('should allow customization of httpClient and the wsdl file download should p
   CustomAgent.prototype.addRequest = function(req, options) {
     req.onSocket(this.proxyStream);
   };
-    
+
   //Create a duplex stream 
     
   var httpReqStream = new stream.PassThrough();
   var httpResStream = new stream.PassThrough();
   var socketStream = duplexer(httpReqStream, httpResStream);
-  
+
+  // Node 4.x requires cork/uncork
+  socketStream.cork = function() {
+  };
+
+  socketStream.uncork = function() {
+  };
 
   //Custom httpClient  
   function MyHttpClient (options, socket){


### PR DESCRIPTION
`npm test` fails on master with Node 4.x and 5.x. The PR mocks up the socket.cork/uncork methods to fix the test failure.