### PR TITLE
path.resolve cannot resolve a null path

### DIFF
--- a/lib/soap.js
+++ b/lib/soap.js
@@ -77,7 +77,7 @@ function createClientAsync(url, options, endpoint) {
 function listen(server, pathOrOptions, services, xml) {
   var options = {},
     path = pathOrOptions,
-    uri = null;
+    uri = "";
 
   if (typeof pathOrOptions === 'object') {
     options = pathOrOptions;


### PR DESCRIPTION
changed the uri from null to empty string due to the fact the path.resolve can't resolve a null path.