### PR TITLE
[Important] fix ExtensionElement description to match order

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -87,25 +87,6 @@ function trim(text) {
   return text.replace(trimLeft, '').replace(trimRight, '');
 }
 
-/**
- * What we want is to copy properties from one object to another one and avoid
- * properties overriding. This way we ensure the 'inheritance' of
- * <xsd:extension base=...> usage.
- *
- * NB: 'Element' (and subtypes) don't have any prototyped properties: there's
- * no need to process a 'hasOwnProperties' call, we should just iterate over the
- * keys.
- */
-function extend(base, obj) {
-  if(base !== null && typeof base === "object" && obj !== null && typeof obj === "object"){
-    Object.keys(obj).forEach(function(key) {
-      if(!base.hasOwnProperty(key))
-        base[key] = obj[key];
-    });
-  }
-  return base;
-}
-
 function deepMerge(destination, source) {
   return _.merge(destination || {}, source, function(a, b) {
       return _.isArray(a) ? a.concat(b) : undefined;
@@ -187,7 +168,7 @@ Element.prototype.endElement = function(stack, nsName) {
       return;
     var parent = stack[stack.length - 2];
     if (this !== stack[0]) {
-      extend(stack[0].xmlns, this.xmlns);
+      _.defaultsDeep(stack[0].xmlns, this.xmlns);
       // delete this.xmlns;
       parent.children.push(this);
       parent.addChild(this);
@@ -814,7 +795,7 @@ ExtensionElement.prototype.description = function(definitions, xmlns) {
 
       if (typeElement) {
         var base = typeElement.description(definitions, schema.xmlns);
-        extend(desc, base);
+        desc = _.defaultsDeep(base, desc);
       }
     }
   }

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -73,6 +73,15 @@ wsdlStrictTests['should get the parent namespace when parent namespace is empty 
   });
 };
 
+wsdlStrictTests['should describe extended elements in correct order'] = function(done) {
+  var expected = '{"DummyService":{"DummyPortType":{"Dummy":{"input":{"DummyRequest":{"DummyField1":"xs:string","DummyField2":"xs:string"},"ExtendedDummyField":"xs:string"},"output":{"DummyResult":"c:DummyResult"}}}}}';
+  soap.createClient(__dirname+'/wsdl/extended_element.wsdl', function(err, client){
+    assert.ok(!err);
+    assert.equal(JSON.stringify(client.describe()), expected);
+    done();
+  });
+};
+
 wsdlStrictTests['should handle element ref'] = function(done) {
   var expectedMsg = '<ns1:fooRq xmlns:ns1="http://example.com/bar/xsd"' +
     ' xmlns="http://example.com/bar/xsd"><bar1:paymentRq' +


### PR DESCRIPTION
https://adwords.google.com/api/adwords/cm/v201605/CampaignService?wsdl

Description for `operations.operand.budget.amount` `mutate` method was like:
```js
budget: 
   { budgetId: 'xsd:long',
     name: 'xsd:string',
     amount: 
      { microAmount: 'xsd:long',
        'ComparableValue.Type': 'xsd:string',
        targetNSAlias: 'tns',
        targetNamespace: 'https://adwords.google.com/api/adwords/cm/v201605' },
     deliveryMethod: 'Budget.BudgetDeliveryMethod|xsd:string|STANDARD,ACCELERATED,UNKNOWN',
     referenceCount: 'xsd:int',
     isExplicitlyShared: 'xsd:boolean',
     status: 'Budget.BudgetStatus|xsd:string|ENABLED,REMOVED,UNKNOWN',
     targetNSAlias: 'tns',
     targetNamespace: 'https://adwords.google.com/api/adwords/cm/v201605' }
```

Should have been like:
```js
budget: 
   { budgetId: 'xsd:long',
     name: 'xsd:string',
     amount: 
      { 'ComparableValue.Type': 'xsd:string',
        microAmount: 'xsd:long',
        targetNSAlias: 'tns',
        targetNamespace: 'https://adwords.google.com/api/adwords/cm/v201605' },
     deliveryMethod: 'Budget.BudgetDeliveryMethod|xsd:string|STANDARD,ACCELERATED,UNKNOWN',
     referenceCount: 'xsd:int',
     isExplicitlyShared: 'xsd:boolean',
     status: 'Budget.BudgetStatus|xsd:string|ENABLED,REMOVED,UNKNOWN',
     targetNSAlias: 'tns',
     targetNamespace: 'https://adwords.google.com/api/adwords/cm/v201605' }
```

Notice the order of `'ComparableValue.Type'` and `microAmount`.

This fixes it.