### PR TITLE
Merge in NTLM authentication support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,6 +38,7 @@ This module lets you connect to web services using SOAP.  It also provides a ser
   - [ClientSSLSecurity](#clientsslsecurity)
   - [WSSecurity](#wssecurity)
   - [WSSecurityCert](#wssecuritycert)
+  - [NtlmSecurity](#ntlmsecurity)
 - [Handling XML Attributes, Value and XML (wsdlOptions).](#handling-xml-attributes-value-and-xml-wsdloptions)
   - [Specifying the exact namespace definition of the root element](#specifying-the-exact-namespace-definition-of-the-root-element)
 - [Handling "ignored" namespaces](#handling-ignored-namespaces)
@@ -504,6 +505,12 @@ WS-Security X509 Certificate support.
 ```
 
 _Note_: Optional dependency 'ursa' is required to be installed succefully when WSSecurityCert is used.
+
+### NtlmSecurity
+
+``` javascript
+  client.setSecurity(new soap.NtlmSecurity('username', 'password', 'domain', 'workstation'));
+```
 
 ## Handling XML Attributes, Value and XML (wsdlOptions).
 Sometimes it is necessary to override the default behaviour of `node-soap` in order to deal with the special requirements

--- a/lib/client.js
+++ b/lib/client.js
@@ -404,7 +404,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
   }
 
   // Added mostly for testability, but possibly useful for debugging
-  if(req && req.headers) //fixes an issue when req or req.headers is indefined
+  if(req && req.headers && !options.ntlm) //fixes an issue when req or req.headers is undefined, doesn't apply to ntlm requests
     self.lastRequestHeaders = req.headers;
 };
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -8,6 +8,7 @@
 var url = require('url');
 var req = require('request');
 var debug = require('debug')('node-soap');
+var httpntlm = require('httpntlm');
 
 var VERSION = require('../package.json').version;
 
@@ -110,13 +111,32 @@ HttpClient.prototype.request = function(rurl, data, callback, exheaders, exoptio
   var self = this;
   var options = self.buildRequest(rurl, data, exheaders, exoptions);
   var headers = options.headers;
-  var req = self._request(options, function(err, res, body) {
-    if (err) {
-      return callback(err);
+  if (exoptions.ntlm) {
+    // sadly when using ntlm nothing to return
+    options.url = rurl;
+    httpntlm[options.method.toLowerCase()](options, function (err, res) {
+      if (err) {
+        return callback(err);
+      }
+      // if result is stream
+      if( typeof res.body != 'string') {
+        res.body = res.body.toString();
+      }
+      res.body = self.handleResponse(req, res, res.body);
+      callback(null, res, res.body);
+    });
+  } else {
+    var req = self._request(options, function (err, res, body) {
+      if (err) {
+        return callback(err);
+      }
+      body = self.handleResponse(req, res, body);
+      callback(null, res, body);
+    });
+    if (headers.Connection !== 'keep-alive') {
+      req.end(data);
     }
-    body = self.handleResponse(req, res, body);
-    callback(null, res, body);
-  });
+  };
 
   return req;
 };

--- a/lib/security/NtlmSecurity.js
+++ b/lib/security/NtlmSecurity.js
@@ -1,0 +1,32 @@
+"use strict";
+
+var _ = require('lodash');
+
+function NtlmSecurity(username, password, domain, workstation) {
+    if (typeof username == "object") {
+        this.defaults = username;
+        this.defaults.ntlm = true;
+    } else {
+        this.defaults = {
+            ntlm: true,
+            username: username,
+            password: password,
+            domain: domain,
+            workstation: workstation
+        };
+    }
+}
+
+NtlmSecurity.prototype.addHeaders = function (headers) {
+  headers.Connection = 'keep-alive';
+};
+
+NtlmSecurity.prototype.toXML = function () {
+    return '';
+};
+
+NtlmSecurity.prototype.addOptions = function (options) {
+    _.merge(options, this.defaults);
+};
+
+module.exports = NtlmSecurity;

--- a/lib/security/index.js
+++ b/lib/security/index.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   BasicAuthSecurity: require('./BasicAuthSecurity')
+, NtlmSecurity: require('./NtlmSecurity')
 , ClientSSLSecurity: require('./ClientSSLSecurity')
 , ClientSSLSecurityPFX: require('./ClientSSLSecurityPFX')
 , WSSecurity: require('./WSSecurity')

--- a/lib/soap.js
+++ b/lib/soap.js
@@ -78,6 +78,7 @@ function listen(server, pathOrOptions, services, xml) {
 
 exports.security = security;
 exports.BasicAuthSecurity = security.BasicAuthSecurity;
+exports.NtlmSecurity = security.NtlmSecurity;
 exports.WSSecurity = security.WSSecurity;
 exports.WSSecurityCert = security.WSSecurityCert;
 exports.ClientSSLSecurity = security.ClientSSLSecurity;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lodash": "3.x.x",
     "node-uuid": "~1.4.3",
     "optional": "^0.1.3",
+    "httpntlm": "^1.5.2",
     "request": ">=2.9.0",
     "sax": ">=0.6",
     "selectn": "^0.9.6",


### PR DESCRIPTION
Pulling in changes from @vision10 https://github.com/vision10/node-soap (via @r24y https://github.com/r24y/node-soap/ who did some cleanup) into one clean package for a pull request.

Cleaned up version of #776 and #741. I've tested it against a live NTLM SOAP server, and it seems to work perfectly. Added basic instructions to the README with respect to syntax usage with the other security types, and regenerated TOC.