### PR TITLE
Add support for attributes in root elements

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1572,7 +1572,14 @@ WSDL.prototype.objectToRpcXML = function(name, params, nsPrefix, nsURI,isParts) 
     if (key !== nsAttrName) {
       var value = params[key];
       var prefixedKey = (isParts ? '' : nsPrefix) + key;
-      parts.push(['<', prefixedKey, '>'].join(''));
+      var attributes = [];
+      if (typeof value === 'object' && value.hasOwnProperty(this.options.attributesKey)) {
+        var attrs = value[this.options.attributesKey];
+        for (var n in attrs) {
+          attributes.push(' ' + n + '=' + '"' + attrs[n] + '"');
+        }
+      }
+      parts.push(['<', prefixedKey ].concat(attributes).concat('>').join(''));
       parts.push((typeof value === 'object') ? this.objectToXML(value, key, nsPrefix, nsURI) : xmlEscape(value));
       parts.push(['</', prefixedKey, '>'].join(''));
     }

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -137,6 +137,24 @@ wsdlNonStrictTests['should load same namespace from included xsd'] = function(do
   });
 };
 
+wsdlNonStrictTests['should all attributes to root elements'] = function(done) {
+  var expectedMsg = '<ns1:fooRq xmlns:ns1="http://example.com/bar/xsd"' +
+    ' xmlns="http://example.com/bar/xsd"><bar1:paymentRq bar1:test="attr"' +
+    ' xmlns:bar1="http://example.com/bar1/xsd">' +
+    '<bar1:bankSvcRq>' +
+    '<requestUID>001</requestUID></bar1:bankSvcRq>' +
+    '</bar1:paymentRq></ns1:fooRq>';
+  // var expectedMsg = 'gg';
+
+  soap.createClient(__dirname + '/wsdl/elementref/foo.wsdl', {}, function(err, client) {
+    assert.ok(!err);
+    client.fooOp({paymentRq: { attributes: {'bar1:test': 'attr'}, bankSvcRq: {':requestUID': '001'}}}, function(err, result) {
+      assert.equal(client.lastMessage, expectedMsg);
+      done();
+    });
+  });
+};
+
 module.exports = {
   'WSDL Parser (strict)': wsdlStrictTests,
   'WSDL Parser (non-strict)': wsdlNonStrictTests


### PR DESCRIPTION
Those changes allow to add attributes to root elements of the soap request. For example:
```js
client.foo({
  foo: {
    attributes: { bar: 'true' },
    $value: 'my-value'
  }
}, function(err, result) {

});
```