### PR TITLE
attribute value of body id in double quotes

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -246,7 +246,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
       ) +
     "<" + envelopeKey + ":Body" +
     (self.bodyAttributes ? self.bodyAttributes.join(' ') : '') +
-    (self.security && self.security.postProcess ? " Id='_0'" : '') +
+    (self.security && self.security.postProcess ? ' Id="_0"' : '') +
     ">" +
     message +
     "</" + envelopeKey + ":Body>" +


### PR DESCRIPTION
It is valid to use single quotes for attribute values, but the body id is the only one. Just making it neat and tidy.