### PR TITLE
better error handling for missing SOAP elements

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -211,6 +211,12 @@ Server.prototype._process = function(input, req, callback) {
     self.log("info", "Attempting to bind to " + pathname);
   }
 
+  //Avoid Cannot convert undefined or null to object due to Object.keys(body)
+  //and throw more meaningful error
+  if(!body){
+    throw new Error('Failed to parse the SOAP Message body');
+  }
+
   // use port.location and current url to find the right binding
   binding = (function(self) {
     var services = self.wsdl.definitions.services;

--- a/test/request-no-envelope-body-test.js
+++ b/test/request-no-envelope-body-test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+var request = require('request');
+var assert = require('assert');
+var http = require('http');
+var soap = require('../');
+var server;
+var port;
+
+describe('No envelope and body elements', function() {
+  var wsdl = '<definitions name="HelloService" targetNamespace="http://www.examples.com/wsdl/HelloService.wsdl" xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://www.examples.com/wsdl/HelloService.wsdl" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><message name="SayHelloRequest"><part name="firstName" type="xsd:string"/></message><message name="SayHelloResponse"><part name="greeting" type="xsd:string"/></message><portType name="Hello_PortType"><operation name="sayHello"><input message="tns:SayHelloRequest"/><output message="tns:SayHelloResponse"/></operation></portType><binding name="Hello_Binding" type="tns:Hello_PortType"><soap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/><operation name="sayHello"><soap:operation soapAction="sayHello"/><input><soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:examples:helloservice" use="encoded"/></input><output><soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:examples:helloservice" use="encoded"/></output></operation></binding><service name="Hello_Service"><documentation>WSDL File for HelloService</documentation><port binding="tns:Hello_Binding" name="Hello_Port"><soap:address location="http://localhost:51515/SayHello/" /></port></service></definitions>';
+  before(function(done){
+    server = http.createServer(function(req, res) {
+      res.statusCode = 404;
+      res.end();
+    }).listen(51515, function() {
+      var soapServer = soap.listen(server, '/SayHello', {
+        Hello_Service: {
+          Hello_Port: {
+            sayHello: function(args){
+              return {
+                greeting: args.firstName
+              }
+            }
+          }
+        }
+      }, wsdl);
+      done();
+    });
+  });
+
+  after(function(){
+    server.close();
+  });
+
+  it('should throw an error when Body and Envelope are missing',
+    function(done){
+      var requestXML = '<sayHello xmlns="http://www.examples.com/wsdl/HelloService.wsdl"><firstName>tarun</firstName></sayHello>';
+      var url = 'http://' + server.address().address + ':' + server.address().port;
+
+      if (server.address().address === '0.0.0.0' || server.address().address === '::') {
+        url =
+          'http://127.0.0.1:' + server.address().port;
+      }
+
+      request({
+        url: url + '/SayHello',
+        method: 'POST',
+        headers: {SOAPAction: "sayHello",
+            "Content-Type": 'text/xml; charset="utf-8"'},
+        body: requestXML
+      }, function(err, response, body){
+        if(err){
+          throw err;
+        }
+        assert.equal(body.indexOf('Failed to parse the SOAP Message body') !== -1, true);
+        done();
+      });
+    });
+
+});

--- a/test/request-response-samples-test.js
+++ b/test/request-response-samples-test.js
@@ -133,6 +133,12 @@ function generateTest(name, methodName, wsdlPath, headerJSON, securityJSON, requ
       if (securityJSON && securityJSON.type === 'ws') {
         client.setSecurity(new WSSecurity(securityJSON.username, securityJSON.password, securityJSON.options));
       }
+
+      //throw more meaningful error
+      if(typeof client[methodName] !== 'function'){
+        throw new Error(method + ' ' + methodName + ' does not exists in wsdl specified in test wsdl: ' + wsdlPath);
+      }
+
       client[methodName](requestJSON, function(err, json, body, soapHeader){
         if(requestJSON){
           if (err) {


### PR DESCRIPTION
Better error handling to speed up debugging:
1. SOAP message missing envelope and body 
2. request/response tests incorrect SOAP method name