### PR TITLE
Update the version of ejs dependency to ~2.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "compress": "^0.99.0",
     "concat-stream": "^1.5.1",
     "debug": "~0.7.4",
-    "ejs": "~2.3.4",
+    "ejs": "~2.5.5",
     "finalhandler": "^0.5.0",
     "lodash": "^3.10.1",
     "node-uuid": "~1.4.3",


### PR DESCRIPTION
This is due to the security vulns described here https://snyk.io/blog/fixing-ejs-rce-vuln

I ran the mocha suite and everything seemed OK - there was a nondeterministic result from some timing test but I don't believe it's related, and I couldn't run full `npm test` because of some lint errors in an unrelated file.