### PR TITLE
gracefully handle errors while parsing xml in xmlToObject and resume the parser with p.resume()

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -155,12 +155,17 @@ Server.prototype._requestListener = function(req, res) {
         });
       }
       catch (err) {
-        error = err.stack || err;
-        res.statusCode = 500;
-        res.write(error);
-        res.end();
-        if (typeof self.log === 'function') {
-          self.log("error", error);
+        if (err.Fault !== undefined) {
+          return self._sendError(err.Fault, function(result, statusCode) {
+            if(statusCode) {
+              res.statusCode = statusCode || 500;
+            }
+            res.write(result);
+            res.end();
+            if (typeof self.log === 'function') {
+              self.log("error", err);
+            }
+          }, new Date().toISOString());
         }
       }
     });

--- a/lib/server.js
+++ b/lib/server.js
@@ -166,6 +166,14 @@ Server.prototype._requestListener = function(req, res) {
               self.log("error", err);
             }
           }, new Date().toISOString());
+        } else {
+          error = err.stack || err;
+          res.statusCode = 500;
+          res.write(error);
+          res.end();
+          if (typeof self.log === 'function') {
+            self.log("error", error);
+          }
         }
       }
     });

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1412,6 +1412,7 @@ WSDL.prototype.xmlToObject = function(xml) {
   };
 
   p.onerror = function(e) {
+    p.resume();
     throw {
       Fault: {
         faultcode: 500,
@@ -1420,8 +1421,7 @@ WSDL.prototype.xmlToObject = function(xml) {
         statusCode: 500
       }
     };
-    p.resume();
-  }
+  };
 
   p.ontext = function(text) {
     text = trim(text);

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1411,6 +1411,18 @@ WSDL.prototype.xmlToObject = function(xml) {
     }
   };
 
+  p.onerror = function(e) {
+    throw {
+      Fault: {
+        faultcode: 500,
+        faultstring: 'Invalid XML',
+        detail: new Error(e).message,
+        statusCode: 500
+      }
+    };
+    p.resume();
+  }
+
   p.ontext = function(text) {
     text = trim(text);
     if (!text.length) {

--- a/test/_socketStream.js
+++ b/test/_socketStream.js
@@ -34,7 +34,8 @@ module.exports = function createSocketStream(file, length) {
 
     //This is for compatibility with old node releases <= 0.10
     //Hackish
-    if(semver.lt(process.version, '0.11.0')) {
+    if(semver.lt(process.version, '0.11.0'))
+    {
       socketStream.on('data', function(data) {
         socketStream.ondata(data,0,length + header.length);
       });
@@ -42,4 +43,6 @@ module.exports = function createSocketStream(file, length) {
     //Now write the response with the wsdl
     var state = socketStream.res.write(header+wsdl);
   });
+
+  return socketStream;
 };

--- a/test/_socketStream.js
+++ b/test/_socketStream.js
@@ -1,4 +1,4 @@
-
+'use strict';
 var fs = require('fs'),
   duplexer = require('duplexer'),
   semver = require('semver'),

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -185,6 +185,25 @@ describe('SOAP Server', function() {
     );
   });
 
+  it('should 500 on missing tag message', function(done) {
+    request.post({
+        url: test.baseUrl + '/stockquote?wsdl',
+        body : '<soapenv:Envelope' +
+                    ' xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"' +
+                    ' xmlns:soap="http://service.applicationsnet.com/soap/">' +
+                '  <soapenv:Header/>' +
+                '  <soapenv:Body>' +
+                '</soapenv:Envelope>',
+        headers: {'Content-Type': 'text/xml'}
+      }, function(err, res, body) {
+        assert.ok(!err);
+        assert.equal(res.statusCode, 500);
+        assert.ok(body.length);
+        done();
+      }
+    );
+  });
+
   it('should server up WSDL', function(done) {
     request(test.baseUrl + '/stockquote?wsdl', function(err, res, body) {
       assert.ok(!err);


### PR DESCRIPTION
Trying to handle sax parser error but can’t find sax parser handling error event in wsdl which result in breaking of app. We can  gracefully handle errors and resume the parser with p.resume(), assign a listener to the error event in the catch block 