### PR TITLE
mustUnderstand only accepts 1 or 0

### DIFF
--- a/lib/security/templates/wsse-security-header.ejs
+++ b/lib/security/templates/wsse-security-header.ejs
@@ -1,6 +1,6 @@
 <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
                xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
-               soap:mustUnderstand="true">
+               soap:mustUnderstand="1">
  	<wsse:BinarySecurityToken   
                EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary" 
                ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3" 


### PR DESCRIPTION
If you look at http://schemas.xmlsoap.org/soap/envelope/, the mustUnderstand only accepts 0 or 1, not true or false.