### PR TITLE
Add option for disabling the WSDL cache

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -87,6 +87,7 @@ If you're in need of support we encourage you to join us and other `node-soap` u
       });
   });
 ```
+This client has a built in WSDL cache. You can use the `disableCache` option to disable it.
 
 #### Options
 
@@ -100,6 +101,7 @@ The `options` argument allows you to customize the client with the following pro
 - request: to override the [request](https://github.com/request/request) module.
 - wsdl_headers: custom HTTP headers to be sent on WSDL requests.
 - wsdl_options: custom options for the request module on WSDL requests.
+- disableCache: don't cache WSDL files, request them every time.
 
 Note: for versions of node >0.10.X, you may need to specify `{connection: 'keep-alive'}` in SOAP headers to avoid truncation of longer chunked responses.
 
@@ -145,7 +147,7 @@ Note: for versions of node >0.10.X, you may need to specify `{connection: 'keep-
 
   var xml = require('fs').readFileSync('myservice.wsdl', 'utf8');
 
-  //http server example  
+  //http server example
   var server = http.createServer(function(request,response) {
       response.end("404: Not Found: " + request.url);
   });

--- a/lib/soap.js
+++ b/lib/soap.js
@@ -10,32 +10,40 @@ var Client = require('./client').Client,
   HttpClient = require('./http'),
   security = require('./security'),
   passwordDigest = require('./utils').passwordDigest,
-  open_wsdl = require('./wsdl').open_wsdl,
+  wsdl = require('./wsdl'),
   WSDL = require('./wsdl').WSDL;
 
-var _wsdlCache = {};
+function createCache() {
+  var cache = {};
+  return function (key, load, callback) {
+    if (!cache[key]) {
+      load(function (err, result) {
+        if (err) {
+          return callback(err);
+        }
+        cache[key] = result;
+        callback(null, result);
+      })
+    } else {
+      process.nextTick(function () {
+        callback(null, cache[key]);
+      });
+    }
+  };
+}
+var getFromCache = createCache();
 
 function _requestWSDL(url, options, callback) {
   if (typeof options === 'function') {
     callback = options;
     options = {};
   }
+  var openWsdl = wsdl.open_wsdl.bind(null, url, options);
 
-  var wsdl = _wsdlCache[url];
-  if (wsdl) {
-    process.nextTick(function() {
-      callback(null, wsdl);
-    });
-  }
-  else {
-    open_wsdl(url, options, function(err, wsdl) {
-      if (err) {
-        return callback(err);
-      } else {
-        _wsdlCache[url] = wsdl;
-      }
-      callback(null, wsdl);
-    });
+  if (options.disableCache === true) {
+    openWsdl(callback);
+  } else {
+    getFromCache(url, openWsdl, callback);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "readable-stream": "~2.0.2",
     "semver": "~5.0.3",
     "should": "~3.3.0",
+    "sinon": "^1.17.5",
     "timekeeper": "~0.0.4"
   }
 }

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -3,7 +3,9 @@
 var fs = require('fs'),
     soap = require('..'),
     http = require('http'),
-    assert = require('assert');
+    assert = require('assert'),
+    sinon = require('sinon'),
+    wsdl = require('../lib/wsdl');
 
 describe('SOAP Client', function() {
   it('should error on invalid host', function(done) {
@@ -93,6 +95,22 @@ describe('SOAP Client', function() {
 
       assert.ok(client.wsdl.definitions.bindings.mySoapBinding.style === 'document');
       done();
+    });
+  });
+
+  it('should allow disabling the wsdl cache', function (done) {
+    var spy = sinon.spy(wsdl, 'open_wsdl');
+    var options = {disableCache: true};
+    soap.createClient(__dirname+'/wsdl/binding_document.wsdl', options, function(err1, client1) {
+      assert.ok(client1);
+      assert.ok(!err1);
+      soap.createClient(__dirname+'/wsdl/binding_document.wsdl', options, function(err2, client2) {
+        assert.ok(client2);
+        assert.ok(!err2);
+        assert.ok(spy.calledTwice);
+        wsdl.open_wsdl.restore();
+        done();
+      });
     });
   });
 


### PR DESCRIPTION
Currently the soapClient is caching WSDLs (this seems to be an undocumented/unconfigurable feature).
The proposed change refactors that code a bit to encapsulate that functionality and adds an option to disable it completely.
The main reason this needs to be addressed are tests. If the cache is enabled, tests using a HTTP mocking solutions, such as [node-nock](https://github.com/node-nock/nock) will end up being dependent tests, as only the first case will call the WSDL, and the rest will behave differently.