### PR TITLE
Fix custom http client not being used when fetching related resources

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1124,6 +1124,9 @@ WSDL.prototype._initializeOptions = function (options) {
   // Allow any request headers to keep passing through
   this.options.wsdl_headers = options.wsdl_headers;
   this.options.wsdl_options = options.wsdl_options;
+  if (options.httpClient) {
+    this.options.httpClient = options.httpClient;
+  }
 
   var ignoreBaseNameSpaces = options ? options.ignoreBaseNameSpaces : null;
   if(ignoreBaseNameSpaces !== null && typeof ignoreBaseNameSpaces !== 'undefined' )

--- a/test/_socketStream.js
+++ b/test/_socketStream.js
@@ -1,0 +1,47 @@
+
+var fs = require('fs'),
+  duplexer = require('duplexer'),
+  semver = require('semver'),
+  should = require('should'),
+  // stream = require('stream'),
+  stream = require('readable-stream');
+
+module.exports = function createSocketStream(file, length) {
+  //Create a duplex stream
+
+  var httpReqStream = new stream.PassThrough();
+  var httpResStream = new stream.PassThrough();
+  var socketStream = duplexer(httpReqStream, httpResStream);
+
+  // Node 4.x requires cork/uncork
+  socketStream.cork = function() {
+  };
+
+  socketStream.uncork = function() {
+  };
+
+  socketStream.req = httpReqStream;
+  socketStream.res = httpResStream;
+
+  var wsdl = fs.readFileSync(file).toString('utf8');
+  //Should be able to read from stream the request
+  socketStream.req.once('readable', function readRequest() {
+    var chunk = socketStream.req.read();
+    should.exist(chunk);
+
+    var header = 'HTTP/1.1 200 OK\r\nContent-Type: text/xml; charset=utf-8\r\nContent-Length: ' + length + '\r\n\r\n';
+
+    //This is for compatibility with old node releases <= 0.10
+    //Hackish
+    if(semver.lt(process.version, '0.11.0'))
+    {
+      socketStream.on('data', function(data) {
+        socketStream.ondata(data,0,length + header.length);
+      });
+    }
+    //Now write the response with the wsdl
+    var state = socketStream.res.write(header+wsdl);
+  });
+
+  return socketStream;
+};

--- a/test/client-customHttp-xsdinclude-test.js
+++ b/test/client-customHttp-xsdinclude-test.js
@@ -1,0 +1,92 @@
+'use strict';
+
+var soap = require('..'),
+    http = require('http'),
+    assert = require('assert'),
+  req = require('request'),
+  httpClient = require('../lib/http.js'),
+  util = require('util'),
+  events = require('events'),
+  createSocketStream = require('./_socketStream');
+
+it('should allow customization of httpClient, the wsdl file, and associated data download should pass through it', function(done) {
+
+  //Make a custom http agent to use streams instead of a real net socket
+  function CustomAgent(options, wsdl, xsd){
+    var self = this;
+    events.EventEmitter.call(this);
+    self.requests = [];
+    self.maxSockets = 1;
+    self.wsdlStream = wsdl;
+    self.xsdStream = xsd;
+    self.options = options || {};
+    self.proxyOptions = {};
+  }
+
+  util.inherits(CustomAgent, events.EventEmitter);
+
+  CustomAgent.prototype.addRequest = function(req, options) {
+    if (/\?xsd$/.test(req.path)) {
+      req.onSocket(this.xsdStream);
+    } else {
+      req.onSocket(this.wsdlStream);
+    }
+  };
+
+  //Custom httpClient
+  function MyHttpClient (options, wsdlSocket, xsdSocket){
+    httpClient.call(this,options);
+    this.agent = new CustomAgent(options, wsdlSocket, xsdSocket);
+  }
+
+  util.inherits(MyHttpClient, httpClient);
+
+  MyHttpClient.prototype.request = function(rurl, data, callback, exheaders, exoptions) {
+    var self = this;
+    var options = self.buildRequest(rurl, data, exheaders, exoptions);
+    //Specify agent to use
+    options.agent = this.agent;
+    var headers = options.headers;
+    var req = self._request(options, function(err, res, body) {
+      if (err) {
+        return callback(err);
+      }
+      body = self.handleResponse(req, res, body);
+      callback(null, res, body);
+    });
+    if (headers.Connection !== 'keep-alive') {
+      req.end(data);
+    }
+    return req;
+  };
+
+  var httpCustomClient = new MyHttpClient({},
+    createSocketStream(__dirname + '/wsdl/xsdinclude/xsd_include_http.wsdl', 2708),
+    createSocketStream(__dirname + '/wsdl/xsdinclude/types.xsd', 982)
+  );
+  var url = 'http://localhost:50000/Dummy.asmx?wsdl';
+  soap.createClient(url,
+    {httpClient: httpCustomClient},
+    function(err, client) {
+      assert.ok(client);
+      assert.ok(!err);
+      assert.equal(client.httpClient, httpCustomClient);
+      var description = (client.describe());
+      assert.deepEqual(client.describe(), {
+        DummyService: {
+          DummyPortType: {
+            Dummy: {
+              "input": {
+                "ID": "IdType|xs:string|pattern",
+                "Name": "NameType|xs:string|minLength,maxLength"
+              },
+              "output": {
+                "Result": "dummy:DummyList"
+              }
+            }
+          }
+        }
+      });
+      done();
+    });
+});

--- a/test/wsdl/xsdinclude/xsd_include_http.wsdl
+++ b/test/wsdl/xsdinclude/xsd_include_http.wsdl
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions targetNamespace="http://www.dummy.com"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                  xmlns:dummy="http://www.dummy.com/Types"
+                  xmlns:tns="http://www.dummy.com">
+	<wsdl:types>
+        <xs:schema targetNamespace="http://www.dummy.com/Types"
+                   xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                   xmlns:dummy="http://www.dummy.com/Types"
+                   elementFormDefault="qualified" attributeFormDefault="unqualified">
+            <xs:include schemaLocation="http://localhost:50000/Platform.asmx?xsd"/>
+            <xs:element name="DummyRequest">
+                <xs:complexType>
+                    <xs:sequence>
+        				<xs:element name="ID" type="dummy:IdType"/>
+        				<xs:element name="Name" type="dummy:NameType"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="DummyResponse">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="Result" type="dummy:DummyList"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:schema>
+	</wsdl:types>
+	<wsdl:message name="DummyRequest">
+		<wsdl:part name="DummyRequest" element="dummy:DummyRequest"/>
+	</wsdl:message>
+	<wsdl:message name="DummyResponse">
+		<wsdl:part name="DummyResponse" element="dummy:DummyResponse"/>
+	</wsdl:message>
+	<wsdl:portType name="DummyPortType">
+		<wsdl:operation name="Dummy">
+			<wsdl:input message="tns:DummyRequest"/>
+			<wsdl:output message="tns:DummyResponse"/>
+		</wsdl:operation>
+	</wsdl:portType>
+	<wsdl:binding name="DummyBinding" type="tns:DummyPortType">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+		<wsdl:operation name="Dummy">
+			<soap:operation soapAction="tns#Dummy" style="document"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="DummySave">
+			<soap:operation soapAction="tns#DummySave" style="document"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:service name="DummyService">
+		<wsdl:port name="DummyPortType" binding="tns:DummyBinding">
+			<soap:address location="http://www.dummy.com/"/>
+		</wsdl:port>
+	</wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
I found this issue when I was first trying to fix strictSSL issues when fetching the WSDL, but initially worked around it with `wsdl_options`. However, since I will need to rewrite some urls on the fly, I need the full custom client to work when fetching the wsdl and all related resources.

`_socketStream.js` can also be used to clean up `client-customHttp-test`, on which I based my test (which is why I put it in a separate file).

In summary: a 1 line fix, with 208 additional lines of test code. :beers: