### PR TITLE
Update soap stub example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -706,7 +706,7 @@ var clientStub = {
   SomeOperation: sinon.stub()
 };
 
-clientStub.SomeOperation.respondWithError = soapStub.createRespondingStub({..error json...});
+clientStub.SomeOperation.respondWithError = soapStub.createErroringStub({..error json...});
 clientStub.SomeOperation.respondWithSuccess = soapStub.createRespondingStub({..success json...});
 
 soapStub.registerClient('my client alias', urlMyApplicationWillUseWithCreateClient, clientStub);


### PR DESCRIPTION
Clarifying confusing part of the example with the error stub. 

Respond with error should use the createErroringStub method so that the client returns an error rather than using createRespondingStub which returns a non-error response to the callback.