### PR TITLE
allow http endpoints for client

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -2215,7 +2215,7 @@ function open_wsdl(uri, options, callback) {
   var request_options = options.wsdl_options;
 
   var wsdl;
-  if (!/^https?:/.test(uri)) {
+if (!/^(http?:|https?:)/.test(uri)) {                
     debug('Reading file: %s', uri);
     fs.readFile(uri, 'utf8', function(err, definition) {
       if (err) {

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var fs = require('fs'),
+  path = require('path'),
   soap = require('..'),
   http = require('http'),
   assert = require('assert'),
@@ -135,7 +136,6 @@ var fs = require('fs'),
         });
       });
     });
-
 
     describe('Headers in request and last response', function () {
       var server = null;
@@ -942,7 +942,7 @@ var fs = require('fs'),
         });
       });
     });
-    
+  
     describe('Client created with createClientAsync', function () {
       it('should error on invalid host', function (done) {
         soap.createClientAsync('http://localhost:1', meta.options)
@@ -1106,5 +1106,36 @@ var fs = require('fs'),
       });
 
     });
+    //
+    describe('wsdl available from an http endpoint', function () {
+      var server, port;
+      //
+      before(function (done) {
+           server = http.createServer(function (req, res) {
+            var rs;
+            try {
+              rs = fs.createReadStream(path.join(__dirname, '/wsdl/default_namespace.wsdl'));
+              res.statusCode = 200;
+              res.setHeader('content-type', 'text/xml; charset=utf-8');
+              rs.pipe(res);
+            }
+            catch (e) {
+              console.log('ERROR: ' + e.stack);
+            }
+        });
+        // take * host, and assigned port, should work fine and avoid EACCESS errors
+        server.listen(function (e) {
+            port = server.address().port;
+            done(e);
+        });
+      });
+      //
+      it('should allow a Client using an http endpoint for the wsdl', function(done) {
+          soap.createClient('http://localhost:' + port, function (err, client) {
+            done(err);
+          });
+      });
+    });
+
   });
 });


### PR DESCRIPTION
With a trivial one line change our shop can connect to http endoints.  Behind firewalls there are enterprise soap services just on http.  We could use self-signed certs but it's a hassle and the change is so minor why not allow it  ? 

I added a test case. 