### PR TITLE
Bumping ursa to 0.9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "xml-crypto": "~0.8.0"
   },
   "optionalDependencies": {
-    "ursa": "0.8.5 || >=0.9.3"
+    "ursa": "0.8.5 || >=0.9.4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
ursa 0.9.4 has fixes for node 6 deprecation warnings and efforts to fix the issues with installing it.