### PR TITLE
mustUnderstand must be 0 or 1.. with tests

### DIFF
--- a/lib/security/templates/wsse-security-header.ejs
+++ b/lib/security/templates/wsse-security-header.ejs
@@ -1,6 +1,6 @@
 <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
                xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
-               soap:mustUnderstand="true">
+               soap:mustUnderstand="1">
  	<wsse:BinarySecurityToken   
                EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary" 
                ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3" 

--- a/lib/security/templates/wsse-security-token.ejs
+++ b/lib/security/templates/wsse-security-token.ejs
@@ -1,3 +1,3 @@
 <wsse:SecurityTokenReference>
-    <wsse:Reference URI="<%-x509Id%>" ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3"/>
+    <wsse:Reference URI="#<%-x509Id%>" ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3"/>
 </wsse:SecurityTokenReference>

--- a/test/security/WSSecurityCert.js
+++ b/test/security/WSSecurityCert.js
@@ -53,7 +53,7 @@ describe('WSSecurityCert', function() {
     xml.should.containEql('<wsse:Security');
     xml.should.containEql('http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd');
     xml.should.containEql('http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd');
-    xml.should.containEql('soap:mustUnderstand="true"');
+    xml.should.containEql('soap:mustUnderstand="1"');
     xml.should.containEql('<wsse:BinarySecurityToken');
     xml.should.containEql('EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary');
     xml.should.containEql('ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3"');

--- a/test/security/WSSecurityCert.js
+++ b/test/security/WSSecurityCert.js
@@ -64,7 +64,7 @@ describe('WSSecurityCert', function() {
     xml.should.containEql('<Expires>' + instance.expires);
     xml.should.containEql('<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">');
     xml.should.containEql('<wsse:SecurityTokenReference>');
-    xml.should.containEql('<wsse:Reference URI="' + instance.x509Id);
+    xml.should.containEql('<wsse:Reference URI="#' + instance.x509Id);
     xml.should.containEql('ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3"/>');
     xml.should.containEql(instance.publicP12PEM);
     xml.should.containEql(instance.signer.getSignatureXml());


### PR DESCRIPTION
If you look at http://schemas.xmlsoap.org/soap/envelope/, the mustUnderstand only accepts 0 or 1, not true or false. Also altered the test