### PR TITLE
Option return a soap fault instead of stack/error on bad request

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -100,7 +100,9 @@ The `options` argument allows you to customize the client with the following pro
 
 - endpoint: to override the SOAP service's host specified in the `.wsdl` file.
 - envelopeKey: to set specific key instead of `<pre><<b>soap</b>:Body></<b>soap</b>:Body></pre>`.
-- escapeXML: escape special XML characters in SOAP message (e.g. `&`, `>`, `<` etc).
+- escapeXML: escape special XML characters in SOAP message (e.g. `&`, `>`, `<` etc), default: `true`.
+- suppressStack: suppress the full stack trace for error messages.
+- returnFault: return an `Invalid XML` SOAP fault on a bad request, default: `false`.
 - forceSoap12Headers: to set proper headers for SOAP v1.2.
 - httpClient: to provide your own http client that implements `request(rurl, data, callback, exheaders, exoptions)`.
 - request: to override the [request](https://github.com/request/request) module.

--- a/lib/server.js
+++ b/lib/server.js
@@ -38,6 +38,7 @@ var Server = function (server, path, services, wsdl, options) {
   this.services = services;
   this.wsdl = wsdl;
   this.suppressStack = options && options.suppressStack;
+  this.returnFault = options && options.returnFault;
 
   if (path[path.length - 1] !== '/')
     path += '/';

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1286,7 +1286,9 @@ WSDL.prototype.xmlToObject = function(xml, callback) {
           // 'cache' this alias to speed future lookups
           self.definitions.messages[originalName] = self.definitions.messages[name];
         } catch (e) {
-          if (self.options.returnFault) p.onerror(e);
+          if (self.options.returnFault) {
+            p.onerror(e);
+          }
         }
       }
 

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1107,6 +1107,11 @@ WSDL.prototype._initializeOptions = function (options) {
   } else {
     this.options.escapeXML = true;
   }
+  if (options.returnFault !== undefined) {
+    this.options.returnFault = options.returnFault;
+  } else {
+    this.options.returnFault = false;
+  }
   // Allow any request headers to keep passing through
   this.options.wsdl_headers = options.wsdl_headers;
   this.options.wsdl_options = options.wsdl_options;
@@ -1253,32 +1258,36 @@ WSDL.prototype.xmlToObject = function(xml, callback) {
       // Support RPC/literal messages where response body contains one element named
       // after the operation + 'Response'. See http://www.w3.org/TR/wsdl#_names
       if (!message) {
-        // Determine if this is request or response
-        var isInput = false;
-        var isOutput = false;
-        if ((/Response$/).test(name)) {
-          isOutput = true;
-          name = name.replace(/Response$/, '');
-        } else if ((/Request$/).test(name)) {
-          isInput = true;
-          name = name.replace(/Request$/, '');
-        } else if ((/Solicit$/).test(name)) {
-          isInput = true;
-          name = name.replace(/Solicit$/, '');
+        try {
+          // Determine if this is request or response
+          var isInput = false;
+          var isOutput = false;
+          if ((/Response$/).test(name)) {
+            isOutput = true;
+            name = name.replace(/Response$/, '');
+          } else if ((/Request$/).test(name)) {
+            isInput = true;
+            name = name.replace(/Request$/, '');
+          } else if ((/Solicit$/).test(name)) {
+            isInput = true;
+            name = name.replace(/Solicit$/, '');
+          }
+          // Look up the appropriate message as given in the portType's operations
+          var portTypes = self.definitions.portTypes;
+          var portTypeNames = Object.keys(portTypes);
+          // Currently this supports only one portType definition.
+          var portType = portTypes[portTypeNames[0]];
+          if (isInput) {
+            name = portType.methods[name].input.$name;
+          } else {
+            name = portType.methods[name].output.$name;
+          }
+          message = self.definitions.messages[name];
+          // 'cache' this alias to speed future lookups
+          self.definitions.messages[originalName] = self.definitions.messages[name];
+        } catch (e) {
+          if (self.options.returnFault) p.onerror(e);
         }
-        // Look up the appropriate message as given in the portType's operations
-        var portTypes = self.definitions.portTypes;
-        var portTypeNames = Object.keys(portTypes);
-        // Currently this supports only one portType definition.
-        var portType = portTypes[portTypeNames[0]];
-        if (isInput) {
-          name = portType.methods[name].input.$name;
-        } else {
-          name = portType.methods[name].output.$name;
-        }
-        message = self.definitions.messages[name];
-        // 'cache' this alias to speed future lookups
-        self.definitions.messages[originalName] = self.definitions.messages[name];
       }
 
       topSchema = message.description(self.definitions);

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -101,8 +101,8 @@ var fs = require('fs'),
         var xmlStr = '<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n\t<head>\n\t\t<title>404 - Not Found</title>\n\t</head>\n\t<body>\n\t\t<h1>404 - Not Found</h1>\n\t\t<script type="text/javascript" src="http://gp1.wpc.edgecastcdn.net/00222B/beluga/pilot_rtm/beluga_beacon.js"></script>\n\t</body>\n</html>';
         client.MyOperation({_xml: xmlStr}, function (err, result, raw, soapHeader) {
             assert.notEqual(raw.indexOf('html'), -1);
-          done();
-        });
+            done();
+          });
       });
     });
 
