### PR TITLE
If a complex type is used, use the complex type element name and not …

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -300,8 +300,13 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
     (method.inputSoap === 'encoded') && (encoding = 'soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" ');
   } else {
     assert.ok(!style || style === 'document', 'invalid message definition for rpc style binding');
+
+    // If a complex type is used, use the complex type element name and not the input name.
+    var rootElement = input.name;
+    if (input.children.length === 1 && input.children[0].$element) rootElement = input.children[0].$element;
+
     // pass `input.$lookupType` if `input.$type` could not be found
-    message = self.wsdl.objectToDocumentXML(input.$name, args, input.targetNSAlias, input.targetNamespace, (input.$type || input.$lookupType));
+    message = self.wsdl.objectToDocumentXML(rootElement, args, input.targetNSAlias, input.targetNamespace, (input.$type || input.$lookupType));
   }
   xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
     "<" + envelopeKey + ":Envelope " +


### PR DESCRIPTION
If a complex type is used, use the complex type element name and not the input name.

Here's an excerpt:
```
    <wsdl:message name="getWidgetSummaryByWidgetNumberRequestMsg">
        <wsdl:part name="getWidgetSummaryByWidgetNumberParameters" element="tns:getWidgetSummaryByWidgetNumber">
        </wsdl:part>
    </wsdl:message>
```
The server is expecting "getWidgetSummaryByWidgetNumber" in the root node, but node-soap uses "getWidgetSummaryByWidgetNumberRequestMsg".

I've tested with SoapUI and it correctly sets the root node to "getWidgetSummaryByWidgetNumber".