### PR TITLE
Drop `travis-ci` test support for `node.js` versions < `4.x` (LTS)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: node_js
 notifications:
   email: false
 node_js:
-  - 0.10
-  - 0.12
   - 4.0
   - 6.9.4
   - 7.4.0


### PR DESCRIPTION
Dropping support for `node.js` versions `0.1` and `0.12.x`.