### PR TITLE
add body parameter

### DIFF
--- a/soap-stub.js
+++ b/soap-stub.js
@@ -98,12 +98,12 @@ function createErroringStub(err) {
  * @param {?} object anything
  * @return {Function}
  */
-function createRespondingStub(object) {
+function createRespondingStub(object, body) {
   return function() {
     this.args.forEach(function(argSet) {
       setTimeout(argSet[1].bind(null, null, object));
     });
-    this.yields(null, object);
+    this.yields(null, object, body);
   };
 }
 


### PR DESCRIPTION
Sometimes the code that invokes the webservice needs to access the raw body to handle deserialization itself (for example because the date format is not correct so the deserialization does not work).

When it's the case, it does not seem possible with the current stub to stub the raw soap response.
This pull requests fixes this.