### PR TITLE
Ensure that supplied request-object is passed through

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1114,6 +1114,11 @@ WSDL.prototype._initializeOptions = function (options) {
     this.options.httpClient = options.httpClient;
   }
 
+  // The supplied request-object should be passed through
+  if (options.request) {
+    this.options.request = options.request;
+  }
+
   var ignoreBaseNameSpaces = options ? options.ignoreBaseNameSpaces : null;
   if (ignoreBaseNameSpaces !== null && typeof ignoreBaseNameSpaces !== 'undefined') {
     this.options.ignoreBaseNameSpaces = ignoreBaseNameSpaces;

--- a/test/client-options-test.js
+++ b/test/client-options-test.js
@@ -13,7 +13,8 @@ describe('SOAP Client', function() {
     },
     'overrideRootElement': {
       'namespace': 'tns'
-    }
+    },
+    'request': 'customRequest'
   };
 
   it('should set WSDL options to those specified in createClient', function(done) {
@@ -23,6 +24,7 @@ describe('SOAP Client', function() {
 
       assert.ok(client.wsdl.options.ignoredNamespaces[0] === 'ignoreThisNS');
       assert.ok(client.wsdl.options.overrideRootElement.namespace === 'tns');
+      assert.ok(client.wsdl.options.request, "customRequest");
       done();
     });
   });


### PR DESCRIPTION
The request-parameter from createClient is lost for later requests in the WSDL-prototype. This PR fixes that problem.