### PR TITLE
Make ursa an optional dependency.

### DIFF
--- a/lib/security/WSSecurityCert.js
+++ b/lib/security/WSSecurityCert.js
@@ -1,6 +1,7 @@
 "use strict";
 
-var ursa = require('ursa');
+var optional = require("optional");
+var ursa = optional('ursa');
 var fs = require('fs');
 var path = require('path');
 var ejs = require('ejs');
@@ -36,7 +37,9 @@ function generateId() {
 }
 
 function WSSecurityCert(privatePEM, publicP12PEM, password, encoding) {
-
+  if (!ursa) {
+    throw new Error('Module ursa must be installed to use WSSecurityCert');
+  }
   this.privateKey = ursa.createPrivateKey(privatePEM, password, encoding);
   this.publicP12PEM = publicP12PEM.toString().replace('-----BEGIN CERTIFICATE-----', '').replace('-----END CERTIFICATE-----', '').replace(/(\r\n|\n|\r)/gm, '');
 

--- a/package.json
+++ b/package.json
@@ -9,15 +9,18 @@
   "dependencies": {
     "compress": "^0.99.0",
     "debug": "~0.7.4",
+    "ejs": "~2.3.4",
     "lodash": "3.x.x",
+    "node-uuid": "~1.4.3",
+    "optional": "^0.1.3",
     "request": ">=2.9.0",
     "sax": ">=0.6",
     "selectn": "^0.9.6",
     "strip-bom": "~0.3.1",
-    "ursa": "0.8.5 || >=0.9.3",
-    "node-uuid": "~1.4.3",
-    "ejs": "~2.3.4",
     "xml-crypto": "~0.8.0"
+  },
+  "optionalDependencies": {
+    "ursa": "0.8.5 || >=0.9.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
'ursa' is a binary module which is required when `WSSecurityCert` is used. For users who don't make use of X509 certificate it isn't required.

Introducing binary module brings extra requirement to the build environment. Some users report that unable to installed 'ursa'.

This PR makes 'ursa' an optional dependency. Fail to install it won't break other functionality of node-soap.

Update and restructure the README as well.