### PR TITLE
EnvelopeKey not used in closing tag

### DIFF
--- a/lib/security/WSSecurityCert.js
+++ b/lib/security/WSSecurityCert.js
@@ -62,7 +62,7 @@ WSSecurityCert.prototype.postProcess = function (xml, envelopeKey) {
     id: this.x509Id
   });
 
-  var xmlWithSec = insertStr(secHeader, xml, xml.indexOf('</soap:Header>'));
+  var xmlWithSec = insertStr(secHeader, xml, xml.indexOf('</' + envelopeKey + ':Header>'));
 
   var references = ["http://www.w3.org/2000/09/xmldsig#enveloped-signature",
     "http://www.w3.org/2001/10/xml-exc-c14n#"];


### PR DESCRIPTION
EnvelopeKey variable is used in opening tag but no in closing tag header. 