### PR TITLE
On error, call callback with error instead of message

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1022,7 +1022,7 @@ var WSDL = function(definition, uri, options) {
     try {
       fromFunc.call(self, definition);
     } catch (e) {
-      return self.callback(e.message);
+      return self.callback(e);
     }
 
     self.processIncludes(function(err) {


### PR DESCRIPTION
As it stands, the callback for `WSDL` is sometimes called with a string in the error position. This error arises from the line `self.callback(e.message)`. This strips useful information (such as the stack trace) before sending the error back to the consumer, as well as violates JS best practices by throwing a string instead of an `Error`.

This PR corrects the issue by calling the callback with the error.
