### PR TITLE
Remove compress dependency

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -18,13 +18,13 @@ function getDateString(d) {
 }
 
 var url = require('url'),
-  compress = null,
+  zlib = null,
   events = require('events'),
   util = require('util'),
   findPrefix = require('./utils').findPrefix;
 
 try {
-  compress = require("compress");
+  zlib = require("zlib");
 } catch (error) {
 }
 
@@ -187,24 +187,19 @@ Server.prototype._requestListener = function (req, res) {
       return self._processRequestXml(req, res, req.body.toString());
     }
 
-    var chunks = [], gunzip;
-    if (compress && req.headers["content-encoding"] === "gzip") {
-      gunzip = new compress.Gunzip();
-      gunzip.init();
+    var chunks = [], gunzip, source = req;
+    if (req.headers["content-encoding"] === "gzip") {
+      gunzip = zlib.createGunzip();
+      req.pipe(gunzip);
+      source = gunzip;
     }
-    req.on('data', function (chunk) {
-      if (gunzip)
-        chunk = gunzip.inflate(chunk, "binary");
+    source.on('data', function (chunk) {
       chunks.push(chunk);
     });
-    req.on('end', function () {
+    source.on('end', function () {
       var xml = chunks.join('');
       var result;
       var error;
-      if (gunzip) {
-        gunzip.end();
-        gunzip = null;
-      }
       self._processRequestXml(req, res, xml);
     });
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "author": "Vinay Pulim <v@pulim.com>",
   "dependencies": {
     "bluebird": "^3.5.0",
-    "compress": "^0.99.0",
     "concat-stream": "^1.5.1",
     "debug": "^2.6.9",
     "ejs": "~2.5.5",

--- a/test/server-compress-test.js
+++ b/test/server-compress-test.js
@@ -1,0 +1,89 @@
+'use strict';
+
+var fs = require('fs');
+var soap = require('..');
+var assert = require('assert');
+
+var http = require('http');
+var zlib = require('zlib');
+
+var path = 'test/request-response-samples/DefaultNamespace__no_xmlns_prefix_used_for_default_namespace/';
+
+var wsdl = path + 'soap.wsdl'
+
+var xml = fs.readFileSync(path + '/soap.wsdl', 'utf8');
+var request = fs.readFileSync(path + '/request.xml', 'utf8');
+var json = fs.readFileSync(path + '/response.json', 'utf8');
+var response = fs.readFileSync(path + '/response.xml', 'utf8');
+
+
+var service = {
+  MyService: {
+    MyServicePort: {
+      DefaultNamespace: function (args) {
+        return JSON.parse(json);
+      }
+    }
+  }
+};
+
+describe('SOAP Server', function () {
+  it('should properly handle compression', function (done) {
+    //http server example
+    var server = http.createServer(function (req, res) {});
+    var clientResponse, gunzipResponse;
+    var count = 0;
+
+    var check = function (a, b) {
+      count += 1;
+
+      if (a && b) {
+        assert(a === b);
+      }
+
+      if (count === 2) {
+        done();
+      }
+    }
+
+    server.listen(8000);
+    soap.listen(server, '/wsdl', service, xml);
+
+    soap.createClient(wsdl, {
+      endpoint: 'http://localhost:8000/wsdl'
+    }, function (error, client) {
+      assert(!error);
+      client.DefaultNamespace({}, function (error, response) {
+        assert(!error);
+        clientResponse = client.lastResponse;
+        check(clientResponse, gunzipResponse);
+      });
+    });
+
+    var gzip = zlib.createGzip();
+
+    gzip.pipe(http.request({
+      host: 'localhost',
+      path: '/wsdl',
+      port: 8000,
+      method: 'POST',
+      headers: {
+        'content-type': 'text/xml; charset=utf-8',
+        'content-encoding': 'gzip',
+        'soapaction': '"DefaultNamespace"'
+      }
+    }, function (res) {
+      var body = '';
+      res.on('data', function (data) {
+        body += data;
+      });
+      res.on('end', function () {
+        gunzipResponse = body;
+        check(clientResponse, gunzipResponse);
+        server.close();
+      });
+    }));
+
+    gzip.end(request);
+  });
+});


### PR DESCRIPTION
Functionality of the compress dependency is available through the node `zlib` module. This pull request removes the `compress` dependency and replaces it with `zlib`.

The PR also adds a test for the server compression. This test consists of sending the same request twice, once through a soap client, once through a gzip stream. Afterwards both responses are checked for equality.

I based the test on an example from the `request-response-samples` folder. This might not be ideal, so feel free to suggest another wsdl file and example request that I can use.