### PR TITLE
Use children's base type as the type of restriction and simpleType elements

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -233,7 +233,7 @@ var DefinitionsElement = Element.createSubClass();
 var ElementTypeMap = {
   types: [TypesElement, 'schema documentation'],
   schema: [SchemaElement, 'element complexType simpleType include import'],
-  element: [ElementElement, 'annotation complexType'],
+  element: [ElementElement, 'annotation complexType simpleType'],
   any: [AnyElement, ''],
   simpleType: [SimpleTypeElement, 'restriction'],
   restriction: [RestrictionElement, 'enumeration all choice sequence'],
@@ -736,7 +736,7 @@ SimpleTypeElement.prototype.description = function(definitions) {
   var children = this.children;
   for (var i = 0, child; child = children[i]; i++) {
     if (child instanceof RestrictionElement)
-      return this.$name + "|" + child.description();
+      return child.description();
   }
   return {};
 };
@@ -763,12 +763,8 @@ RestrictionElement.prototype.description = function(definitions, xmlns) {
     };
     return desc;
   }
-
-    // then simple element
-  var base = this.$base ? this.$base + "|" : "";
-  return base + this.children.map(function(child) {
-    return child.description();
-  }).join(",");
+  
+  return this.$base;
 };
 
 ExtensionElement.prototype.description = function(definitions, xmlns) {
@@ -913,6 +909,8 @@ ElementElement.prototype.description = function(definitions, xmlns) {
     element[name] = {};
     for (var i = 0, child; child = children[i]; i++) {
       if (child instanceof ComplexTypeElement) {
+        element[name] = child.description(definitions, xmlns);
+      } else if (child instanceof SimpleTypeElement) {
         element[name] = child.description(definitions, xmlns);
       }
     }

--- a/test/client-customHttp-xsdinclude-test.js
+++ b/test/client-customHttp-xsdinclude-test.js
@@ -77,8 +77,8 @@ it('should allow customization of httpClient, the wsdl file, and associated data
           DummyPortType: {
             Dummy: {
               "input": {
-                "ID": "IdType|xs:string|pattern",
-                "Name": "NameType|xs:string|minLength,maxLength"
+                "ID": "xs:string",
+                "Name": "xs:string"
               },
               "output": {
                 "Result": "dummy:DummyList"

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -100,7 +100,7 @@ var fs = require('fs'),
         
         var xmlStr = '<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n\t<head>\n\t\t<title>404 - Not Found</title>\n\t</head>\n\t<body>\n\t\t<h1>404 - Not Found</h1>\n\t\t<script type="text/javascript" src="http://gp1.wpc.edgecastcdn.net/00222B/beluga/pilot_rtm/beluga_beacon.js"></script>\n\t</body>\n</html>';
         client.MyOperation({_xml: xmlStr}, function (err, result, raw, soapHeader) {
-            assert.notEqual(raw.indexOf('html'), -1);
+          assert.notEqual(raw.indexOf('html'), -1);
           done();
         });
       });
@@ -206,25 +206,25 @@ var fs = require('fs'),
       });
 
       
-     it('should have xml request modified', function (done) {
-          soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function(err, client) {
-              assert.ok(client);
-              assert.ok(!err);
+      it('should have xml request modified', function (done) {
+        soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function(err, client) {
+            assert.ok(client);
+            assert.ok(!err);
 
-              client.MyOperation({}, function(err, result) {
-                      assert.ok(result);
-                      assert.ok(client.lastResponse);
-                      assert.ok(client.lastResponseHeaders);
+            client.MyOperation({}, function(err, result) {
+                    assert.ok(result);
+                    assert.ok(client.lastResponse);
+                    assert.ok(client.lastResponseHeaders);
 
-                      done();
+                    done();
                   }, {
-                      postProcess: function(_xml) {
-                          return _xml.replace('soap', 'SOAP');
-                      }
-                  }
-              );
+              postProcess: function(_xml) {
+                return _xml.replace('soap', 'SOAP');
+              }
+            }
+            );
           }, baseUrl);
-       });
+      });
       
       it('should have the correct extra header in the request', function (done) {
         soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -937,5 +937,35 @@ var fs = require('fs'),
         });
       });
     });
