### PR TITLE
Allowing Bluebird suffix override

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -131,6 +131,7 @@ The `options` argument allows you to customize the client with the following pro
 - wsdl_headers: custom HTTP headers to be sent on WSDL requests.
 - wsdl_options: custom options for the request module on WSDL requests.
 - disableCache: don't cache WSDL files, request them every time.
+- overridePromiseSuffix: If your wsdl operations contains names with Async suffix, you will need to override the default promise suffix to a custom one, default: `Async`.
 
 Note: for versions of node >0.10.X, you may need to specify `{connection: 'keep-alive'}` in SOAP headers to avoid truncation of longer chunked responses.
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -24,7 +24,8 @@ var Client = function(wsdl, endpoint, options) {
   this._initializeOptions(options);
   this._initializeServices(endpoint);
   this.httpClient = options.httpClient || new HttpClient(options);
-  BluebirdPromise.promisifyAll(this);
+  var suffixOption = options.overridePromiseSuffix ? { suffix: options.overridePromiseSuffix } : null;
+  BluebirdPromise.promisifyAll(this, suffixOption);
 };
 util.inherits(Client, events.EventEmitter);
 

--- a/test/client-options-test.js
+++ b/test/client-options-test.js
@@ -14,7 +14,7 @@ describe('SOAP Client', function() {
     'overrideRootElement': {
       'namespace': 'tns'
     },
-    'overridePromiseSuffix': 'test',
+    'overridePromiseSuffix': 'Test',
     'request': 'customRequest'
   };
 
@@ -25,7 +25,7 @@ describe('SOAP Client', function() {
 
       assert.ok(client.wsdl.options.ignoredNamespaces[0] === 'ignoreThisNS');
       assert.ok(client.wsdl.options.overrideRootElement.namespace === 'tns');
-      assert.ok(typeof client.MyOperationtest === 'function');
+      assert.ok(typeof client.MyOperationTest === 'function');
       assert.ok(client.wsdl.options.request, "customRequest");
       done();
     });

--- a/test/client-options-test.js
+++ b/test/client-options-test.js
@@ -14,6 +14,7 @@ describe('SOAP Client', function() {
     'overrideRootElement': {
       'namespace': 'tns'
     },
+    'overridePromiseSuffix': 'test',
     'request': 'customRequest'
   };
 
@@ -24,6 +25,7 @@ describe('SOAP Client', function() {
 
       assert.ok(client.wsdl.options.ignoredNamespaces[0] === 'ignoreThisNS');
       assert.ok(client.wsdl.options.overrideRootElement.namespace === 'tns');
+      assert.ok(typeof client.MyOperationtest === 'function');
       assert.ok(client.wsdl.options.request, "customRequest");
       done();
     });


### PR DESCRIPTION
I have a use case, where the third party has functions with suffix 'Async' and it conflicts with BlueBird. Need to be able to override it.