### PR TITLE
Add support for SOAP message with element composed of mixed content

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1694,6 +1694,9 @@ WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlns
         continue;
       }
 
+      // Check if the current item is a plain-text element
+      var isText = (name === '#text');
+
       var attr = self.processAttributes(child, nsContext);
 
       var value = '';
@@ -1839,13 +1842,13 @@ WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlns
         ns = '';
       }
 
-      if (!Array.isArray(child)) {
+      if (!Array.isArray(child) && !isText) {
         // start tag
         parts.push(['<', emptyNonSubNameSpace ? '' : appendColon(nonSubNameSpace || ns), name, attr, xmlnsAttrib,
           (child === null ? ' xsi:nil="true"' : ''), '>'].join(''));
       }
       parts.push(value);
-      if (!Array.isArray(child)) {
+      if (!Array.isArray(child) && !isText) {
         // end tag
         parts.push(['</', emptyNonSubNameSpace ? '' : appendColon(nonSubNameSpace || ns), name, '>'].join(''));
       }


### PR DESCRIPTION
The goal of these changes is to support XML elements composed of mixed content (plain-text + children elements). Exmple:
```
<v1:items>
    Some plain text
    <v1:item>
        <v1:product>
            <v1:names>
                <v1:name>none</v1:name>
            </v1:names>
        </v1:product>
    </v1:item>
</v1:items>
```

With the modifications, it can be generated with the following json as input:
```
"v1:items": {
    "#text": "Some plain text",
    "v1:item": {
        "v1:product": {
            "v1:names": {
                "v1:name": "none"
            }
        }
    }
}
```