### PR TITLE
Lookup definitions in child element first

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -2048,7 +2048,7 @@ WSDL.prototype.findChildSchemaObject = function(parameterTypeObj, childName, bac
       if (child.$base) {
         var baseQName = splitQName(child.$base);
         var childNameSpace = baseQName.prefix === TNS_PREFIX ? '' : baseQName.prefix;
-        childNsURI = this.definitions.xmlns[baseQName.prefix];
+        childNsURI = child.xmlns[baseQName.prefix] || this.definitions.xmlns[baseQName.prefix];
 
         var foundBase = this.findSchemaType(baseQName.name, childNsURI);
 

--- a/test/request-response-samples/RetrieveFareQuoteDateRange__should_handle_child_namespaces/childs/childxs0.wsdl
+++ b/test/request-response-samples/RetrieveFareQuoteDateRange__should_handle_child_namespaces/childs/childxs0.wsdl
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:tns="http://tempuri.org/">
+    <xs:element name="RetrieveFareQuoteDateRange">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="0" name="RetrieveFareQuoteDateRangeRequest" nillable="true" type="q5:RetrieveFareQuoteByDateRange"
+                    xmlns:q5="http://tempuri.org/Service/Pricing.Request.FareQuote" /></xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="RetrieveFareQuoteDateRangeResponse">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="0" name="RetrieveFareQuoteDateRangeResult" nillable="true" type="q6:ViewFareQuote" xmlns:q6="http://tempuri.org/Service/Pricing.Response"
+                /></xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/test/request-response-samples/RetrieveFareQuoteDateRange__should_handle_child_namespaces/childs/childxs3.wsdl
+++ b/test/request-response-samples/RetrieveFareQuoteDateRange__should_handle_child_namespaces/childs/childxs3.wsdl
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/Service/Request"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://tempuri.org/Service/Request">
+    <xs:complexType name="CarrierInfo">
+        <xs:sequence>
+            <xs:element name="CarrierCodes" nillable="true" type="tns:ArrayOfCarrierCode" /></xs:sequence>
+    </xs:complexType>
+    <xs:element name="CarrierInfo" nillable="true" type="tns:CarrierInfo" />
+    <xs:complexType name="ArrayOfCarrierCode">
+        <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="CarrierCode" nillable="true" type="tns:CarrierCode" /></xs:sequence>
+    </xs:complexType>
+    <xs:element name="ArrayOfCarrierCode" nillable="true" type="tns:ArrayOfCarrierCode" />
+    <xs:complexType name="CarrierCode">
+        <xs:sequence>
+            <xs:element name="AccessibleCarrierCode" nillable="true" type="xs:string" /></xs:sequence>
+    </xs:complexType>
+    <xs:element name="CarrierCode" nillable="true" type="tns:CarrierCode" />
+    <xs:simpleType name="Enumerations.CurrencyCodeTypes">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="ARS" />
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:element name="Enumerations.CurrencyCodeTypes" nillable="true" type="tns:Enumerations.CurrencyCodeTypes" />
+    <xs:complexType name="TransactionInfo">
+        <xs:sequence>
+            <xs:element name="CarrierCodes" nillable="true" type="tns:ArrayOfCarrierCode" />
+            <xs:element minOccurs="0" name="ClientIPAddress" nillable="true" type="xs:string" />
+            <xs:element minOccurs="0" name="HistoricUserName" nillable="true" type="xs:string" /></xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/test/request-response-samples/RetrieveFareQuoteDateRange__should_handle_child_namespaces/childs/childxs7.wsdl
+++ b/test/request-response-samples/RetrieveFareQuoteDateRange__should_handle_child_namespaces/childs/childxs7.wsdl
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/Service/Pricing.Request.FareQuote"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://tempuri.org/Service/Pricing.Request.FareQuote">
+    <xs:complexType name="RetrieveFareQuote">
+        <xs:complexContent mixed="false">
+            <xs:extension base="q1:TransactionInfo" xmlns:q1="http://tempuri.org/Service/Request">
+                <xs:sequence>
+                    <xs:element name="CurrencyOfFareQuote" type="q1:Enumerations.CurrencyCodeTypes" />
+                    <xs:element name="PromotionalCode" nillable="true" type="xs:string" />
+                    <xs:element name="IataNumberOfRequestor" nillable="true" type="xs:string" />
+                    <xs:element name="CorporationID" type="xs:int" />
+                    <xs:element name="FareFilterMethod" type="q2:Enums.FareFilterMethodType" xmlns:q2="http://tempuri.org/Service/Pricing.Request"
+                    />
+                    <xs:element name="FareGroupMethod" type="q3:Enums.FareGroupMethodType" xmlns:q3="http://tempuri.org/Service/Pricing.Request"
+                    />
+                    <xs:element name="InventoryFilterMethod" type="q4:Enums.InventoryFilterMethodType" xmlns:q4="http://tempuri.org/Service/Pricing.Request"
+                    />
+                    <xs:element name="FareQuoteDetails" nillable="true" type="tns:ArrayOfFareQuoteDetail" /></xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:element name="RetrieveFareQuote" nillable="true" type="tns:RetrieveFareQuote" />
+    <xs:complexType name="ArrayOfFareQuoteDetail">
+        <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="FareQuoteDetail" nillable="true" type="tns:FareQuoteDetail"
+            /></xs:sequence>
+    </xs:complexType>
+    <xs:element name="ArrayOfFareQuoteDetail" nillable="true" type="tns:ArrayOfFareQuoteDetail" />
+    <xs:complexType name="FareQuoteDetail">
+        <xs:sequence>
+            <xs:element name="Origin" nillable="true" type="xs:string" />
+            <xs:element name="Destination" nillable="true" type="xs:string" />
+            <xs:element name="UseAirportsNotMetroGroups" type="xs:boolean" />
+            <xs:element minOccurs="0" name="UseAirportsNotMetroGroupsAsRule" type="xs:boolean" />
+            <xs:element minOccurs="0" name="UseAirportsNotMetroGroupsForFrom" type="xs:boolean" />
+            <xs:element minOccurs="0" name="UseAirportsNotMetroGroupsForTo" type="xs:boolean" />
+            <xs:element name="DateOfDeparture" type="xs:dateTime" />
+            <xs:element name="FareTypeCategory" type="xs:int" />
+            <xs:element name="FareClass" nillable="true" type="xs:string" />
+            <xs:element name="FareBasisCode" nillable="true" type="xs:string" />
+            <xs:element name="Cabin" nillable="true" type="xs:string" />
+            <xs:element name="LFID" type="xs:int" />
+            <xs:element name="OperatingCarrierCode" nillable="true" type="xs:string" />
+            <xs:element name="MarketingCarrierCode" nillable="true" type="xs:string" />
+            <xs:element name="NumberOfDaysBefore" type="xs:int" />
+            <xs:element name="NumberOfDaysAfter" type="xs:int" />
+            <xs:element name="LanguageCode" nillable="true" type="xs:string" />
+            <xs:element name="TicketPackageID" nillable="true" type="xs:string" />
+            <xs:element name="FareQuoteRequestInfos" nillable="true" type="tns:ArrayOfFareQuoteRequestInfo" />
+            <xs:element minOccurs="0" name="OverrideEffectiveDate" type="xs:dateTime" /></xs:sequence>
+    </xs:complexType>
+    <xs:element name="FareQuoteDetail" nillable="true" type="tns:FareQuoteDetail" />
+    <xs:complexType name="ArrayOfFareQuoteRequestInfo">
+        <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="FareQuoteRequestInfo" nillable="true" type="tns:FareQuoteRequestInfo"
+            /></xs:sequence>
+    </xs:complexType>
+    <xs:element name="ArrayOfFareQuoteRequestInfo" nillable="true" type="tns:ArrayOfFareQuoteRequestInfo" />
+    <xs:complexType name="FareQuoteRequestInfo">
+        <xs:sequence>
+            <xs:element name="PassengerTypeID" type="xs:int" />
+            <xs:element name="TotalSeatsRequired" type="xs:int" /></xs:sequence>
+    </xs:complexType>
+    <xs:element name="FareQuoteRequestInfo" nillable="true" type="tns:FareQuoteRequestInfo" />
+    <xs:complexType name="RetrieveFareQuoteByDateRange">
+        <xs:complexContent mixed="false">
+            <xs:extension base="q5:TransactionInfo" xmlns:q5="http://tempuri.org/Service/Request">
+                <xs:sequence>
+                    <xs:element name="CurrencyOfFareQuote" nillable="true" type="xs:string" />
+                    <xs:element name="PromotionalCode" nillable="true" type="xs:string" />
+                    <xs:element name="IataNumberOfRequestor" nillable="true" type="xs:string" />
+                    <xs:element name="CorporationID" type="xs:int" />
+                    <xs:element name="FareFilterMethod" type="q6:Enums.FareFilterMethodType" xmlns:q6="http://tempuri.org/Service/Pricing.Request"
+                    />
+                    <xs:element name="FareGroupMethod" type="q7:Enums.FareGroupMethodType" xmlns:q7="http://tempuri.org/Service/Pricing.Request"
+                    />
+                    <xs:element name="InventoryFilterMethod" type="q8:Enums.InventoryFilterMethodType" xmlns:q8="http://tempuri.org/Service/Pricing.Request"
+                    />
+                    <xs:element name="FareQuoteDetails" nillable="true" type="tns:ArrayOfFareQuoteDetailDateRange" /></xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:element name="RetrieveFareQuoteByDateRange" nillable="true" type="tns:RetrieveFareQuoteByDateRange" />
+    <xs:complexType name="ArrayOfFareQuoteDetailDateRange">
+        <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="FareQuoteDetailDateRange" nillable="true" type="tns:FareQuoteDetailDateRange"
+            /></xs:sequence>
+    </xs:complexType>
+    <xs:element name="ArrayOfFareQuoteDetailDateRange" nillable="true" type="tns:ArrayOfFareQuoteDetailDateRange" />
+    <xs:complexType name="FareQuoteDetailDateRange">
+        <xs:sequence>
+            <xs:element name="Origin" nillable="true" type="xs:string" />
+            <xs:element name="Destination" nillable="true" type="xs:string" />
+            <xs:element name="UseAirportsNotMetroGroups" type="xs:boolean" />
+            <xs:element minOccurs="0" name="UseAirportsNotMetroGroupsAsRule" type="xs:boolean" />
+            <xs:element minOccurs="0" name="UseAirportsNotMetroGroupsForFrom" type="xs:boolean" />
+            <xs:element minOccurs="0" name="UseAirportsNotMetroGroupsForTo" type="xs:boolean" />
+            <xs:element name="DateOfDepartureStart" type="xs:dateTime" />
+            <xs:element name="DateOfDepartureEnd" type="xs:dateTime" />
+            <xs:element name="FareTypeCategory" type="xs:int" />
+            <xs:element name="FareClass" nillable="true" type="xs:string" />
+            <xs:element name="FareBasisCode" nillable="true" type="xs:string" />
+            <xs:element name="Cabin" nillable="true" type="xs:string" />
+            <xs:element name="LFID" type="xs:int" />
+            <xs:element name="OperatingCarrierCode" nillable="true" type="xs:string" />
+            <xs:element name="MarketingCarrierCode" nillable="true" type="xs:string" />
+            <xs:element name="LanguageCode" nillable="true" type="xs:string" />
+            <xs:element name="TicketPackageID" nillable="true" type="xs:string" />
+            <xs:element name="FareQuoteRequestInfos" nillable="true" type="tns:ArrayOfFareQuoteRequestInfo" />
+            <xs:element minOccurs="0" name="OverrideEffectiveDate" type="xs:dateTime" /></xs:sequence>
+    </xs:complexType>
+    <xs:element name="FareQuoteDetailDateRange" nillable="true" type="tns:FareQuoteDetailDateRange" />
+    <xs:complexType name="RetrieveSystemFareQuote">
+        <xs:complexContent mixed="false">
+            <xs:extension base="tns:RetrieveFareQuote">
+                <xs:sequence>
+                    <xs:element name="ReservationChannel" type="q9:Enumerations.ReservationChannelTypes" xmlns:q9="http://tempuri.org/Service/Request"
+                    /></xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:element name="RetrieveSystemFareQuote" nillable="true" type="tns:RetrieveSystemFareQuote" />
+    <xs:complexType name="RetrieveFareQuoteShop">
+        <xs:complexContent mixed="false">
+            <xs:extension base="q10:TransactionInfoNoSession" xmlns:q10="http://tempuri.org/Service/Request">
+                <xs:sequence>
+                    <xs:element name="CurrencyOfFareQuote" type="q10:Enumerations.CurrencyCodeTypes" />
+                    <xs:element name="PromotionalCode" nillable="true" type="xs:string" />
+                    <xs:element name="IataNumberOfRequestor" nillable="true" type="xs:string" />
+                    <xs:element name="CorporationID" type="xs:int" />
+                    <xs:element name="FareFilterMethod" type="q11:Enums.FareFilterMethodType" xmlns:q11="http://tempuri.org/Service/Pricing.Request"
+                    />
+                    <xs:element name="FareGroupMethod" type="q12:Enums.FareGroupMethodType" xmlns:q12="http://tempuri.org/Service/Pricing.Request"
+                    />
+                    <xs:element name="InventoryFilterMethod" type="q13:Enums.InventoryFilterMethodType" xmlns:q13="http://tempuri.org/Service/Pricing.Request"
+                    />
+                    <xs:element name="FareQuoteDetails" nillable="true" type="tns:ArrayOfFareQuoteDetail" /></xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:element name="RetrieveFareQuoteShop" nillable="true" type="tns:RetrieveFareQuoteShop" />
+    <xs:complexType name="RetrieveFareQuoteShopByDateRange">
+        <xs:complexContent mixed="false">
+            <xs:extension base="q14:TransactionInfoNoSession" xmlns:q14="http://tempuri.org/Service/Request">
+                <xs:sequence>
+                    <xs:element name="CurrencyOfFareQuote" nillable="true" type="xs:string" />
+                    <xs:element name="PromotionalCode" nillable="true" type="xs:string" />
+                    <xs:element name="IataNumberOfRequestor" nillable="true" type="xs:string" />
+                    <xs:element name="CorporationID" type="xs:int" />
+                    <xs:element name="FareFilterMethod" type="q15:Enums.FareFilterMethodType" xmlns:q15="http://tempuri.org/Service/Pricing.Request"
+                    />
+                    <xs:element name="FareGroupMethod" type="q16:Enums.FareGroupMethodType" xmlns:q16="http://tempuri.org/Service/Pricing.Request"
+                    />
+                    <xs:element name="InventoryFilterMethod" type="q17:Enums.InventoryFilterMethodType" xmlns:q17="http://tempuri.org/Service/Pricing.Request"
+                    />
+                    <xs:element name="FareQuoteDetails" nillable="true" type="tns:ArrayOfFareQuoteDetailDateRange" /></xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:element name="RetrieveFareQuoteShopByDateRange" nillable="true" type="tns:RetrieveFareQuoteShopByDateRange" /></xs:schema>

--- a/test/request-response-samples/RetrieveFareQuoteDateRange__should_handle_child_namespaces/childs/childxs9.wsdl
+++ b/test/request-response-samples/RetrieveFareQuoteDateRange__should_handle_child_namespaces/childs/childxs9.wsdl
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/Service/Bridge.Request"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://tempuri.org/Service/Bridge.Request">
+    <xs:import schemaLocation="../childs/childxs3.wsdl" namespace="http://tempuri.org/Service/Request"
+    />
+    <xs:complexType name="IataNumberInfo">
+        <xs:complexContent mixed="false">
+            <xs:extension base="q1:BaseFareChargeInfo" xmlns:q1="http://tempuri.org/Service/Request">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="IataNumber" nillable="true" type="xs:string" /></xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:element name="IataNumberInfo" nillable="true" type="tns:IataNumberInfo" /></xs:schema>

--- a/test/request-response-samples/RetrieveFareQuoteDateRange__should_handle_child_namespaces/request.json
+++ b/test/request-response-samples/RetrieveFareQuoteDateRange__should_handle_child_namespaces/request.json
@@ -1,0 +1,45 @@
+{
+  "RetrieveFareQuoteDateRangeRequest": {
+    "CarrierCodes": {
+      "CarrierCode": { "AccessibleCarrierCode": "DUMMY" }
+    },
+    "ClientIPAddress": "?",
+    "HistoricUserName": "?",
+    "CurrencyOfFareQuote": "ARS",
+    "PromotionalCode": null,
+    "IataNumberOfRequestor": null,
+    "CorporationID": 1,
+    "FareFilterMethod": "NoComb",
+    "FareGroupMethod": "FareType",
+    "InventoryFilterMethod": "Available",
+    "FareQuoteDetails": {
+      "FareQuoteDetailDateRange": [
+        {
+          "Origin": "A",
+          "Destination": "B",
+          "UseAirportsNotMetroGroups": "false",
+          "UseAirportsNotMetroGroupsAsRule": "false",
+          "UseAirportsNotMetroGroupsForFrom": "false",
+          "UseAirportsNotMetroGroupsForTo": "false",
+          "DateOfDepartureStart": "2017-10-27",
+          "DateOfDepartureEnd": "2017-10-27",
+          "FareTypeCategory": 1,
+          "FareClass": null,
+          "FareBasisCode": null,
+          "Cabin": null,
+          "LFID": 0,
+          "OperatingCarrierCode": null,
+          "MarketingCarrierCode": null,
+          "LanguageCode": "en",
+          "TicketPackageID": 1,
+          "FareQuoteRequestInfos": {
+            "FareQuoteRequestInfo": {
+              "PassengerTypeID": 1,
+              "TotalSeatsRequired": 1
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/request-response-samples/RetrieveFareQuoteDateRange__should_handle_child_namespaces/request.xml
+++ b/test/request-response-samples/RetrieveFareQuoteDateRange__should_handle_child_namespaces/request.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:tns="http://tempuri.org/"
+    xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract">
+    <soap:Body>
+        <RetrieveFareQuoteDateRange xmlns="http://tempuri.org/">
+            <RetrieveFareQuoteDateRangeRequest>
+                <ns1:CarrierCodes xmlns:ns1="http://tempuri.org/Service/Request">
+                    <ns1:CarrierCode>
+                        <ns1:AccessibleCarrierCode>DUMMY</ns1:AccessibleCarrierCode>
+                    </ns1:CarrierCode>
+                </ns1:CarrierCodes>
+                <ns1:ClientIPAddress xmlns:ns1="http://tempuri.org/Service/Request">?</ns1:ClientIPAddress>
+                <ns1:HistoricUserName xmlns:ns1="http://tempuri.org/Service/Request">?</ns1:HistoricUserName>
+                    <q5:CurrencyOfFareQuote xmlns:ns1="http://tempuri.org/Service/Request"
+                        xmlns:q5="http://tempuri.org/Service/Pricing.Request.FareQuote">ARS</q5:CurrencyOfFareQuote>
+                    <q5:PromotionalCode xmlns:ns1="http://tempuri.org/Service/Request"
+                        xmlns:q5="http://tempuri.org/Service/Pricing.Request.FareQuote" xsi:nil="true"></q5:PromotionalCode>
+                    <q5:IataNumberOfRequestor xmlns:ns1="http://tempuri.org/Service/Request"
+                        xmlns:q5="http://tempuri.org/Service/Pricing.Request.FareQuote" xsi:nil="true"></q5:IataNumberOfRequestor>
+                    <q5:CorporationID xmlns:ns1="http://tempuri.org/Service/Request"
+                        xmlns:q5="http://tempuri.org/Service/Pricing.Request.FareQuote">1</q5:CorporationID>
+                    <q5:FareFilterMethod xmlns:ns1="http://tempuri.org/Service/Request"
+                        xmlns:q5="http://tempuri.org/Service/Pricing.Request.FareQuote">NoComb</q5:FareFilterMethod>
+                    <q5:FareGroupMethod xmlns:ns1="http://tempuri.org/Service/Request"
+                        xmlns:q5="http://tempuri.org/Service/Pricing.Request.FareQuote">FareType</q5:FareGroupMethod>
+                    <q5:InventoryFilterMethod xmlns:ns1="http://tempuri.org/Service/Request"
+                        xmlns:q5="http://tempuri.org/Service/Pricing.Request.FareQuote">Available</q5:InventoryFilterMethod>
+                    <q5:FareQuoteDetails xmlns:ns1="http://tempuri.org/Service/Request"
+                        xmlns:q5="http://tempuri.org/Service/Pricing.Request.FareQuote">
+                        <q5:FareQuoteDetailDateRange>
+                            <q5:Origin>A</q5:Origin>
+                            <q5:Destination>B</q5:Destination>
+                            <q5:UseAirportsNotMetroGroups>false</q5:UseAirportsNotMetroGroups>
+                            <q5:UseAirportsNotMetroGroupsAsRule>false</q5:UseAirportsNotMetroGroupsAsRule>
+                            <q5:UseAirportsNotMetroGroupsForFrom>false</q5:UseAirportsNotMetroGroupsForFrom>
+                            <q5:UseAirportsNotMetroGroupsForTo>false</q5:UseAirportsNotMetroGroupsForTo>
+                            <q5:DateOfDepartureStart>2017-10-27</q5:DateOfDepartureStart>
+                            <q5:DateOfDepartureEnd>2017-10-27</q5:DateOfDepartureEnd>
+                            <q5:FareTypeCategory>1</q5:FareTypeCategory>
+                            <q5:FareClass xsi:nil="true"></q5:FareClass>
+                            <q5:FareBasisCode xsi:nil="true"></q5:FareBasisCode>
+                            <q5:Cabin xsi:nil="true"></q5:Cabin>
+                            <q5:LFID>0</q5:LFID>
+                            <q5:OperatingCarrierCode xsi:nil="true"></q5:OperatingCarrierCode>
+                            <q5:MarketingCarrierCode xsi:nil="true"></q5:MarketingCarrierCode>
+                            <q5:LanguageCode>en</q5:LanguageCode>
+                            <q5:TicketPackageID>1</q5:TicketPackageID>
+                            <q5:FareQuoteRequestInfos>
+                                <q5:FareQuoteRequestInfo>
+                                    <q5:PassengerTypeID>1</q5:PassengerTypeID>
+                                    <q5:TotalSeatsRequired>1</q5:TotalSeatsRequired>
+                                </q5:FareQuoteRequestInfo>
+                            </q5:FareQuoteRequestInfos>
+                        </q5:FareQuoteDetailDateRange>
+                    </q5:FareQuoteDetails>
+            </RetrieveFareQuoteDateRangeRequest>
+        </RetrieveFareQuoteDateRange>
+    </soap:Body>
+</soap:Envelope>

--- a/test/request-response-samples/RetrieveFareQuoteDateRange__should_handle_child_namespaces/response.json
+++ b/test/request-response-samples/RetrieveFareQuoteDateRange__should_handle_child_namespaces/response.json
@@ -1,0 +1,24 @@
+{
+    "RetrieveFareQuoteDateRangeResult": {
+        "CommissionIncluded": "false",
+        "Exceptions": {
+            "ExceptionInformation.Exception": {
+                "ExceptionCode": "0",
+                "ExceptionDescription": "Successful Transaction",
+                "ExceptionSource": "RetrieveFareQuoteDateRange",
+                "ExceptionLevel": "Success"
+            }
+        },
+        "FlightSegments": null,
+        "LegDetails": null,
+        "RequestedCorporationID": "0",
+        "RequestedCurrencyOfFareQuote": "ARS",
+        "RequestedFareFilterMethod": "102",
+        "RequestedGroupMethod": "0",
+        "RequestedIataNumber": null,
+        "RequestedInventoryFilterMethod": "0",
+        "RequestedReservationChannel": "8",
+        "SegmentDetails": null,
+        "TaxDetails": null
+    }
+}

--- a/test/request-response-samples/RetrieveFareQuoteDateRange__should_handle_child_namespaces/response.xml
+++ b/test/request-response-samples/RetrieveFareQuoteDateRange__should_handle_child_namespaces/response.xml
@@ -1,0 +1,30 @@
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+    <s:Body>
+        <RetrieveFareQuoteDateRangeResponse xmlns="http://tempuri.org/">
+            <RetrieveFareQuoteDateRangeResult xmlns:a="http://tempuri.org/Service/Pricing.Response"
+                xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+                <a:CommissionIncluded>false</a:CommissionIncluded>
+                <a:Exceptions xmlns:b="http://tempuri.org/Service/Exceptions">
+                    <b:ExceptionInformation.Exception>
+                        <b:ExceptionCode>0</b:ExceptionCode>
+                        <b:ExceptionDescription>Successful Transaction</b:ExceptionDescription>
+                        <b:ExceptionSource>RetrieveFareQuoteDateRange</b:ExceptionSource>
+                        <b:ExceptionLevel>Success</b:ExceptionLevel>
+                    </b:ExceptionInformation.Exception>
+                </a:Exceptions>
+                <a:FlightSegments/>
+                <a:LegDetails/>
+                <a:RequestedCorporationID>0</a:RequestedCorporationID>
+                <a:RequestedCurrencyOfFareQuote>ARS</a:RequestedCurrencyOfFareQuote>
+                <a:RequestedFareFilterMethod>102</a:RequestedFareFilterMethod>
+                <a:RequestedGroupMethod>0</a:RequestedGroupMethod>
+                <a:RequestedIataNumber/>
+                <a:RequestedInventoryFilterMethod>0</a:RequestedInventoryFilterMethod>
+                <a:RequestedPromotionalCode i:nil="true" />
+                <a:RequestedReservationChannel>8</a:RequestedReservationChannel>
+                <a:SegmentDetails/>
+                <a:TaxDetails/>
+            </RetrieveFareQuoteDateRangeResult>
+        </RetrieveFareQuoteDateRangeResponse>
+    </s:Body>
+</s:Envelope>

--- a/test/request-response-samples/RetrieveFareQuoteDateRange__should_handle_child_namespaces/soap.wsdl
+++ b/test/request-response-samples/RetrieveFareQuoteDateRange__should_handle_child_namespaces/soap.wsdl
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="Service" targetNamespace="http://tempuri.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
+    xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:tns="http://tempuri.org/"
+    xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy"
+    xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract"
+    xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata">
+	<wsdl:types>
+		<xsd:schema targetNamespace="http://tempuri.org/Imports">
+			<xsd:import schemaLocation="./childs/childxs0.wsdl" namespace="http://tempuri.org/" />
+			<xsd:import schemaLocation="./childs/childxs7.wsdl" namespace="http://tempuri.org/FareQuote" />
+			<xsd:import schemaLocation="./childs/childxs9.wsdl" namespace="http://tempuri.org/Request" /></xsd:schema>
+	</wsdl:types>
+	<wsdl:message name="Service_RetrieveFareQuoteDateRange_InputMessage">
+		<wsdl:part name="parameters" element="tns:RetrieveFareQuoteDateRange" /></wsdl:message>
+	<wsdl:message name="Service_RetrieveFareQuoteDateRange_OutputMessage">
+		<wsdl:part name="parameters" element="tns:RetrieveFareQuoteDateRangeResponse" /></wsdl:message>
+	<wsdl:portType name="Service">
+		<wsdl:operation name="RetrieveFareQuoteDateRange">
+			<wsdl:input wsaw:Action="http://tempuri.org/Service/RetrieveFareQuoteDateRange" message="tns:Service_RetrieveFareQuoteDateRange_InputMessage"
+			/>
+			<wsdl:output wsaw:Action="http://tempuri.org/Service/RetrieveFareQuoteDateRangeResponse" message="tns:Service_RetrieveFareQuoteDateRange_OutputMessage"
+			/></wsdl:operation>
+	</wsdl:portType>
+	<wsdl:binding name="BasicHttpBinding_Service" type="tns:Service">
+		<soap:binding transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="RetrieveFareQuoteDateRange">
+			<soap:operation soapAction="http://tempuri.org/Service/RetrieveFareQuoteDateRange" style="document" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:service name="Service">
+		<wsdl:port name="BasicHttpBinding_Service" binding="tns:BasicHttpBinding_Service">
+			<soap:address location="http://tempuri.org/Service.Pricing.svc" />
+		</wsdl:port>
+	</wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
I have this case where the `xmlns` definition is added as a `xmlns:{prefix}` attribute to the element and the _wsdl_ library wasn't able to find the Schema Object because It only looks into the global definitions.
Example of a not working xml schema:

```xml
  <xs:extension xmlns:q1="http://schemas.org/Request" base="q1:Info">
    <xs:sequence>
      <xs:element name="id" nillable="true" type="xs:string"/>
    </xs:sequence>
  </xs:extension>
```

This PR solves the issue describe above by looking the prefix in the child xmlns with a fallback to the `this.definitions.xmlns`.

I'm not sure if this this needs an specific unit test to being added, if so please let me know I'll try to add it.

