### PR TITLE
Fix "_.defaultsDeep is not a function" error by updating lodash.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "debug": "~0.7.4",
     "ejs": "~2.3.4",
     "finalhandler": "^0.5.0",
-    "lodash": "3.x.x",
+    "lodash": "^3.10.1",
     "node-uuid": "~1.4.3",
     "optional": "^0.1.3",
     "request": ">=2.9.0",


### PR DESCRIPTION
The package.json specifies that it needs lodash@3.x.x.

However, the code uses the lodash defaultsDeep function which was introduced in 3.10.0.

If say lodash@3.9.3 is installed for whatever reason (maybe another package says it requires that specific version), you end up getting a "_.defaultsDeep is not a function" error.

Here I've updated the requirement from "3.x.x" to "^3.10.1" but you might want to update to the latest 4.