### PR TITLE
Fix broken options variable in client SOAP requests

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -16,7 +16,6 @@ var HttpClient = require('./http'),
 
 var Client = function(wsdl, endpoint, options) {
   events.EventEmitter.call(this);
-
   options = options || {};
   this.wsdl = wsdl;
   this._initializeOptions(options);
@@ -121,6 +120,18 @@ Client.prototype._initializeServices = function(endpoint) {
 Client.prototype._initializeOptions = function(options) {
   this.wsdl.options.attributesKey = options.attributesKey || 'attributes';
   this.wsdl.options.envelopeKey = options.envelopeKey || 'soap';
+  if(options.ignoredNamespaces !== undefined) {
+    if(options.ignoredNamespaces.override !== undefined) {
+      if(options.ignoredNamespaces.override === true) {
+        if(options.ignoredNamespaces.namespaces !== undefined) {
+          this.wsdl.options.ignoredNamespaces = options.ignoredNamespaces.namespaces;
+        }
+      }
+    }
+  }
+  if(options.overrideRootElement !== undefined) {
+    this.wsdl.options.overrideRootElement = options.overrideRootElement;
+  }
   this.wsdl.options.forceSoap12Headers = !!options.forceSoap12Headers;
 };
 
@@ -217,10 +228,10 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
   if (self.security && self.security.addOptions)
     self.security.addOptions(options);
 
-    if ((style === 'rpc')&& ( ( input.parts || input.name==="element" ) || args === null) ) {
-      assert.ok(!style || style === 'rpc', 'invalid message definition for document style binding');
-      message = self.wsdl.objectToRpcXML(name, args, alias, ns,(input.name!=="element" ));
-      (method.inputSoap === 'encoded') && (encoding = 'soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" ');
+  if ((style === 'rpc')&& ( ( input.parts || input.name==="element" ) || args === null) ) {
+    assert.ok(!style || style === 'rpc', 'invalid message definition for document style binding');
+    message = self.wsdl.objectToRpcXML(name, args, alias, ns,(input.name!=="element" ));
+    (method.inputSoap === 'encoded') && (encoding = 'soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" ');
   } else {
     assert.ok(!style || style === 'document', 'invalid message definition for rpc style binding');
     // pass `input.$lookupType` if `input.$type` could not be found

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1544,33 +1544,33 @@ WSDL.prototype.objectToDocumentXML = function(name, params, nsPrefix, nsURI, typ
  * @param {String} nsURI
  * @returns {string}
  */
- WSDL.prototype.objectToRpcXML = function(name, params, nsPrefix, nsURI,isParts) {
-   var parts = [];
-   var defs = this.definitions;
-   var nsAttrName = '_xmlns';
+WSDL.prototype.objectToRpcXML = function(name, params, nsPrefix, nsURI,isParts) {
+  var parts = [];
+  var defs = this.definitions;
+  var nsAttrName = '_xmlns';
 
-   nsPrefix = nsPrefix || findPrefix(defs.xmlns, nsURI);
+  nsPrefix = nsPrefix || findPrefix(defs.xmlns, nsURI);
 
-   nsURI = nsURI || defs.xmlns[nsPrefix];
-   nsPrefix = nsPrefix === TNS_PREFIX ? '' : (nsPrefix + ':');
+  nsURI = nsURI || defs.xmlns[nsPrefix];
+  nsPrefix = nsPrefix === TNS_PREFIX ? '' : (nsPrefix + ':');
 
-   parts.push(['<', nsPrefix, name, '>'].join(''));
+  parts.push(['<', nsPrefix, name, '>'].join(''));
 
-   for (var key in params) {
-     if (!params.hasOwnProperty(key)) {
-       continue;
-     }
-     if (key !== nsAttrName) {
-       var value = params[key];
-       var prefixedKey = (isParts ? '' : nsPrefix) + key;
-       parts.push(['<', prefixedKey, '>'].join(''));
-       parts.push((typeof value === 'object') ? this.objectToXML(value, key, nsPrefix, nsURI) : xmlEscape(value));
-       parts.push(['</', prefixedKey, '>'].join(''));
-     }
-   }
-   parts.push(['</', nsPrefix, name, '>'].join(''));
-   return parts.join('');
- };
+  for (var key in params) {
+    if (!params.hasOwnProperty(key)) {
+      continue;
+    }
+    if (key !== nsAttrName) {
+      var value = params[key];
+      var prefixedKey = (isParts ? '' : nsPrefix) + key;
+      parts.push(['<', prefixedKey, '>'].join(''));
+      parts.push((typeof value === 'object') ? this.objectToXML(value, key, nsPrefix, nsURI) : xmlEscape(value));
+      parts.push(['</', prefixedKey, '>'].join(''));
+    }
+  }
+  parts.push(['</', nsPrefix, name, '>'].join(''));
+  return parts.join('');
+};
 
 
 function appendColon(ns) {

--- a/test/client-options-test.js
+++ b/test/client-options-test.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var fs = require('fs'),
+    soap = require('..'),
+    http = require('http'),
+    assert = require('assert');
+
+describe('SOAP Client', function() {
+  var options = {
+    'ignoredNamespaces': {
+      'namespaces': ['ignoreThisNS'],
+      'override': true
+    },
+    'overrideRootElement': {
+      'namespace': 'tns'
+    }
+  };
+
+  it('should set WSDL options to those specified in createClient', function(done) {
+    soap.createClient(__dirname+'/wsdl/json_response.wsdl', options, function(err, client) {
+      assert.ok(client);
+      assert.ok(!err);
+
+      assert.ok(client.wsdl.options.ignoredNamespaces[0] === 'ignoreThisNS');
+      assert.ok(client.wsdl.options.overrideRootElement.namespace === 'tns');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
The options variable was not registering in client SOAP requests, regardless of its contents. I modified the client.js file to include some items from wsdl.js, and it automagically worked the way it was supposed to. I suspect there might be a broken link to the WSDL class in the Client class that caused this, but I cannot tell for certain. Perhaps someone with more experience with this library could investigate further?

Thanks!
Jesse