### PR TITLE
Remove special handling of methods only taking a string paramter

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -221,8 +221,6 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
       assert.ok(!style || style === 'rpc', 'invalid message definition for document style binding');
       message = self.wsdl.objectToRpcXML(name, args, alias, ns,(input.name!=="element" ));
       (method.inputSoap === 'encoded') && (encoding = 'soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" ');
-    } else if (typeof (args) === 'string') {
-    message = args;
   } else {
     assert.ok(!style || style === 'document', 'invalid message definition for rpc style binding');
     // pass `input.$lookupType` if `input.$type` could not be found

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -695,4 +695,35 @@ describe('SOAP Client', function() {
 
   });
 
+  describe('Method invocation', function() {
+
+    it('shall generate correct payload for methods with string parameter', function(done) {
+      // Mock the http post function in order to easy be able to validate the
+      // generated payload
+      var stringParameterValue = 'MY_STRING_PARAMETER_VALUE';
+      var expectedSoapBody = '<sstringElement xmlns="http://www.BuiltinTypes.com/">' +
+          stringParameterValue +
+          '</sstringElement>';
+      var request = null;
+      var mockRequestHandler = function(_request) {
+        request = _request;
+        return {};
+      };
+      var options = {
+        request: mockRequestHandler,
+      };
+      soap.createClient(__dirname+'/wsdl/builtin_types.wsdl', options, function(err, client) {
+        assert.ok(client);
+
+        // Call the method
+        client.StringOperation(stringParameterValue);
+
+        // Analyse and validate the generated soap body
+        var requestBody = request.body;
+        var soapBody = requestBody.match(/<soap:Body>(.*)<\/soap:Body>/)[1];
+        assert.ok(soapBody === expectedSoapBody);
+        done();
+      });
+    });
+  });
 });

--- a/test/wsdl/builtin_types.wsdl
+++ b/test/wsdl/builtin_types.wsdl
@@ -98,6 +98,10 @@
     <wsdl:part name="unsignedByte" element="tns:unsignedByteElement" />
   </wsdl:message>
 
+  <wsdl:message name="StringRequest">
+    <wsdl:part element="tns:sstringElement" name="string"></wsdl:part>
+  </wsdl:message>
+
   <wsdl:message name="Response">
     <wsdl:part name="nonPositiveInteger" element="tns:nonPositiveIntegerElement" />
     <wsdl:part name="body" element="tns:nonNegativeIntegerElement"/>
@@ -108,12 +112,26 @@
       <wsdl:input message="tns:Request"/>
       <wsdl:output message="tns:Response"/>
     </wsdl:operation>
+    <wsdl:operation name="StringOperation">
+      <wsdl:input message="tns:StringRequest"/>
+      <wsdl:output message="tns:Response"/>
+    </wsdl:operation>
   </wsdl:portType>
 
   <wsdl:binding name="Binding" type="tns:PortType">
     <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
     <wsdl:operation name="Operation">
       <soap:operation soapAction="http://www.BuiltinTypes.com/Operation" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+
+    <wsdl:operation name="StringOperation">
+      <soap:operation soapAction="http://www.BuiltinTypes.com/StringOperation" style="document"/>
       <wsdl:input>
         <soap:body use="literal"/>
       </wsdl:input>


### PR DESCRIPTION
Methods where the only argument is a string will get caught here
and because of that wrong xml message will be generated and posted
to the server.

The service I am trying to connect to as well as this site: https://www.wsdl-analyzer.com/
says that the expected payload now is generated, before it was not possible to pass a string argument to the client.[METHOD] function unless that was a full xml-formatted body. Calling the function with an object as argument does not generate the expected body, since the data then get's embedded into one more layers of xml-tags.

Please correct me if I'm wrong, maybe I use the library wrong, but could not get this to work in any other way.

### Changes
**lib/client.js** - Removed line 224 and 225 and that is my actual patch

**test/client-test.js** - Added unit test for the patch


