### PR TITLE
Add yarn.lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 node_modules
 npm-debug.log
 coverage
-
+yarn.lock
 .vscode
 .idea
 *.iml


### PR DESCRIPTION
It's recommended to add Yarn lock file into git (https://yarnpkg.com/blog/2016/11/24/lockfiles-for-all/). But since node-soap doesn't officially make use of Yarn, I add it to `.gitignore`  so that individual contributors may choose Yarn over NPM.