### PR TITLE
Add exchange unique id in client events

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -436,14 +436,21 @@ client.MyService.MyPort.MyFunction({name: 'value'}, options, extraHeaders, funct
 Client instances emit the following events:
 
 * request - Emitted before a request is sent. The event handler receives the
-entire Soap request (Envelope) including headers.
+entire Soap request (Envelope) including headers. The second parameter is the exchange id. 
 * message - Emitted before a request is sent. The event handler receives the
-Soap body contents. Useful if you don't want to log /store Soap headers.
+Soap body contents. Useful if you don't want to log /store Soap headers. The second parameter is the exchange id. 
 * soapError - Emitted when an erroneous response is received.
   Useful if you want to globally log errors.
+  The second parameter is the exchange id. 
 * response - Emitted after a response is received. The event handler receives
 the SOAP response body as well as the entire `IncomingMessage` response object.
+The third parameter is the exchange id. 
 This is emitted for all responses (both success and errors).
+
+An 'exchange' is a request/response couple. 
+Event handlers receive the exchange id in all events.
+The exchange id is the same for the requests events and the responses events, this way you can use it to retrieve the matching request
+when an response event is received.
 
 ## Security
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -13,7 +13,8 @@ var HttpClient = require('./http'),
   debug = require('debug')('node-soap'),
   findPrefix = require('./utils').findPrefix,
   _ = require('lodash'),
-  concatStream = require('concat-stream');
+  concatStream = require('concat-stream'),
+  uuid = require('node-uuid');
 
 var Client = function(wsdl, endpoint, options) {
   events.EventEmitter.call(this);
@@ -271,8 +272,10 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
   self.lastRequest = xml;
   self.lastEndpoint = location;
 
-  self.emit('message', message);
-  self.emit('request', xml);
+  var eid = uuid.v4();
+
+  self.emit('message', message, eid);
+  self.emit('request', xml, eid);
 
   var tryJSONparse = function(body) {
     try {
@@ -292,7 +295,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
       self.lastResponse = null;
       self.lastResponseHeaders = null;
       self.lastElapsedTime = null;
-      self.emit('response', null, null);
+      self.emit('response', null, null, eid);
 
       callback(err);
     };
@@ -307,7 +310,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
           self.lastResponse = body;
           self.lastResponseHeaders = response && response.headers;
           self.lastElapsedTime = Date.now() - startTime;
-          self.emit('response', body, response);
+          self.emit('response', body, response, eid);
 
           return parseSync(body, response);
 
@@ -319,12 +322,12 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
         self.lastResponse = response;
         self.lastResponseHeaders = response && response.headers;
         self.lastElapsedTime = Date.now() - startTime;
-        self.emit('response', '<stream>', response);
+        self.emit('response', '<stream>', response, eid);
 
         if (error) {
           error.response = response;
           error.body = '<stream>';
-          self.emit('soapError', error);
+          self.emit('soapError', error, eid);
           return callback(error, response);
         }
 
@@ -338,7 +341,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
     self.lastResponse = body;
     self.lastResponseHeaders = response && response.headers;
     self.lastElapsedTime = response && response.elapsedTime;
-    self.emit('response', body, response);
+    self.emit('response', body, response, eid);
 
     if (err) {
       callback(err);
@@ -364,7 +367,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
       }
       error.response = response;
       error.body = body;
-      self.emit('soapError', error);
+      self.emit('soapError', error, eid);
       return callback(error, response, body);
     }
     return finish(obj, body, response);


### PR DESCRIPTION
When using client events, it's useful to have a way to identify the corresponding soap request when we receive a response or an error.

This pull request adds an exchange unique id to requests and responses events (including message and errors). The exchange id is the same in requests and responses events, it's easy then to retrieve the request when an error happen for example.