### PR TITLE
Fix possible crash when send empty post using postman

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -46,7 +46,7 @@ var Server = function(server, path, services, wsdl, options) {
     server.removeAllListeners('request');
     server.addListener('request', function(req, res) {
       if (typeof self.authorizeConnection === 'function') {
-        if (!self.authorizeConnection(req.connection.remoteAddress)) {
+        if (!self.authorizeConnection(req)) {
           res.end();
           return;
         }

--- a/lib/server.js
+++ b/lib/server.js
@@ -120,7 +120,11 @@ Server.prototype._requestListener = function(req, res) {
     }
     res.end();
   } else if (req.method === 'POST') {
-    res.setHeader('Content-Type', req.headers['content-type'] || "application/xml");
+	if (typeof req.headers['content-type'] !== "undefined") {
+	  res.setHeader('Content-Type', req.headers['content-type']);
+	} else {
+	  res.setHeader('Content-Type', "application/xml");
+	}
     var chunks = [], gunzip;
     if (compress && req.headers["content-encoding"] === "gzip") {
       gunzip = new compress.Gunzip();

--- a/lib/server.js
+++ b/lib/server.js
@@ -120,7 +120,7 @@ Server.prototype._requestListener = function(req, res) {
     }
     res.end();
   } else if (req.method === 'POST') {
-    res.setHeader('Content-Type', req.headers['content-type']);
+    res.setHeader('Content-Type', req.headers['content-type'] || "application/xml");
     var chunks = [], gunzip;
     if (compress && req.headers["content-encoding"] === "gzip") {
       gunzip = new compress.Gunzip();

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -184,6 +184,20 @@ describe('SOAP Server', function() {
       }
     );
   });
+  
+  it('should 500 on empty message and undefined Content-Type', function(done) {
+    request.post({
+        url: test.baseUrl + '/stockquote?wsdl',
+        body : '',
+        headers: {'Content-Type': undefined}
+      }, function(err, res, body) {
+        assert.ok(!err);
+        assert.equal(res.statusCode, 500);
+        assert.ok(body.length);
+        done();
+      }
+    );
+  });
 
   it('should 500 on missing tag message', function(done) {
     request.post({


### PR DESCRIPTION
1. Quick fix to prevent server fail pathetically when sending empty body in postman to soap endpoint. Still need author to fix other stuff, since we should assume body can be empty.
2. Give authroizeConnection full access to req object, remoteAddress itself is not enough.