### PR TITLE
Don't include ignoredNamespaces aliases in Envelope

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -2055,7 +2055,7 @@ WSDL.prototype._xmlnsMap = function() {
   var xmlns = this.definitions.xmlns;
   var str = '';
   for (var alias in xmlns) {
-    if (alias === '' || alias === TNS_PREFIX) {
+    if (alias === '' || alias === TNS_PREFIX || this.isIgnoredNameSpace(alias)) {
       continue;
     }
     var ns = xmlns[alias];


### PR DESCRIPTION
I had to add this in because the Bing Ads API was breaking entirely when there were too many(?) namespaces on the soap:Envelope element. Bing defines a number of duplicate namespaces for whatever reason and you end up with something like this as part your request body.

`
<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:tns="https://bingads.microsoft.com/Customer/v9" xmlns:q1="https://adapi.microsoft.com" xmlns:q2="https://adapi.microsoft.com" xmlns:q3="https://adapi.microsoft.com" xmlns:q4="https://adapi.microsoft.com" xmlns:q5="https://adapi.microsoft.com" xmlns:q6="https://adapi.microsoft.com" xmlns:q7="https://adapi.microsoft.com" xmlns:q8="https://adapi.microsoft.com" xmlns:q9="https://adapi.microsoft.com" xmlns:q10="https://adapi.microsoft.com" xmlns:q11="https://adapi.microsoft.com" xmlns:q12="https://adapi.microsoft.com" xmlns:q13="https://adapi.microsoft.com" xmlns:q14="https://adapi.microsoft.com" xmlns:q15="https://adapi.microsoft.com" xmlns:q16="https://adapi.microsoft.com" xmlns:q17="https://adapi.microsoft.com" xmlns:q18="https://adapi.microsoft.com" xmlns:q19="https://adapi.microsoft.com" xmlns:q20="https://adapi.microsoft.com" xmlns:q21="https://adapi.microsoft.com" xmlns:q22="https://adapi.microsoft.com" xmlns:q23="https://adapi.microsoft.com" xmlns:q24="https://adapi.microsoft.com" xmlns:q25="https://adapi.microsoft.com" xmlns:q26="https://adapi.microsoft.com" xmlns:q27="https://adapi.microsoft.com" xmlns:q28="https://adapi.microsoft.com" xmlns:q29="https://adapi.microsoft.com" xmlns:q30="https://adapi.microsoft.com" xmlns:q31="https://adapi.microsoft.com" xmlns:q32="https://adapi.microsoft.com" xmlns:q33="https://adapi.microsoft.com">
`

I am not sure if this change will impact anything else. I figure if the namespace is included in the "ignoredNamespaces" option it is safe to omit from the root element.
