### PR TITLE
soap request envelop generation fails when request has complexType as root

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -217,11 +217,11 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
   if (self.security && self.security.addOptions)
     self.security.addOptions(options);
 
-  if (input.parts || args === null) {
-    assert.ok(!style || style === 'rpc', 'invalid message definition for document style binding');
-    message = self.wsdl.objectToRpcXML(name, args, alias, ns);
-    (method.inputSoap === 'encoded') && (encoding = 'soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" ');
-  } else if (typeof (args) === 'string') {
+    if ((style === 'rpc')&& ( ( input.parts || input.name==="element" ) || args === null) ) {
+      assert.ok(!style || style === 'rpc', 'invalid message definition for document style binding');
+      message = self.wsdl.objectToRpcXML(name, args, alias, ns,(input.name!=="element" ));
+      (method.inputSoap === 'encoded') && (encoding = 'soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" ');
+    } else if (typeof (args) === 'string') {
     message = args;
   } else {
     assert.ok(!style || style === 'document', 'invalid message definition for rpc style binding');

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1540,31 +1540,33 @@ WSDL.prototype.objectToDocumentXML = function(name, params, nsPrefix, nsURI, typ
  * @param {String} nsURI
  * @returns {string}
  */
-WSDL.prototype.objectToRpcXML = function(name, params, nsPrefix, nsURI) {
-  var parts = [];
-  var defs = this.definitions;
-  var nsAttrName = '_xmlns';
+ WSDL.prototype.objectToRpcXML = function(name, params, nsPrefix, nsURI,isParts) {
+   var parts = [];
+   var defs = this.definitions;
+   var nsAttrName = '_xmlns';
 
-  nsPrefix = nsPrefix || findPrefix(defs.xmlns, nsURI);
-  nsURI = nsURI || defs.xmlns[nsPrefix];
-  nsPrefix = nsPrefix === TNS_PREFIX ? '' : (nsPrefix + ':');
-  parts.push(['<', nsPrefix, name, '>'].join(''));
+   nsPrefix = nsPrefix || findPrefix(defs.xmlns, nsURI);
 
-  for (var key in params) {
-    if (!params.hasOwnProperty(key)) {
-      continue;
-    }
-    if (key !== nsAttrName) {
-      var value = params[key];
-      parts.push(['<', key, '>'].join(''));
-      parts.push((typeof value === 'object') ? this.objectToXML(value, key, nsPrefix, nsURI) : xmlEscape(value));
-      parts.push(['</', key, '>'].join(''));
-    }
-  }
-  parts.push(['</', nsPrefix, name, '>'].join(''));
+   nsURI = nsURI || defs.xmlns[nsPrefix];
+   nsPrefix = nsPrefix === TNS_PREFIX ? '' : (nsPrefix + ':');
 
-  return parts.join('');
-};
+   parts.push(['<', nsPrefix, name, '>'].join(''));
+
+   for (var key in params) {
+     if (!params.hasOwnProperty(key)) {
+       continue;
+     }
+     if (key !== nsAttrName) {
+       var value = params[key];
+       var prefixedKey = (isParts ? '' : nsPrefix) + key;
+       parts.push(['<', prefixedKey, '>'].join(''));
+       parts.push((typeof value === 'object') ? this.objectToXML(value, key, nsPrefix, nsURI) : xmlEscape(value));
+       parts.push(['</', prefixedKey, '>'].join(''));
+     }
+   }
+   parts.push(['</', nsPrefix, name, '>'].join(''));
+   return parts.join('');
+ };
 
 
 function appendColon(ns) {

--- a/test/request-response-samples/createData__should_generate_complex_type_request/request.json
+++ b/test/request-response-samples/createData__should_generate_complex_type_request/request.json
@@ -1,0 +1,30 @@
+{
+  "ModelCRUDRequest":{
+  "ModelCRUD":{
+    "serviceType":"CreateInterest",
+    "TableName":"WTC_EmployeeInterest",
+    "RecordID":0,
+    "Filter":"",
+    "Action":"Create",
+          "DataRow":{
+              "field":[{
+                  "attributes":{"column":"C_BPartner_ID"},
+                  "val":"1001047"
+              },{
+                "attributes":{"column":"Interest"},
+                "val":"Cooking"
+              }]
+          }
+  },
+  "ADLoginRequest":{
+    "user":"WTCAdmin",
+    "pass":"WTCAdmin",
+    "lang":"192",
+    "ClientID":11,
+    "RoleID":102,
+    "OrgID":1000001,
+    "WarehouseID":1000000,
+    "stage":0
+  }
+ }
+}

--- a/test/request-response-samples/createData__should_generate_complex_type_request/request.xml
+++ b/test/request-response-samples/createData__should_generate_complex_type_request/request.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://3e.pl/ADInterface">
+   <soap:Body>
+      <tns:createData>
+         <tns:ModelCRUDRequest>
+            <ModelCRUD>
+               <serviceType>CreateInterest</serviceType>
+               <TableName>WTC_EmployeeInterest</TableName>
+               <RecordID>0</RecordID>
+               <Filter></Filter>
+               <Action>Create</Action>
+               <DataRow>
+                  <tns:field column="C_BPartner_ID">
+                     <val>1001047</val>
+                  </tns:field>
+                  <tns:field column="Interest">
+                     <val>Cooking</val>
+                  </tns:field>
+               </DataRow>
+            </ModelCRUD>
+            <ADLoginRequest>
+               <user>WTCAdmin</user>
+               <pass>WTCAdmin</pass>
+               <lang>192</lang>
+               <ClientID>11</ClientID>
+               <RoleID>102</RoleID>
+               <OrgID>1000001</OrgID>
+               <WarehouseID>1000000</WarehouseID>
+               <stage>0</stage>
+            </ADLoginRequest>
+         </tns:ModelCRUDRequest>
+      </tns:createData>
+   </soap:Body>
+</soap:Envelope>

--- a/test/request-response-samples/createData__should_generate_complex_type_request/response.json
+++ b/test/request-response-samples/createData__should_generate_complex_type_request/response.json
@@ -1,0 +1,6 @@
+{
+  "StandardResponse":{
+    "attributes":{"RecordID":"1000027"}
+  }
+
+}

--- a/test/request-response-samples/createData__should_generate_complex_type_request/response.xml
+++ b/test/request-response-samples/createData__should_generate_complex_type_request/response.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+   <soap:Body>
+      <ns1:createDataResponse xmlns:ns1="http://3e.pl/ADInterface">
+         <StandardResponse RecordID="1000027" xmlns="http://3e.pl/ADInterface"/>
+      </ns1:createDataResponse>
+   </soap:Body>
+</soap:Envelope>

--- a/test/request-response-samples/createData__should_generate_complex_type_request/soap.wsdl
+++ b/test/request-response-samples/createData__should_generate_complex_type_request/soap.wsdl
@@ -1,0 +1,159 @@
+<wsdl:definitions xmlns:soapenc12="http://www.w3.org/2003/05/soap-encoding" xmlns:tns="http://3e.pl/ADInterface" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap11="http://schemas.xmlsoap.org/soap/envelope/" xmlns:wsdlsoap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soapenc11="http://schemas.xmlsoap.org/soap/encoding/" xmlns:soap12="http://www.w3.org/2003/05/soap-envelope" targetNamespace="http://3e.pl/ADInterface">
+<script id="tinyhippos-injected"/>
+<wsdl:types>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://3e.pl/ADInterface" elementFormDefault="qualified" targetNamespace="http://3e.pl/ADInterface">
+
+<xsd:complexType name="Field">
+<xsd:sequence>
+<xsd:element name="Tab" type="tns:Tab"/>
+<xsd:element name="lookupInfo" type="tns:LookupInfo"/>
+<xsd:element name="Description" type="xsd:string"/>
+<xsd:element name="Help" type="xsd:string"/>
+<xsd:element name="ColumnSQL" type="xsd:string"/>
+<xsd:element name="DisplayLogic" type="xsd:string"/>
+<xsd:element name="ReadOnlyLogic" type="xsd:string"/>
+<xsd:element maxOccurs="1" minOccurs="0" name="lookup" type="tns:LookupValues"/>
+</xsd:sequence>
+<xsd:attribute name="Name" type="xsd:string"/>
+<xsd:attribute name="WindowNo" type="xsd:int"/>
+<xsd:attribute name="TabNo" type="xsd:int"/>
+<xsd:attribute name="AD_Window_ID" type="xsd:int"/>
+<xsd:attribute name="tabReadOnly" type="xsd:boolean"/>
+<xsd:attribute name="isProcess" type="xsd:boolean"/>
+<xsd:attribute name="ColumnName" type="xsd:string"/>
+<xsd:attribute name="Header" type="xsd:string"/>
+<xsd:attribute name="displayType" type="xsd:int"/>
+<xsd:attribute name="AD_Column_ID" type="xsd:int"/>
+<xsd:attribute name="DisplayLength" type="xsd:int"/>
+<xsd:attribute name="IsSameLine" type="xsd:boolean"/>
+<xsd:attribute name="IsDisplayed" type="xsd:boolean"/>
+<xsd:attribute name="DefaultValue" type="xsd:string"/>
+<xsd:attribute name="IsMandatory" type="xsd:boolean"/>
+<xsd:attribute name="IsReadOnly" type="xsd:boolean"/>
+<xsd:attribute name="IsUpdateable" type="xsd:boolean"/>
+<xsd:attribute name="IsAlwaysUpdateable" type="xsd:boolean"/>
+<xsd:attribute name="IsHeading" type="xsd:boolean"/>
+<xsd:attribute name="IsFieldOnly" type="xsd:boolean"/>
+<xsd:attribute name="IsEncryptedField" type="xsd:boolean"/>
+<xsd:attribute name="IsEncryptedColumn" type="xsd:boolean"/>
+<xsd:attribute name="IsSelectionColumn" type="xsd:boolean"/>
+<xsd:attribute name="SortNo" type="xsd:int"/>
+<xsd:attribute name="FieldLength" type="xsd:int"/>
+<xsd:attribute name="VFormat" type="xsd:string"/>
+<xsd:attribute name="ValueMin" type="xsd:string"/>
+<xsd:attribute name="ValueMax" type="xsd:string"/>
+<xsd:attribute name="FieldGroup" type="xsd:string"/>
+<xsd:attribute name="IsKey" type="xsd:boolean"/>
+<xsd:attribute name="IsParent" type="xsd:boolean"/>
+<xsd:attribute name="Callout" type="xsd:string"/>
+<xsd:attribute name="AD_Process_ID" type="xsd:int"/>
+<xsd:attribute name="ObscureType" type="xsd:string"/>
+<xsd:attribute name="ValidationCode" type="xsd:string"/>
+<xsd:attribute name="AD_Reference_Value_ID" type="xsd:int"/>
+<xsd:attribute name="isRange" type="xsd:boolean"/>
+<xsd:attribute name="DefaultValue2" type="xsd:string"/>
+</xsd:complexType>
+<xsd:complexType name="DataRow">
+<xsd:sequence>
+<xsd:element maxOccurs="unbounded" minOccurs="0" name="field" type="tns:DataField"/>
+</xsd:sequence>
+</xsd:complexType>
+<!--
+
+   int WindowNo, int AD_Window_ID, int AD_Menu_ID, int TabNo, int PrevTabNo, int PrevRecNo, boolean getData, int RowStart, int RowCount)
+
+-->
+<xsd:element name="ADLoginRequest" type="tns:ADLoginRequest"/>
+<xsd:element name="ADLoginResponse" type="tns:ADLoginResponse"/>
+<xsd:complexType name="ADLoginRequest">
+<xsd:sequence>
+<xsd:element name="user" type="xsd:string"/>
+<xsd:element name="pass" type="xsd:string"/>
+<xsd:element name="lang" type="xsd:string"/>
+<xsd:element name="ClientID" type="xsd:int"/>
+<xsd:element name="RoleID" type="xsd:int"/>
+<xsd:element name="OrgID" type="xsd:int"/>
+<xsd:element name="WarehouseID" type="xsd:int"/>
+<xsd:element name="stage" type="xsd:int"/>
+</xsd:sequence>
+</xsd:complexType>
+<xsd:complexType name="ADLoginResponse">
+<xsd:sequence>
+<xsd:element name="status" type="xsd:int"/>
+<xsd:element name="roles" type="tns:LookupValues"/>
+<xsd:element name="langs" type="tns:LookupValues"/>
+<xsd:element name="orgs" type="tns:LookupValues"/>
+<xsd:element name="clients" type="tns:LookupValues"/>
+<xsd:element name="warehouses" type="tns:LookupValues"/>
+</xsd:sequence>
+</xsd:complexType>
+<xsd:complexType name="StandardResponse">
+<xsd:sequence>
+<xsd:element name="Error" type="xsd:string"/>
+</xsd:sequence>
+<xsd:attribute name="IsError" type="xsd:boolean"/>
+<xsd:attribute name="RecordID" type="xsd:int"/>
+</xsd:complexType>
+<xsd:element name="Location" type="tns:Location"/>
+<xsd:element name="StandardResponse" type="tns:StandardResponse"/>
+
+
+<xsd:element name="ModelCRUDRequest" type="tns:ModelCRUDRequest"/>
+<xsd:complexType name="ModelCRUD">
+<xsd:sequence>
+<xsd:element name="serviceType" type="xsd:string"/>
+<xsd:element name="TableName" type="xsd:string"/>
+<xsd:element name="RecordID" type="xsd:int"/>
+<xsd:element name="Filter" type="xsd:string"/>
+<xsd:element name="Action">
+<xsd:simpleType>
+<xsd:restriction base="xsd:string">
+<xsd:enumeration value="Create"/>
+<xsd:enumeration value="Read"/>
+<xsd:enumeration value="Update"/>
+<xsd:enumeration value="Delete"/>
+</xsd:restriction>
+</xsd:simpleType>
+</xsd:element>
+<xsd:element maxOccurs="1" minOccurs="0" name="DataRow" type="tns:DataRow"/>
+</xsd:sequence>
+</xsd:complexType>
+<xsd:complexType name="ModelCRUDRequest">
+<xsd:sequence>
+<xsd:element maxOccurs="1" minOccurs="1" name="ModelCRUD" type="tns:ModelCRUD"/>
+<xsd:element maxOccurs="1" minOccurs="1" name="ADLoginRequest" type="tns:ADLoginRequest"/>
+</xsd:sequence>
+</xsd:complexType>
+</xsd:schema>
+</wsdl:types>
+<wsdl:message name="createDataRequest">
+<wsdl:part name="ModelCRUDRequest" element="tns:ModelCRUDRequest"/>
+</wsdl:message>
+<wsdl:message name="createDataResponse">
+<wsdl:part name="StandardResponse" element="tns:StandardResponse"/>
+</wsdl:message>
+<wsdl:portType name="ModelADServicePortType">
+<wsdl:operation name="createData">
+<wsdl:input name="createDataRequest" message="tns:createDataRequest"/>
+<wsdl:output name="createDataResponse" message="tns:createDataResponse"/>
+</wsdl:operation>
+</wsdl:portType>
+<wsdl:binding name="ModelADServiceHttpBinding" type="tns:ModelADServicePortType">
+<wsdlsoap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/>
+<wsdl:operation name="createData">
+<wsdlsoap:operation soapAction=""/>
+<wsdl:input name="createDataRequest">
+<wsdlsoap:body use="literal" namespace="http://3e.pl/ADInterface"/>
+</wsdl:input>
+<wsdl:output name="createDataResponse">
+<wsdlsoap:body use="literal" namespace="http://3e.pl/ADInterface"/>
+</wsdl:output>
+</wsdl:operation>
+
+</wsdl:binding>
+<wsdl:service name="ModelADService">
+<wsdl:port name="ModelADServiceHttpPort" binding="tns:ModelADServiceHttpBinding">
+<wsdlsoap:address location="http://localhost:1509"/>
+</wsdl:port>
+</wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
Below is the sample of the one operation from my wsdl

```
<wsdl:operation name="queryData">
<wsdl:input name="queryDataRequest" message="tns:queryDataRequest"/>
<wsdl:output name="queryDataResponse" message="tns:queryDataResponse"/>
</wsdl:operation>

<wsdl:message name="queryDataRequest">
<wsdl:part name="ModelCRUDRequest" element="tns:ModelCRUDRequest"/>
</wsdl:message>


<xsd:complexType name="ModelCRUDRequest">
<xsd:sequence>
<xsd:element maxOccurs="1" minOccurs="1" name="ModelCRUD" type="tns:ModelCRUD"/>
<xsd:element maxOccurs="1" minOccurs="1" name="ADLoginRequest" type="tns:ADLoginRequest"/>
</xsd:sequence>
</xsd:complexType>


<xsd:complexType name="ModelCRUD">
<xsd:sequence>
<xsd:element name="serviceType" type="xsd:string"/>
<xsd:element name="TableName" type="xsd:string"/>
<xsd:element name="RecordID" type="xsd:int"/>
<xsd:element name="Filter" type="xsd:string"/>
<xsd:element name="Action">
<xsd:simpleType>
<xsd:restriction base="xsd:string">
<xsd:enumeration value="Create"/>
<xsd:enumeration value="Read"/>
<xsd:enumeration value="Update"/>
<xsd:enumeration value="Delete"/>
</xsd:restriction>
</xsd:simpleType>
</xsd:element>
<xsd:element maxOccurs="1" minOccurs="0" name="DataRow" type="tns:DataRow"/>
</xsd:sequence>
</xsd:complexType>

<xsd:complexType name="ADLoginRequest">
<xsd:sequence>
<xsd:element name="user" type="xsd:string"/>
<xsd:element name="pass" type="xsd:string"/>
<xsd:element name="lang" type="xsd:string"/>
<xsd:element name="ClientID" type="xsd:int"/>
<xsd:element name="RoleID" type="xsd:int"/>
<xsd:element name="OrgID" type="xsd:int"/>
<xsd:element name="WarehouseID" type="xsd:int"/>
<xsd:element name="stage" type="xsd:int"/>
</xsd:sequence>
</xsd:complexType>
```


for the above operation the input envelop should be generated as below

```
 <tns:createData>
     <tns:ModelCRUDRequest><tns:ModelCRUD>
    <tns:serviceType>CreateInterest</tns:serviceType>   <tns:TableName>EmployeeInterest</tns:TableName>
<tns:RecordID>0</tns:RecordID>
<tns:Filter></tns:Filter>
<tns:Action>Create</tns:Action>
<tns:DataRow>
     <tns:field column="C_BPartner_ID">
     <tns:val>1001047</tns:val>
   </tns:field>
   <tns:field column="Interest">
   <tns:val>Cooking</tns:val>
    </tns:field></tns:DataRow>
</tns:ModelCRUD>
<tns:ADLoginRequest>
<tns:user>WTCAdmin</tns:user>
<tns:pass>WTCAdmin</tns:pass>
<tns:lang>192</tns:lang>
<tns:ClientID>121</tns:ClientID>
<tns:RoleID>1112</tns:RoleID>
<tns:OrgID>21212</tns:OrgID>
<tns:WarehouseID>23433</tns:WarehouseID>
<tns:stage>0</tns:stage>
</tns:ADLoginRequest>
</tns:ModelCRUDRequest>
</tns:createData>
```

where as the current version throws AssertError.

Which is fixed in this commit.
