### PR TITLE
patch for implementations of request() without body in the callback

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -2184,6 +2184,7 @@ function open_wsdl(uri, options, callback) {
       if (err) {
         callback(err);
       } else if (response && response.statusCode === 200) {
+        definition || (definition = response.body);
         wsdl = new WSDL(definition, uri, options);
         WSDL_CACHE[ uri ] = wsdl;
         wsdl.WSDL_CACHE = WSDL_CACHE;


### PR DESCRIPTION
When mocking request() with an options: { request } override, (in this case httpntlm to fetch the WSDL w/ authentication)... a small patch is required to pull the response.body payload instead of definition, which is undefined.

https://www.npmjs.com/package/httpntlm