### PR TITLE
Remove not needed header declaration on request function

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -109,7 +109,6 @@ HttpClient.prototype.handleResponse = function(req, res, body) {
 HttpClient.prototype.request = function(rurl, data, callback, exheaders, exoptions) {
   var self = this;
   var options = self.buildRequest(rurl, data, exheaders, exoptions);
-  var headers = options.headers;
   var req = self._request(options, function(err, res, body) {
     if (err) {
       return callback(err);


### PR DESCRIPTION
Issue: Allocation of unused variables is not recommended.
Fix: Remove unused declaration for var header on request function