### PR TITLE
[EDIT] Added an ability to have custom WSSE usernametoken attribute. Added unit testing for it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ yarn.lock
 .vscode
 .idea
 *.iml
+*swp
+*swo

--- a/lib/security/WSSecurity.js
+++ b/lib/security/WSSecurity.js
@@ -4,6 +4,19 @@ var crypto = require('crypto');
 var passwordDigest = require('../utils').passwordDigest;
 var validPasswordTypes = ['PasswordDigest', 'PasswordText'];
 
+// avoid dependency on date formatting libraries
+function getDate(d) {
+  function pad(n) {
+    return n < 10 ? '0' + n : n;
+  }
+  return d.getUTCFullYear() + '-'
+    + pad(d.getUTCMonth() + 1) + '-'
+    + pad(d.getUTCDate()) + 'T'
+    + pad(d.getUTCHours()) + ':'
+    + pad(d.getUTCMinutes()) + ':'
+    + pad(d.getUTCSeconds()) + 'Z';
+}
+
 function WSSecurity(username, password, options) {
   options = options || {};
   this._username = username;
@@ -41,7 +54,6 @@ function WSSecurity(username, password, options) {
 }
 
 WSSecurity.prototype.toXML = function() {
-  // avoid dependency on date formatting libraries
   var now = new Date();
   var created = getDate(now);
   var timeStampXml = '';
@@ -83,15 +95,3 @@ WSSecurity.prototype.toXML = function() {
 };
 
 module.exports = WSSecurity;
-
-function getDate(d) {
-	function pad(n) {
-		return n < 10 ? '0' + n : n;
-	}
-	return d.getUTCFullYear() + '-'
-		+ pad(d.getUTCMonth() + 1) + '-'
-		+ pad(d.getUTCDate()) + 'T'
-		+ pad(d.getUTCHours()) + ':'
-		+ pad(d.getUTCMinutes()) + ':'
-		+ pad(d.getUTCSeconds()) + 'Z';
-}

--- a/lib/security/WSSecurity.js
+++ b/lib/security/WSSecurity.js
@@ -8,6 +8,12 @@ function WSSecurity(username, password, options) {
   options = options || {};
   this._username = username;
   this._password = password;
+	this._wsu = {
+		name: options.customWsuName || 'wsu',
+		id: options.customWsuId || 'Id',
+		value: options.customWsuValue || 'SecurityToken-'+getDate(new Date()),
+		path: options.customWsuPath || 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd',
+	};
   //must account for backward compatibility for passwordType String param as well as object options defaults: passwordType = 'PasswordText', hasTimeStamp = true   
   if (typeof options === 'string') {
     this._passwordType = options ? options : 'PasswordText';
@@ -36,17 +42,6 @@ function WSSecurity(username, password, options) {
 
 WSSecurity.prototype.toXML = function() {
   // avoid dependency on date formatting libraries
-  function getDate(d) {
-    function pad(n) {
-      return n < 10 ? '0' + n : n;
-    }
-    return d.getUTCFullYear() + '-'
-      + pad(d.getUTCMonth() + 1) + '-'
-      + pad(d.getUTCDate()) + 'T'
-      + pad(d.getUTCHours()) + ':'
-      + pad(d.getUTCMinutes()) + ':'
-      + pad(d.getUTCSeconds()) + 'Z';
-  }
   var now = new Date();
   var created = getDate(now);
   var timeStampXml = '';
@@ -75,16 +70,28 @@ WSSecurity.prototype.toXML = function() {
       "<wsse:Nonce EncodingType=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary\">" + nonce + "</wsse:Nonce>";
   }
 
-  return "<wsse:Security " + (this._actor ? "soap:actor=\"" + this._actor + "\" " : "") +
-    (this._mustUnderstand ? "soap:mustUnderstand=\"1\" " : "") +
-    "xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\" xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\">" +
-    timeStampXml +
-    "<wsse:UsernameToken xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\" wsu:Id=\"SecurityToken-" + created + "\">" +
-    "<wsse:Username>" + this._username + "</wsse:Username>" +
-    password +
-    (this._hasTokenCreated ? "<wsu:Created>" + created + "</wsu:Created>" : "") +
-    "</wsse:UsernameToken>" +
-    "</wsse:Security>";
+	return "<wsse:Security " + (this._actor ? "soap:actor=\"" + this._actor + "\" " : "") +
+		(this._mustUnderstand ? "soap:mustUnderstand=\"1\" " : "") +
+		"xmlns:wsse=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\" xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\">" +
+		timeStampXml +
+		"<wsse:UsernameToken xmlns:"+this._wsu.name+"=\""+this._wsu.path+"\" "+this._wsu.name+":"+this._wsu.id+"=\""+this._wsu.value+"\">" +
+		"<wsse:Username>" + this._username + "</wsse:Username>" +
+		password +
+		(this._hasTokenCreated ? "<wsu:Created>" + created + "</wsu:Created>" : "") +
+		"</wsse:UsernameToken>" +
+		"</wsse:Security>";
 };
 
 module.exports = WSSecurity;
+
+function getDate(d) {
+	function pad(n) {
+		return n < 10 ? '0' + n : n;
+	}
+	return d.getUTCFullYear() + '-'
+		+ pad(d.getUTCMonth() + 1) + '-'
+		+ pad(d.getUTCDate()) + 'T'
+		+ pad(d.getUTCHours()) + ':'
+		+ pad(d.getUTCMinutes()) + ':'
+		+ pad(d.getUTCSeconds()) + 'Z';
+}

--- a/test/custom-usernametoken-attr-test.js
+++ b/test/custom-usernametoken-attr-test.js
@@ -1,5 +1,0 @@
-'use strict';
-
-describe('Custom UsernameToken Attribute', function () {
-
-});

--- a/test/custom-usernametoken-attr-test.js
+++ b/test/custom-usernametoken-attr-test.js
@@ -1,0 +1,5 @@
+'use strict';
+
+describe('Custom UsernameToken Attribute', function () {
+
+});

--- a/test/security/WSSecurity.js
+++ b/test/security/WSSecurity.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var fs = require('fs'),
-  join = require('path').join;
+  join = require('path').join,
+	assert = require('assert');
 
 describe('WSSecurity', function() {
   var WSSecurity = require('../../').WSSecurity;
@@ -69,4 +70,37 @@ describe('WSSecurity', function() {
     xml.should.containEql('</wsse:UsernameToken></wsse:Security>');
 
   });
+	var username = 'myUser';
+	var password = 'myPass';
+	it('should accept additional parameters for custom UsernameToken attribute.', function() {
+		var options = {
+			customWsuName: "kor",
+			customWsuId: "clientId",
+			customWsuValue: "12345678",
+			customWsuPath: "http://www.korea.com",
+		};
+		var instance = new WSSecurity(username, password, options);
+		instance.should.have.property('_wsu', {
+			name: options.customWsuName,
+			id: options.customWsuId,
+			value: options.customWsuValue,
+			path: options.customWsuPath,
+		});
+	});
 });
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/test/security/WSSecurity.js
+++ b/test/security/WSSecurity.js
@@ -1,8 +1,7 @@
 'use strict';
 
 var fs = require('fs'),
-  join = require('path').join,
-	assert = require('assert');
+  join = require('path').join;
 
 describe('WSSecurity', function() {
   var WSSecurity = require('../../').WSSecurity;
@@ -70,9 +69,9 @@ describe('WSSecurity', function() {
     xml.should.containEql('</wsse:UsernameToken></wsse:Security>');
 
   });
-	var username = 'myUser';
-	var password = 'myPass';
 	it('should accept additional parameters for custom UsernameToken attribute.', function() {
+    var username = 'myUser';
+    var password = 'myPass';
 		var options = {
 			customWsuName: "kor",
 			customWsuId: "clientId",
@@ -88,19 +87,3 @@ describe('WSSecurity', function() {
 		});
 	});
 });
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
I needed to put custom attribute to usernamToken element in WSSE security header like below.
<wsse:UsernameToken kor:clientId="myClientId" xmlns:kor="https://www.korea.com/auth">
...
</wsse:UsernameToken>

It will be achieved by passing additional keys and properties to options for soap.WSSecurity constructor.

For example,
let options = {
...
customWsuName: 'kor',
customWsuId: 'clientId',
customWsuValue: 'myClientId',
customWsuPath: 'https://www.korea.com/auth',
};

Unless specified, default values will be used.
