### PR TITLE
Removes wsdl.onReady from the Server constructor

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -274,8 +274,9 @@ Server.prototype._process = function (input, req, callback) {
   }
 
   try {
+    var firstXmlElement = (Object.keys(body)[0] === 'attributes' ? Object.keys(body)[1] : Object.keys(body)[0]);
     if (binding.style === 'rpc') {
-      methodName = Object.keys(body)[0];
+      methodName = firstXmlElement;
 
       self.emit('request', obj, methodName);
       if (headers)
@@ -291,7 +292,7 @@ Server.prototype._process = function (input, req, callback) {
         style: 'rpc'
       }, req, callback);
     } else {
-      var messageElemName = (Object.keys(body)[0] === 'attributes' ? Object.keys(body)[1] : Object.keys(body)[0]);
+      var messageElemName = firstXmlElement;
       var pair = binding.topElements[messageElemName];
 
       self.emit('request', obj, pair.methodName);

--- a/lib/server.js
+++ b/lib/server.js
@@ -40,42 +40,40 @@ var Server = function (server, path, services, wsdl, options) {
 
   if (path[path.length - 1] !== '/')
     path += '/';
-  wsdl.onReady(function (err) {
-    if (typeof server.route === 'function' && typeof server.use === 'function') {
-      //handle only the required URL path for express server
-      server.route(path).all(function (req, res, next) {
-        if (typeof self.authorizeConnection === 'function') {
-          if (!self.authorizeConnection(req)) {
-            res.end();
-            return;
-          }
+  if (typeof server.route === 'function' && typeof server.use === 'function') {
+    //handle only the required URL path for express server
+    server.route(path).all(function (req, res, next) {
+      if (typeof self.authorizeConnection === 'function') {
+        if (!self.authorizeConnection(req)) {
+          res.end();
+          return;
         }
+      }
+      self._requestListener(req, res);
+    });
+  } else {
+    var listeners = server.listeners('request').slice();
+    server.removeAllListeners('request');
+    server.addListener('request', function (req, res) {
+      if (typeof self.authorizeConnection === 'function') {
+        if (!self.authorizeConnection(req)) {
+          res.end();
+          return;
+        }
+      }
+      var reqPath = url.parse(req.url).pathname;
+      if (reqPath[reqPath.length - 1] !== '/') {
+        reqPath += '/';
+      }
+      if (path === reqPath) {
         self._requestListener(req, res);
-      });
-    } else {
-      var listeners = server.listeners('request').slice();
-      server.removeAllListeners('request');
-      server.addListener('request', function (req, res) {
-        if (typeof self.authorizeConnection === 'function') {
-          if (!self.authorizeConnection(req)) {
-            res.end();
-            return;
-          }
+      } else {
+        for (var i = 0, len = listeners.length; i < len; i++) {
+          listeners[i].call(this, req, res);
         }
-        var reqPath = url.parse(req.url).pathname;
-        if (reqPath[reqPath.length - 1] !== '/') {
-          reqPath += '/';
-        }
-        if (path === reqPath) {
-          self._requestListener(req, res);
-        } else {
-          for (var i = 0, len = listeners.length; i < len; i++) {
-            listeners[i].call(this, req, res);
-          }
-        }
-      });
-    }
-  });
+      }
+    });
+  }
 
   this._initializeOptions(options);
 };


### PR DESCRIPTION
server.route() must be called sync for the module to work fine when passed server is a instance of express.Router
### Use case

When trying to integrate the module for serving SOAP requests on an already existing express setup, i needed to mount it not on an express app instance, but a Router instance. 
### Why the current code does not work in my case

It seems that the onReady callback makes the `server.route` call too late in this case
### Solution

Dont use onReady at all. Anyway, the wsdl would be full loaded right away.
### Open to make it better

If somebody points me on the need for the onReady call, maybe we can think a better solution than mine.
