### PR TITLE
Support array of certs for ClientSSLSecurity ca.

### DIFF
--- a/lib/security/ClientSSLSecurity.js
+++ b/lib/security/ClientSSLSecurity.js
@@ -10,7 +10,7 @@ var fs = require('fs')
  * @module ClientSSLSecurity
  * @param {Buffer|String}   key
  * @param {Buffer|String}   cert
- * @param {Buffer|String}   [ca]
+ * @param {Buffer|String|Array}   [ca]
  * @param {Object}          [defaults]
  * @constructor
  */
@@ -36,7 +36,7 @@ function ClientSSLSecurity(key, cert, ca, defaults) {
   }
 
   if (ca) {
-    if(Buffer.isBuffer(ca)) {
+    if(Buffer.isBuffer(ca) || Array.isArray(ca)) {
       this.ca = ca;
     } else if (typeof ca === 'string') {
       this.ca = fs.readFileSync(ca);

--- a/test/_socketStream.js
+++ b/test/_socketStream.js
@@ -1,3 +1,4 @@
+'use strict';
 
 var fs = require('fs'),
   duplexer = require('duplexer'),

--- a/test/security/ClientSSLSecurity.js
+++ b/test/security/ClientSSLSecurity.js
@@ -43,4 +43,10 @@ describe('ClientSSLSecurity', function() {
     instance.should.have.property("cert", certBuffer);
     instance.should.have.property("key", keyBuffer);
   });
+
+  it('should accept a Array as argument for the ca', function () {
+    var caList = [];
+    var instance = new ClientSSLSecurity(null, null, caList);
+    instance.should.have.property("ca", caList);
+  });
 });


### PR DESCRIPTION
In server configurations where there are problems with the server side
certificate chain, it is sometimes required that the client add multiple
certs into the trust repository. The lower-level https library supports
this transparently in the agentOptions but ClientSSLSecurity's type
detection of Buffer and String made it impossible to access directly.

This commit adds support for passing an array of certificates.