### PR TITLE
upgrade to lodash 4.17.4

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -88,7 +88,7 @@ function trim(text) {
 }
 
 function deepMerge(destination, source) {
-  return _.merge(destination || {}, source, function(a, b) {
+  return _.mergeWith(destination || {}, source, function(a, b) {
       return _.isArray(a) ? a.concat(b) : undefined;
     });
 }
@@ -1168,7 +1168,7 @@ WSDL.prototype._processNextInclude = function(includes, callback) {
     self._includesWsdl.push(wsdl);
 
     if (wsdl.definitions instanceof DefinitionsElement) {
-      _.merge(self.definitions, wsdl.definitions, function(a,b) {
+      _.mergeWith(self.definitions, wsdl.definitions, function(a,b) {
         return (a instanceof SchemaElement) ? a.merge(b) : undefined;
       });
     } else {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "debug": "~0.7.4",
     "ejs": "~2.5.5",
     "finalhandler": "^0.5.0",
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.4",
     "optional": "^0.1.3",
     "request": ">=2.9.0",
     "sax": ">=0.6",


### PR DESCRIPTION
Lodash 4.x merge function does not take customizer function as the third argument anymore : 

https://lodash.com/docs/4.17.4#merge

Instead we have to use the function mergeWith

That's problematic when a dependency other than node-soap requires lodash 4.x : lodash 4.x ends up being used and wsdl inclusion does not work anymore.

This pull request switches to lodash 4.17.4 and use mergeWith function to fix this.