### PR TITLE
Always submit valid XML from the client.

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1121,7 +1121,11 @@ WSDL.prototype._initializeOptions = function (options) {
 
   this.options.valueKey = options.valueKey || this.valueKey;
   this.options.xmlKey = options.xmlKey || this.xmlKey;
-  this.options.escapeXML = options.escapeXML || false;
+  if (options.escapeXML !== undefined) {
+    this.options.escapeXML = options.escapeXML;
+  } else {
+    this.options.escapeXML = true;
+  }
   // Allow any request headers to keep passing through
   this.options.wsdl_headers = options.wsdl_headers;
   this.options.wsdl_options = options.wsdl_options;

--- a/test/request-response-samples/Dummy__should_escape_xml/common.xsd
+++ b/test/request-response-samples/Dummy__should_escape_xml/common.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:tns="http://www.Dummy.com/Common/Types" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.Dummy.com/Common/Types" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:complexType name="DummyResult">
+		<xs:sequence>
+			<xs:element name="DummyList" type="tns:DummyList" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="code" type="xs:string" use="optional"/>
+	</xs:complexType>
+	<xs:complexType name="Dummy">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="language" type="xs:language" use="optional"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="DummyList">
+		<xs:sequence>
+			<xs:element name="DummyElement" type="tns:Dummy" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+    <xs:complexType name="DummyFilter">
+        <xs:sequence>
+            <xs:element name="DummyIntFilter" type="xs:string" minOccurs="0"/>
+            <xs:element name="DummyStringFilter" type="xs:string" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>
+

--- a/test/request-response-samples/Dummy__should_escape_xml/name.xsd
+++ b/test/request-response-samples/Dummy__should_escape_xml/name.xsd
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:c="http://www.Dummy.com/Common/Types" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.Dummy.com/Name/Types" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:import namespace="common.xsd" schemaLocation="common.xsd"/>
+	<xs:element name="DummyRequest">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="DummyField1" type="xs:string" minOccurs="0"/>
+				<xs:element name="DummyFilter" type="c:DummyFilter" minOccurs="0"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="DummyResponse">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="DummyResult" type="c:DummyResult"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/test/request-response-samples/Dummy__should_escape_xml/request.json
+++ b/test/request-response-samples/Dummy__should_escape_xml/request.json
@@ -1,0 +1,6 @@
+{
+  "DummyField1": "foo & bar",
+  "DummyFilter": {
+    "DummyStringFilter": null
+  }
+}

--- a/test/request-response-samples/Dummy__should_escape_xml/request.xml
+++ b/test/request-response-samples/Dummy__should_escape_xml/request.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns:tns="http://www.Dummy.com" xmlns:n="http://www.Dummy.com/Name/Types">
+  <soap:Body>
+    <n:DummyRequest xmlns:n="http://www.Dummy.com/Name/Types" xmlns="http://www.Dummy.com/Name/Types">
+      <n:DummyField1>foo &amp; bar</n:DummyField1>
+      <n:DummyFilter>
+        <c:DummyStringFilter xmlns:c="http://www.Dummy.com/Common/Types" xsi:nil="true">
+        </c:DummyStringFilter>
+      </n:DummyFilter>
+    </n:DummyRequest>
+  </soap:Body>
+</soap:Envelope>

--- a/test/request-response-samples/Dummy__should_escape_xml/response.json
+++ b/test/request-response-samples/Dummy__should_escape_xml/response.json
@@ -1,0 +1,5 @@
+{
+  "DummyResult": {
+    "DummyList": null
+  }
+}

--- a/test/request-response-samples/Dummy__should_escape_xml/response.xml
+++ b/test/request-response-samples/Dummy__should_escape_xml/response.xml
@@ -1,0 +1,12 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:tns="http://www.Dummy.com" xmlns:n="http://www.Dummy.com/Name/Types" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <soap:Header></soap:Header>
+    <soap:Body>
+       <n:DummyResponse>
+           <n:DummyResult>
+               <c:DummyList xmlns:c="http://www.Dummy.com/Common/Types">
+                   <c:DummyElement xsi:nil="true" />
+               </c:DummyList>
+           </n:DummyResult>
+       </n:DummyResponse>
+    </soap:Body>
+</soap:Envelope>

--- a/test/request-response-samples/Dummy__should_escape_xml/soap.wsdl
+++ b/test/request-response-samples/Dummy__should_escape_xml/soap.wsdl
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" 
+xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" 
+xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+xmlns:tns="http://www.Dummy.com"  xmlns:n="http://www.Dummy.com/Name/Types"  xmlns:ns="http://schemas.xmlsoap.org/soap/encoding/" targetNamespace="http://www.Dummy.com">
+	<wsdl:types>
+		<xs:schema>
+			<xs:import namespace="http://www.Dummy.com/Common/Types" schemaLocation="common.xsd"/>
+			<xs:import namespace="http://www.Dummy.com/Name/Types" schemaLocation="name.xsd"/>
+		</xs:schema>
+	</wsdl:types>
+	<wsdl:message name="DummyRequest">
+		<wsdl:part name="DummyRequest" element="n:DummyRequest"/>
+	</wsdl:message>
+	<wsdl:message name="DummyResponse">
+		<wsdl:part name="DummyResponse" element="n:DummyResponse"/>
+	</wsdl:message>
+	<wsdl:portType name="DummyPortType">
+		<wsdl:operation name="Dummy">
+			<wsdl:input message="tns:DummyRequest"/>
+			<wsdl:output message="tns:DummyResponse"/>
+		</wsdl:operation>
+	</wsdl:portType>
+	<wsdl:binding name="DummyBinding" type="tns:DummyPortType">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+		<wsdl:operation name="Dummy">
+			<soap:operation soapAction="http://www.Dummy.com#Dummy" style="document"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:service name="DummyService">
+		<wsdl:port name="DummyPortType" binding="tns:DummyBinding">
+			<soap:address location="http://www.Dummy.com/"/>
+		</wsdl:port>
+	</wsdl:service>
+</wsdl:definitions>
+


### PR DESCRIPTION
Previously, if the client made a request that contained ampersands:

    {
      "DummyField1": "foo & bar",
    }

then we would submit invalid XML:

    <n:DummyField1>foo & bar</n:DummyField1>

The WSDL server I'm using (a Service-Now instance) then complains:

    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
      <SOAP-ENV:Header/>
      <SOAP-ENV:Body>
        <SOAP-ENV:Fault>
          <faultcode>SOAP-ENV:Server</faultcode>
          <faultstring>Unable to parse SOAP document</faultstring>
          <detail>Error completing SOAP request</detail>
        </SOAP-ENV:Fault>
      </SOAP-ENV:Body>
    </SOAP-ENV:Envelope>

We now default to escaping XML, so a stray & can't break usage of node-soap. I've added a test for this.