+    
+    it('should respect the types defined in the response schema', function (done) {
+      var server = null;
+      var hostname = '127.0.0.1';
+      var port = 15099;
+      var baseUrl = 'http://' + hostname + ':' + port;
+
+      server = http.createServer(function (req, res) {
+        res.statusCode = 200;
+        res.write('<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Header/><soapenv:Body><buil:restrictedIntElement xmlns:buil="http://www.BuiltinTypes.com/">1</buil:restrictedIntElement></soapenv:Body></soapenv:Envelope>');
+        res.end();
+      }).listen(port, hostname, function () {
+        soap.createClient(__dirname + '/wsdl/builtin_types.wsdl', meta.options, function (err, client) {
+          assert.ok(client);
+          assert.ok(!err);
+
+          client.IntOperation({}, function (err, result, body, responseSoapHeaders) {
+            server.close();
+            server = null;
+            assert.ok(!err);
+            assert.ok(!responseSoapHeaders);
+            assert.ok(result);
+            assert.ok(body);
+            assert.equal(typeof result, 'number');
+            done();
+          });
+        }, baseUrl);
+      });
+    });
+    
   });
 });

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -129,7 +129,7 @@ wsdlStrictTests['should get empty namespace prefix'] = function(done) {
 };
 
 wsdlNonStrictTests['should load same namespace from included xsd'] = function(done) {
-  var expected = '{"DummyService":{"DummyPortType":{"Dummy":{"input":{"ID":"IdType|xs:string|pattern","Name":"NameType|xs:string|minLength,maxLength"},"output":{"Result":"dummy:DummyList"}}}}}';
+  var expected = '{"DummyService":{"DummyPortType":{"Dummy":{"input":{"ID":"xs:string","Name":"xs:string"},"output":{"Result":"dummy:DummyList"}}}}}';
   soap.createClient(__dirname + '/wsdl/xsdinclude/xsd_include.wsdl', function(err, client) {
     assert.ok(!err);
     assert.equal(JSON.stringify(client.describe()), expected);

--- a/test/wsdl/builtin_types.wsdl
+++ b/test/wsdl/builtin_types.wsdl
@@ -47,6 +47,14 @@
       <xs:element name="unsignedShortElement" type="xs:unsignedShort" />
       <xs:element name="unsignedByteElement" type="xs:unsignedByte" />
       <xs:element name="stringElement" type="xs:string" />
+      <xs:element name="restrictedIntElement">
+          <xs:simpleType>
+              <xs:restriction base="xs:int">
+                  <xs:minInclusive value="0"/>
+                  <xs:maxInclusive value="99"/>
+              </xs:restriction>
+          </xs:simpleType>
+      </xs:element>
     </xs:schema>
   </wsdl:types>
 
@@ -106,6 +114,10 @@
     <wsdl:part name="nonPositiveInteger" element="tns:nonPositiveIntegerElement" />
     <wsdl:part name="body" element="tns:nonNegativeIntegerElement"/>
   </wsdl:message>
+  
+  <wsdl:message name="IntResponse">
+    <wsdl:part name="restrictedInteger" element="tns:restrictedIntElement" />
+  </wsdl:message>
 
   <wsdl:portType name="PortType">
     <wsdl:operation name="Operation">
@@ -115,6 +127,10 @@
     <wsdl:operation name="StringOperation">
       <wsdl:input message="tns:StringRequest"/>
       <wsdl:output message="tns:Response"/>
+    </wsdl:operation>
+    <wsdl:operation name="IntOperation">
+      <wsdl:input message="tns:Request"/>
+      <wsdl:output message="tns:IntResponse"/>
     </wsdl:operation>
   </wsdl:portType>
 
@@ -139,6 +155,16 @@
         <soap:body use="literal"/>
       </wsdl:output>
     </wsdl:operation>
+
+    <wsdl:operation name="IntOperation">
+      <soap:operation soapAction="http://www.BuiltinTypes.com/StringOperation" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
   </wsdl:binding>
 
   <wsdl:service name="Service">
@@ -147,4 +173,3 @@
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>
-


### PR DESCRIPTION
While using node-soap, I realized that the type of restricted simple types (as described, for instance, in the first example [here](https://www.w3schools.com/xml/schema_facets.asp)) is not correctly taken into account.

In wsdl.js:
- the description of a simple type was the concatenation of the simple type's name and its child's description, separated by a "|"
- the description of a restriction element was the concatenation of the restriction's name, a "|", then the list of comma-separated names of the restriction's children
It seems that this has been around for quite some time, but as far as I can see this is used nowhere else in the code base.

In the case of a "restricted integer" (as described in the previously mentioned example of w3schools), this unusual type description is incompatible with the logic of wsdl.js which, for instance, converts a field to an integer when needed (see wsdl.js:1428). As a result, this kind of fields are simply returned by node-soap as strings, while we could be already parsed into integers according to the schema definition.

This pull requests simplifies the description of `restriction` and `simpleType` elements, so that the previously mentioned example is correctly parsed as an integer. A test case is added to reproduce the issue and ensure that 

The second commit is just a formatting fix, so that `npm test` passes.