### PR TITLE
Adding promise based async to client creation and soap client with Bluebird Promise library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
   - 4.0
   - 6.9.4
   - 7.4.0
+  - node
 env:
   - CXX=g++-4.8
 addons:

--- a/Readme.md
+++ b/Readme.md
@@ -9,12 +9,13 @@ This module lets you connect to web services using SOAP.  It also provides a ser
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 
-- [Features](#features)
+- [Features:](#features)
 - [Install](#install)
 - [Why can't I file an issue?](#why-cant-i-file-an-issue)
 - [Where can I find help?](#where-can-i-find-help)
 - [Module](#module)
   - [soap.createClient(url[, options], callback) - create a new SOAP client from a WSDL url. Also supports a local filesystem path.](#soapcreateclienturl-options-callback---create-a-new-soap-client-from-a-wsdl-url-also-supports-a-local-filesystem-path)
+  - [soap.createClientAsync(url[, options]) - create a new SOAP client from a WSDL url. Also supports a local filesystem path.](#soapcreateclientasyncurl-options---create-a-new-soap-client-from-a-wsdl-url-also-supports-a-local-filesystem-path)
   - [soap.listen(*server*, *path*, *services*, *wsdl*) - create a new SOAP server that listens on *path* and provides *services*.](#soaplistenserver-path-services-wsdl---create-a-new-soap-server-that-listens-on-path-and-provides-services)
   - [Options](#options)
   - [Server Logging](#server-logging)
@@ -29,7 +30,9 @@ This module lets you connect to web services using SOAP.  It also provides a ser
   - [Client.describe() - description of services, ports and methods as a JavaScript object](#clientdescribe---description-of-services-ports-and-methods-as-a-javascript-object)
   - [Client.setSecurity(security) - use the specified security protocol](#clientsetsecuritysecurity---use-the-specified-security-protocol)
   - [Client.*method*(args, callback) - call *method* on the SOAP service.](#clientmethodargs-callback---call-method-on-the-soap-service)
+  - [Client.*method*Async(args) - call *method* on the SOAP service.](#clientmethodasyncargs---call-method-on-the-soap-service)
   - [Client.*service*.*port*.*method*(args, callback[, options[, extraHeaders]]) - call a *method* using a specific *service* and *port*](#clientserviceportmethodargs-callback-options-extraheaders---call-a-method-using-a-specific-service-and-port)
+  - [Overriding the namespace prefix](#overriding-the-namespace-prefix)
   - [Client.*lastRequest* - the property that contains last full soap request for client logging](#clientlastrequest---the-property-that-contains-last-full-soap-request-for-client-logging)
   - [Client.setEndpoint(url) - overwrite the SOAP service endpoint address](#clientsetendpointurl---overwrite-the-soap-service-endpoint-address)
   - [Client Events](#client-events)
@@ -40,7 +43,11 @@ This module lets you connect to web services using SOAP.  It also provides a ser
   - [WSSecurity](#wssecurity)
   - [WSSecurityCert](#wssecuritycert)
 - [Handling XML Attributes, Value and XML (wsdlOptions).](#handling-xml-attributes-value-and-xml-wsdloptions)
+  - [Overriding the `value` key](#overriding-the-value-key)
+  - [Overriding the `xml` key](#overriding-the-xml-key)
+  - [Overriding the `attributes` key](#overriding-the-attributes-key)
   - [Specifying the exact namespace definition of the root element](#specifying-the-exact-namespace-definition-of-the-root-element)
+  - [Custom Deserializer](#custom-deserializer)
 - [Handling "ignored" namespaces](#handling-ignored-namespaces)
 - [Handling "ignoreBaseNameSpaces" attribute](#handling-ignorebasenamespaces-attribute)
 - [soap-stub](#soap-stub)
@@ -92,6 +99,21 @@ If you're looking for professional help you can contact the maintainers through 
       });
   });
 ```
+This client has a built in WSDL cache. You can use the `disableCache` option to disable it.
+
+### soap.createClientAsync(url[, options]) - create a new SOAP client from a WSDL url. Also supports a local filesystem path.
+
+``` javascript
+  var soap = require('soap');
+  var url = 'http://example.com/wsdl?wsdl';
+  var args = {name: 'value'};
+  soap.createClientAsync(url).then((client) => {
+    return client.MyFunctionAsync(args);
+  }).then((result) => {
+    console.log(result);
+  });
+```
+
 This client has a built in WSDL cache. You can use the `disableCache` option to disable it.
 
 #### Options
@@ -374,7 +396,15 @@ An instance of `Client` is passed to the `soap.createClient` callback.  It is us
 
 The `args` argument allows you to supply arguments that generate an XML document inside of the SOAP Body section.
 
+### Client.*method*Async(args) - call *method* on the SOAP service.
 
+``` javascript
+  client.MyFunctionAsync({name: 'value'}).then((result) => {
+    // result is a javascript object
+  })
+```
+
+The `args` argument allows you to supply arguments that generate an XML document inside of the SOAP Body section.
 
 ##### Example with JSON for the `args`
 The example above uses `{name: 'value'}` as the args. This may generate a SOAP messages such as:

--- a/lib/client.js
+++ b/lib/client.js
@@ -14,6 +14,7 @@ var HttpClient = require('./http'),
   findPrefix = require('./utils').findPrefix,
   _ = require('lodash'),
   concatStream = require('concat-stream'),
+  Promise = require("bluebird"),
   uuid = require('uuid');
 
 var Client = function(wsdl, endpoint, options) {
@@ -23,6 +24,7 @@ var Client = function(wsdl, endpoint, options) {
   this._initializeOptions(options);
   this._initializeServices(endpoint);
   this.httpClient = options.httpClient || new HttpClient(options);
+  Promise.promisifyAll(this);
 };
 util.inherits(Client, events.EventEmitter);
 

--- a/lib/soap.js
+++ b/lib/soap.js
@@ -10,6 +10,7 @@ var Client = require('./client').Client,
   HttpClient = require('./http'),
   security = require('./security'),
   passwordDigest = require('./utils').passwordDigest,
+  Promise = require("bluebird"),
   wsdl = require('./wsdl'),
   WSDL = require('./wsdl').WSDL;
 
@@ -59,6 +60,20 @@ function createClient(url, options, callback, endpoint) {
   });
 }
 
+function createClientAsync(url, options, endpoint) {
+  if (typeof options === 'undefined') {
+    options = {};
+  }
+  return new Promise(function(resolve, reject) {
+    createClient(url, options, function(err, client) {
+      if (err) {
+        reject(err);
+      }
+      resolve(client);
+    }, endpoint);
+  });
+}
+
 function listen(server, pathOrOptions, services, xml) {
   var options = {},
     path = pathOrOptions,
@@ -84,6 +99,7 @@ exports.ClientSSLSecurity = security.ClientSSLSecurity;
 exports.ClientSSLSecurityPFX = security.ClientSSLSecurityPFX;
 exports.BearerSecurity = security.BearerSecurity;
 exports.createClient = createClient;
+exports.createClientAsync = createClientAsync;
 exports.passwordDigest = passwordDigest;
 exports.listen = listen;
 exports.WSDL = WSDL;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "author": "Vinay Pulim <v@pulim.com>",
   "dependencies": {
+    "bluebird": "^3.5.0",
     "compress": "^0.99.0",
     "concat-stream": "^1.5.1",
     "debug": "~0.7.4",


### PR DESCRIPTION
# Adding promise returning variants of soap client creation and function calls within client

I wanted to use promises to handle async functionality of client and added [Bluebird](http://bluebirdjs.com/docs/getting-started.html) Promises to `createClientAsync` and all client function calls. This helps to keep code clean in my mind.

With these changes its possible to use `.then()` and nodes new `async/await` functionality

## Examples

```javascript
function createSoapClientAndMakeApiCall () {
  var soap = require('soap');
  var url = 'http://example.com/wsdl?wsdl';
  var args = {name: 'value'};
  soap.createClientAsync(url).then((client) => {
    return client.MyFunctionAsync(args);
  }).then((result) => {
    console.log(result);
  });
}
```

```javascript
async function createSoapClientAndMakeApiCall () {
  var soap = require('soap');
  var url = 'http://example.com/wsdl?wsdl';
  var args = {name: 'value'};
  var client  = await soap.createClientAsync(url);
  var result = await MyFunctionAsync(args);
  console.log(result);
}
```

## Updated .travis.yml

For my testing I also added `node` for NodeJS environments
