### PR TITLE
Upgrade debug dependency to avoid possible security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "bluebird": "^3.5.0",
     "compress": "^0.99.0",
     "concat-stream": "^1.5.1",
-    "debug": "~0.7.4",
+    "debug": "^2.6.9",
     "ejs": "~2.5.5",
     "finalhandler": "^1.0.3",
     "lodash": "^3.10.1",


### PR DESCRIPTION
There's a ReDoS vulnerability in debug:

https://nodesecurity.io/advisories/534
https://github.com/visionmedia/debug/issues/501

This PR upgrades debug to 2.6.9 which has a fix:

https://github.com/visionmedia/debug/releases/tag/2.6.9

Tests pass successfully after upgrade