### PR TITLE
added tns prefix in SOAP's method name, the server requires it

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -224,7 +224,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
   } else {
     assert.ok(!style || style === 'document', 'invalid message definition for rpc style binding');
     // pass `input.$lookupType` if `input.$type` could not be found
-    message = self.wsdl.objectToDocumentXML(input.$name, args, input.targetNSAlias, input.targetNamespace, (input.$type || input.$lookupType));
+    message = self.wsdl.objectToDocumentXML("tns:" + input.$name, args, input.targetNSAlias, input.targetNamespace, (input.$type || input.$lookupType));
   }
   xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
     "<" + envelopeKey + ":Envelope " +


### PR DESCRIPTION
SOAP server doesn’t accept the SOAP call if tns colon prefix is not
present in SOAP’s method name