### PR TITLE
Preserve the original error object when throwing an XML parsing error

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1398,14 +1398,14 @@ WSDL.prototype.xmlToObject = function(xml) {
 
   p.onerror = function(e) {
     p.resume();
-    throw {
-      Fault: {
-        faultcode: 500,
-        faultstring: 'Invalid XML',
-        detail: new Error(e).message,
-        statusCode: 500
-      }
+    var errorObject = e instanceof Error ? e : new Error(e);
+    errorObject.Fault = {
+      faultcode: 500,
+      faultstring: 'Invalid XML',
+      detail: errorObject.message,
+      statusCode: 500
     };
+    throw errorObject;
   };
 
   p.ontext = function(text) {

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -588,6 +588,8 @@ describe('SOAP Client', function() {
       soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', function (err, client) {
         client.MyOperation({}, function(err, result) {
           assert.ok(err);
+          assert.ok(err instanceof Error);
+          assert.ok(err.stack);
           assert.ok(err.response);
           assert.ok(err.body);
           done();


### PR DESCRIPTION
When catching and rethrowing an error from the sax parser, the original error is discarded which contains a valuable stack trace. This change preserves the original error object and only adds a Fault sub-object to it instead of discarding it.
