### PR TITLE
Fix method name discovery for RPC calls where the first XML element has some attributes.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -242,8 +242,9 @@ Server.prototype._process = function(input, req, callback) {
   }
 
   try {
+    var firstXmlElement = (Object.keys(body)[0] === 'attributes' ? Object.keys(body)[1] : Object.keys(body)[0]);
     if (binding.style === 'rpc') {
-      methodName = Object.keys(body)[0];
+      methodName = firstXmlElement;
 
       self.emit('request', obj, methodName);
       if (headers)
@@ -259,7 +260,7 @@ Server.prototype._process = function(input, req, callback) {
         style: 'rpc'
       }, req, callback);
     } else {
-      var messageElemName = (Object.keys(body)[0] === 'attributes' ? Object.keys(body)[1] : Object.keys(body)[0]);
+      var messageElemName = firstXmlElement;
       var pair = binding.topElements[messageElemName];
 
       self.emit('request', obj, pair.methodName);


### PR DESCRIPTION
The same logic was already in place for "Document" type request. So I just applied it to both cases (RPC and Document).