@@ -206,7 +206,7 @@ var fs = require('fs'),
       });
 
       
-     it('should have xml request modified', function (done) {
+      it('should have xml request modified', function (done) {
           soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function(err, client) {
               assert.ok(client);
               assert.ok(!err);
@@ -217,14 +217,14 @@ var fs = require('fs'),
                       assert.ok(client.lastResponseHeaders);
 
                       done();
-                  }, {
-                      postProcess: function(_xml) {
+                    }, {
+                  postProcess: function(_xml) {
                           return _xml.replace('soap', 'SOAP');
-                      }
-                  }
+                        }
+                }
               );
-          }, baseUrl);
-       });
+            }, baseUrl);
+        });
       
       it('should have the correct extra header in the request', function (done) {
         soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {

--- a/test/server-options-test.js
+++ b/test/server-options-test.js
@@ -290,4 +290,44 @@ describe('SOAP Server with Options', function() {
       );
     });
   });
+  
+  it('should return soap fault in server response', function(done) {
+    test.server.listen(15099, null, null, function() {
+      test.soapServer = soap.listen(test.server, {
+        path: '/stockquote',
+        services: test.service,
+        xml: test.wsdl,
+        uri: __dirname + '/wsdl/strict/',
+        escapeXML: false,
+        returnFault: true
+      }, test.service, test.wsdl);
+      test.baseUrl = 'http://' + test.server.address().address + ":" + test.server.address().port;
+
+      //windows return 0.0.0.0 as address and that is not
+      //valid to use in a request
+      if (test.server.address().address === '0.0.0.0' || test.server.address().address === '::') {
+        test.baseUrl = 'http://127.0.0.1:' + test.server.address().port;
+      }
+
+      request.post({
+        url: test.baseUrl + '/stockquote?wsdl',
+        body : '<soapenv:Envelope' +
+                    ' xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"' +
+                    ' xmlns:soap="http://service.applicationsnet.com/soap/">' +
+                '  <soapenv:Header/>' +
+                '  <soapenv:Body>' +
+                '    <soap:WrongTag/>' +
+                '  </soapenv:Body>' +
+                '</soapenv:Envelope>',
+        headers: {'Content-Type': 'text/xml'}
+      }, function(err, res, body) {
+        assert.ok(!err);
+        assert.equal(res.statusCode, 500);
+        assert.ok(body.match(/<faultcode>.*<\/faultcode>/g),
+          "Invalid XML");
+        done();
+      }
+      );
+    });
+  });
 });


### PR DESCRIPTION
In production, when a bad soap request is made, it should return a soap
fault and not a stack trace or text error message.

This change adds a WSDL option to return the fault, or continue to
return the stack trace or message.

A test case has been added to cover this new  functionality

also cleans up some jshint issues in test cases.