### PR TITLE
Only add references for the soap:Body and wsse:Security/Timestamp elements in WSSecurityCert

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -265,7 +265,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
     "</" + envelopeKey + ":Envelope>";
 
   if(self.security && self.security.postProcess){
-    xml = self.security.postProcess(xml);
+    xml = self.security.postProcess(xml, envelopeKey);
   }
 
   self.lastMessage = message;

--- a/lib/security/WSSecurityCert.js
+++ b/lib/security/WSSecurityCert.js
@@ -47,12 +47,6 @@ function WSSecurityCert(privatePEM, publicP12PEM, password, encoding) {
   this.signer.signingKey = this.privateKey.toPrivatePem();
   this.x509Id = "x509-" + generateId();
 
-  var references = ["http://www.w3.org/2000/09/xmldsig#enveloped-signature",
-    "http://www.w3.org/2001/10/xml-exc-c14n#"];
-
-  this.signer.addReference("//*[local-name(.)='Body']", references);
-  this.signer.addReference("//*[local-name(.)='Timestamp']", references);
-
   var _this = this;
   this.signer.keyInfoProvider = {};
   this.signer.keyInfoProvider.getKeyInfo = function (key) {
@@ -60,7 +54,7 @@ function WSSecurityCert(privatePEM, publicP12PEM, password, encoding) {
   };
 }
 
-WSSecurityCert.prototype.postProcess = function (xml) {
+WSSecurityCert.prototype.postProcess = function (xml, envelopeKey) {
   this.created = generateCreated();
   this.expires = generateExpires();
 
@@ -72,6 +66,12 @@ WSSecurityCert.prototype.postProcess = function (xml) {
   });
 
   var xmlWithSec = insertStr(secHeader, xml, xml.indexOf('</soap:Header>'));
+
+  var references = ["http://www.w3.org/2000/09/xmldsig#enveloped-signature",
+    "http://www.w3.org/2001/10/xml-exc-c14n#"];
+
+  this.signer.addReference("//*[name(.)='" + envelopeKey + ":Body']", references);
+  this.signer.addReference("//*[name(.)='wsse:Security']/*[local-name(.)='Timestamp']", references);
 
   this.signer.computeSignature(xmlWithSec);
 

--- a/test/security/WSSecurityCert.js
+++ b/test/security/WSSecurityCert.js
@@ -48,7 +48,7 @@ describe('WSSecurityCert', function() {
 
   it('should insert a WSSecurity signing block when postProcess is called', function() {
     var instance = new WSSecurityCert(key, cert, '', 'utf8');
-    var xml = instance.postProcess('<soap:Header></soap:Header><soap:Body></soap:Body>');
+    var xml = instance.postProcess('<soap:Header></soap:Header><soap:Body></soap:Body>', 'soap');
 
     xml.should.containEql('<wsse:Security');
     xml.should.containEql('http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd');
@@ -68,5 +68,12 @@ describe('WSSecurityCert', function() {
     xml.should.containEql('ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3"/>');
     xml.should.containEql(instance.publicP12PEM);
     xml.should.containEql(instance.signer.getSignatureXml());
+  });
+
+  it('should only add two Reference elements, for Soap Body and Timestamp inside wsse:Security element', function() {
+    var instance = new WSSecurityCert(key, cert, '', 'utf8');
+    var xml = instance.postProcess('<soap:Header></soap:Header><soap:Body><Body></Body><Timestamp></Timestamp></soap:Body>', 'soap');
+
+    xml.match(/<Reference URI="#/g).should.have.length(2);
   });
 });


### PR DESCRIPTION
At the moment WSSecurityCert tries to incorrectly also add calculate digests and add references for elements inside soap:Body; for example if you have:

```xml
<soap:Header></soap:Header><soap:Body><Body></Body><Timestamp></Timestamp></soap:Body>
```

And use WSSecurityCert, it will result in the following:

```xml
<soap:Header><wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
               xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
               soap:mustUnderstand="1">
    <wsse:BinarySecurityToken
               EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary"
               ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3"
               wsu:Id="x509-a398536eac094d8889972a0cb4565f52">MIIB7DCCAZYCCQC7gs0MDNn6MTANBgkqhkiG9w0BAQUFADB9MQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0ExCzAJBgNVBAcTAlNGMQ8wDQYDVQQKEwZKb3llbnQxEDAOBgNVBAsTB05vZGUuanMxDzANBgNVBAMTBmFnZW50MjEgMB4GCSqGSIb3DQEJARYRcnlAdGlueWNsb3Vkcy5vcmcwHhcNMTEwMzE0MTgyOTEyWhcNMzgwNzI5MTgyOTEyWjB9MQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0ExCzAJBgNVBAcTAlNGMQ8wDQYDVQQKEwZKb3llbnQxEDAOBgNVBAsTB05vZGUuanMxDzANBgNVBAMTBmFnZW50MjEgMB4GCSqGSIb3DQEJARYRcnlAdGlueWNsb3Vkcy5vcmcwXDANBgkqhkiG9w0BAQEFAANLADBIAkEAyXb8FrRdKbhrKLgLSsn61i1C7w7fVVVd7OQsmV/7p9WB2lWFiDlCWKGU9SiIz/A6wNZDUAuc2E+VwtpCT561AQIDAQABMA0GCSqGSIb3DQEBBQUAA0EAC8HzpuNhFLCI3A5KkBS5zHAQax6TFUOhbpBCR0aTDbJ6F1liDTK1lmU/BjvPoj+91LHwrmh29rK8kBPEjmymCQ==</wsse:BinarySecurityToken>
    <Timestamp xmlns="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" Id="_1">
        <Created>2017-01-10T17:11:17Z</Created>
        <Expires>2017-01-10T17:21:17Z</Expires>
    </Timestamp>
<Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" /><SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1" /><Reference URI="#_0"><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" /><Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" /></Transforms><DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" /><DigestValue>+a/MnIamE2MEuaDxCQq8WpiQbFg=</DigestValue></Reference><Reference URI="#_1"><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" /><Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" /></Transforms><DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" /><DigestValue>8m8dRxp/eBYs8d8k2wR5rQ1nAa8=</DigestValue></Reference><Reference URI="#_1"><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" /><Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" /></Transforms><DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" /><DigestValue>vB+Gk490BDDSHMiUExR0f14o9t4=</DigestValue></Reference><Reference URI="#_2"><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" /><Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" /></Transforms><DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" /><DigestValue>kpya6dq9RIaQjlQuDW2oatPhkkM=</DigestValue></Reference></SignedInfo><SignatureValue>rglvc4t2m2gIiRKC8+s+80uhfPDYfOF6lg8f4tTAhMjEj85/rNPyn5zr3CwR9gQgjB6FzG/dPojDzok45pYQKw==</SignatureValue><KeyInfo><wsse:SecurityTokenReference>
    <wsse:Reference URI="#x509-a398536eac094d8889972a0cb4565f52" ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3"/>
</wsse:SecurityTokenReference>
</KeyInfo></Signature></wsse:Security>
</soap:Header><soap:Body><Body></Body><Timestamp></Timestamp></soap:Body>
```

As you can see there are too many Reference elements in the SignedInfo. The reason is that the WSSecurityCert adds references for elements named "Body" or "Timestamp" regardless where they are in the document, or what their namespace is. The reason why the corresponding elements in the soap:Body don't have the Id attribute is because WSSecurityCert's postProcess doesn't modify the body at all, it only adds the signature with `insertStr(this.signer.getSignatureXml(), xmlWithSec, xmlWithSec.indexOf('</wsse:Security>'))`

The correct output should be this:

```xml
<soap:Header><wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
               xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
               soap:mustUnderstand="1">
    <wsse:BinarySecurityToken
               EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary"
               ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3"
               wsu:Id="x509-5494ac42946f449e84824fa3780e423b">MIIB7DCCAZYCCQC7gs0MDNn6MTANBgkqhkiG9w0BAQUFADB9MQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0ExCzAJBgNVBAcTAlNGMQ8wDQYDVQQKEwZKb3llbnQxEDAOBgNVBAsTB05vZGUuanMxDzANBgNVBAMTBmFnZW50MjEgMB4GCSqGSIb3DQEJARYRcnlAdGlueWNsb3Vkcy5vcmcwHhcNMTEwMzE0MTgyOTEyWhcNMzgwNzI5MTgyOTEyWjB9MQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0ExCzAJBgNVBAcTAlNGMQ8wDQYDVQQKEwZKb3llbnQxEDAOBgNVBAsTB05vZGUuanMxDzANBgNVBAMTBmFnZW50MjEgMB4GCSqGSIb3DQEJARYRcnlAdGlueWNsb3Vkcy5vcmcwXDANBgkqhkiG9w0BAQEFAANLADBIAkEAyXb8FrRdKbhrKLgLSsn61i1C7w7fVVVd7OQsmV/7p9WB2lWFiDlCWKGU9SiIz/A6wNZDUAuc2E+VwtpCT561AQIDAQABMA0GCSqGSIb3DQEBBQUAA0EAC8HzpuNhFLCI3A5KkBS5zHAQax6TFUOhbpBCR0aTDbJ6F1liDTK1lmU/BjvPoj+91LHwrmh29rK8kBPEjmymCQ==</wsse:BinarySecurityToken>
    <Timestamp xmlns="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" Id="_1">
        <Created>2017-01-10T17:10:29Z</Created>
        <Expires>2017-01-10T17:20:29Z</Expires>
    </Timestamp>
<Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" /><SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1" /><Reference URI="#_0"><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" /><Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" /></Transforms><DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" /><DigestValue>+a/MnIamE2MEuaDxCQq8WpiQbFg=</DigestValue></Reference><Reference URI="#_1"><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" /><Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" /></Transforms><DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" /><DigestValue>B8HHqXNFFOxavBAgTk+qwrIlOCE=</DigestValue></Reference></SignedInfo><SignatureValue>IfZB2Dh3jC0hmBqWYHyQ8e4uuTFU2uJ+1X8UePJjoCLuLiF0as/91ENrpjN+vYLbgDyT8SiQ1uypBDlWN6zCRw==</SignatureValue><KeyInfo><wsse:SecurityTokenReference>
    <wsse:Reference URI="#x509-5494ac42946f449e84824fa3780e423b" ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3"/>
</wsse:SecurityTokenReference>
</KeyInfo></Signature></wsse:Security>
</soap:Header><soap:Body><Body></Body><Timestamp></Timestamp></soap:Body>
```

This pull request fixes the issue by being more specific about the elements for which to calculate digests for.