### PR TITLE
Added option to suppress error stack in server response

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -37,6 +37,7 @@ var Server = function (server, path, services, wsdl, options) {
   this.path = path;
   this.services = services;
   this.wsdl = wsdl;
+  this.suppressStack = options && options.suppressStack;
 
   if (path[path.length - 1] !== '/')
     path += '/';
@@ -142,7 +143,7 @@ Server.prototype._processRequestXml = function (req, res, xml) {
         }
       }, new Date().toISOString());
     } else {
-      error = err.stack || err;
+      error = err.stack ? (self.suppressStack === true ? err.message : err.stack) : err;
       res.statusCode = 500;
       res.write(error);
       res.end();

--- a/lib/soap.js
+++ b/lib/soap.js
@@ -73,7 +73,7 @@ function listen(server, pathOrOptions, services, xml) {
   }
 
   var wsdl = new WSDL(xml || services, uri, options);
-  return new Server(server, path, services, wsdl);
+  return new Server(server, path, services, wsdl, options);
 }
 
 exports.security = security;


### PR DESCRIPTION
In case of e.g. wrong SOAP operation name in POST body, the server response will contain the full javascript stack trace, which can/should be considered a security risk.

Supplying the option "{ suppressStack: true }" will now only send the error message to the client. Default is false, to maintain previous behaviour.

Nevertheless, the wrong SOAP operation name error _should_ be fixed also, since it will not result in a descriptive error message but in 'Cannot read property 'output' of undefined' instead. This fix is not covered by this pull request.