### PR TITLE
add array options for namespaces in WSDL to set into Envelop

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1068,7 +1068,8 @@ var WSDL = function(definition, uri, options) {
       }
 
       // prepare soap envelope xmlns definition string
-      self.xmlnsInEnvelope = self._xmlnsMap();
+      var xmlnsIntoEnvelope = options.xmlnsIntoEnvelope;
+      self.xmlnsInEnvelope = self._xmlnsMap(xmlnsIntoEnvelope);
 
       self.callback(err, self);
     });
@@ -2081,14 +2082,20 @@ WSDL.prototype._fromServices = function(services) {
 
 WSDL.prototype._splitQName = splitQName;
 
-WSDL.prototype._xmlnsMap = function() {
+WSDL.prototype._xmlnsMap = function (xmlnsIntoEnvelope) {
   var xmlns = this.definitions.xmlns;
   var str = '';
   for (var alias in xmlns) {
     if (alias === '' || alias === TNS_PREFIX) {
       continue;
     }
+
     var ns = xmlns[alias];
+    if (ns && xmlnsIntoEnvelope && ~xmlnsIntoEnvelope.indexOf(alias)) {
+      str += ' xmlns:' + alias + '="' + ns + '"';
+      continue;
+    }
+
     switch (ns) {
       case "http://xml.apache.org/xml-soap" : // apachesoap
       case "http://schemas.xmlsoap.org/wsdl/" : // wsdl


### PR DESCRIPTION
I need to preserve some xml namespaces from schemas.xmlsoap.org and www.w3.org into the envelop from the wsdl. The _xmlnsMap filter always the namespaces without criterial, so I added an option to configure that.