### PR TITLE
Namespace prefix is required on first element when elementFormDefault=unqualified

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1660,7 +1660,7 @@ WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlns
 
   if (self.options.overrideRootElement && isFirst) {
     ns = self.options.overrideRootElement.namespace;
-  } else if (prefixNamespace && ((qualified || isFirst) || soapHeader) && !this.isIgnoredNameSpace(nsPrefix)) {
+  } else if (prefixNamespace && (qualified || isFirst || soapHeader) && !this.isIgnoredNameSpace(nsPrefix)) {
     ns = nsPrefix;
   }
 
@@ -1840,7 +1840,9 @@ WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlns
       }
 
       ns = noColonNameSpace(ns);
-      if (this.isIgnoredNameSpace(ns)) {
+      if (prefixNamespace && !qualified && isFirst && !self.options.overrideRootElement) {
+        ns = nsPrefix;
+      } else if (this.isIgnoredNameSpace(ns)) {
         ns = '';
       }
 

--- a/test/request-response-samples/execFile__add_default_namespace_prefix/request.json
+++ b/test/request-response-samples/execFile__add_default_namespace_prefix/request.json
@@ -1,0 +1,6 @@
+{
+		"fileName": "PSTN",
+		"arguments": "abc",
+		"base64EncodedStdIn": "dGVzdA==",
+		"startDetached": "true"
+}

--- a/test/request-response-samples/execFile__add_default_namespace_prefix/request.xml
+++ b/test/request-response-samples/execFile__add_default_namespace_prefix/request.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="urn:FileExecutor">
+  <soap:Body>
+    <tns:execFileParams>
+      <fileName>PSTN</fileName>
+      <arguments>abc</arguments>
+      <base64EncodedStdIn>dGVzdA==</base64EncodedStdIn>
+      <startDetached>true</startDetached>
+    </tns:execFileParams>
+  </soap:Body>
+</soap:Envelope>

--- a/test/request-response-samples/execFile__add_default_namespace_prefix/response.json
+++ b/test/request-response-samples/execFile__add_default_namespace_prefix/response.json
@@ -1,0 +1,3 @@
+{
+    "base64EncodedStdOut": "cXc="
+}

--- a/test/request-response-samples/execFile__add_default_namespace_prefix/response.xml
+++ b/test/request-response-samples/execFile__add_default_namespace_prefix/response.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:FileExecutor">
+   <soapenv:Header/>
+   <soapenv:Body>
+      <urn:execFileResult>
+         <base64EncodedStdOut>cXc=</base64EncodedStdOut>
+      </urn:execFileResult>
+   </soapenv:Body>
+</soapenv:Envelope>

--- a/test/request-response-samples/execFile__add_default_namespace_prefix/soap.wsdl
+++ b/test/request-response-samples/execFile__add_default_namespace_prefix/soap.wsdl
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+	targetNamespace="urn:FileExecutor"
+	xmlns:tns="urn:FileExecutor"
+	xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+	xmlns="http://schemas.xmlsoap.org/wsdl/">
+	<types>
+		<schema
+			xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+			xmlns="http://www.w3.org/2001/XMLSchema"
+			xmlns:tns="urn:FileExecutor"
+			targetNamespace="urn:FileExecutor"
+			elementFormDefault="unqualified" attributeFormDefault="unqualified">
+			<element name="execFileParams" type="tns:execFileParams"/>
+			<complexType name="execFileParams">
+				<sequence>
+					<element name="fileName" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="arguments" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+					<element name="base64EncodedStdIn" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+					<element name="startDetached" type="xsd:boolean" minOccurs="1" maxOccurs="1"/>
+				</sequence>
+			</complexType>
+			<element name="execFileResult" type="tns:execFileResult"/>
+			<complexType name="execFileResult">
+				<sequence>
+					<element name="base64EncodedStdOut" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+				</sequence>
+			</complexType>
+		</schema>
+	</types>
+	<message name="execFileRequest">
+		<part name="execFileRequest" element="tns:execFileParams"/>
+	</message>
+	<message name="execFileResponse">
+		<part name="execFileResponse" element="tns:execFileResult"/>
+	</message>
+	<portType name="FileExecutorPortType">
+		<operation name="execFile">
+			<input message="tns:execFileRequest"/>
+			<output message="tns:execFileResponse"/>
+		</operation>
+	</portType>
+	<binding name="FileExecutorBinding" type="tns:FileExecutorPortType">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+		<operation name="execFile">
+			<soap:operation type="document"/>
+			<input>
+				<soap:body use="literal"/>
+			</input>
+			<output>
+				<soap:body use="literal"/>
+			</output>
+		</operation>
+	</binding>
+	<service name="FileExecutorService">
+		<port name="FileExecutorPortType" binding="tns:FileExecutorBinding">
+			<soap:address location="http://127.0.0.1/"/>
+		</port>
+	</service>
+</definitions>


### PR DESCRIPTION
This PR fixes an issue that the namespace prefix was missing on the first element in SOAP body. 

In below example, this PR adds the `tns` in `<tns:execFileParams>`. 

```
<?xml version="1.0" encoding="utf-8"?>
<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="urn:FileExecutor">
  <soap:Body>
    <tns:execFileParams>
      <fileName>PSTN</fileName>
      <arguments>abc</arguments>
      <base64EncodedStdIn>dGVzdA==</base64EncodedStdIn>
      <startDetached>true</startDetached>
    </tns:execFileParams>
  </soap:Body>
</soap:Envelope>
```

I have crosschecked the generated SOAP request in SoapUI-5.2.1 using the same WSDL.