### PR TITLE
Allow agent reuse for ClientSSLSecurity if forever option is set

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -394,7 +394,7 @@ An instance of `Client` is passed to the `soap.createClient` callback.  It is us
 
 ### Client.setSecurity(security) - use the specified security protocol
 
-### Client.*method*(args, callback) - call *method* on the SOAP service.
+### Client.*method*(args, callback, options) - call *method* on the SOAP service.
 
 ``` javascript
   client.MyFunction({name: 'value'}, function(err, result, raw, soapHeader) {
@@ -405,6 +405,11 @@ An instance of `Client` is passed to the `soap.createClient` callback.  It is us
 ```
 
 The `args` argument allows you to supply arguments that generate an XML document inside of the SOAP Body section.
+
+The `options` object is optional and is passed to the `request`-module.
+Interesting properties might be:
+* `timeout`: Timeout in milliseconds
+* `forever`: Enables keep alive connections
 
 ### Client.*method*Async(args) - call *method* on the SOAP service.
 
@@ -589,6 +594,8 @@ as default request options to the constructor:
 * `strictSSL: false`
 * `secureOptions: constants.SSL_OP_NO_TLSv1_2` (this is likely needed for node >= 10.0)
 
+If you want to reuse tls sessions, you can use the option `forever: true`. 
+
 ``` javascript
 client.setSecurity(new soap.ClientSSLSecurity(
                 '/path/to/key',
@@ -600,6 +607,7 @@ client.setSecurity(new soap.ClientSSLSecurity(
                     // rejectUnauthorized: false,
                     // hostname: 'some-hostname'
                     // secureOptions: constants.SSL_OP_NO_TLSv1_2,
+                    // forever: true,
                 },
       ));
 ```

--- a/lib/security/ClientSSLSecurity.js
+++ b/lib/security/ClientSSLSecurity.js
@@ -48,6 +48,8 @@ function ClientSSLSecurity(key, cert, ca, defaults) {
 
   this.defaults = {};
   _.merge(this.defaults, defaults);
+
+  this.agent = null;
 }
 
 ClientSSLSecurity.prototype.toXML = function(headers) {
@@ -55,11 +57,26 @@ ClientSSLSecurity.prototype.toXML = function(headers) {
 };
 
 ClientSSLSecurity.prototype.addOptions = function(options) {
+  var httpsAgent = null;
+
   options.key = this.key;
   options.cert = this.cert;
   options.ca = this.ca;
   _.merge(options, this.defaults);
-  options.agent = new https.Agent(options);
+
+  if (!!options.forever) {
+    if (!this.agent) {
+      options.keepAlive = true;
+
+      this.agent = new https.Agent(options);
+    }
+
+    httpsAgent = this.agent;
+  } else {
+    httpsAgent = new https.Agent(options);
+  }
+
+  options.agent = httpsAgent;
 };
 
 module.exports = ClientSSLSecurity;

--- a/test/security/ClientSSLSecurity.js
+++ b/test/security/ClientSSLSecurity.js
@@ -49,4 +49,39 @@ describe('ClientSSLSecurity', function() {
     var instance = new ClientSSLSecurity(null, null, caList);
     instance.should.have.property("ca", caList);
   });
+
+  describe('forever parameter', function () {
+    it('should return different agents if parameter is not present', function () {
+      var instance = new ClientSSLSecurity();
+      var firstOptions = {};
+      var secondOptions = {};
+
+      instance.addOptions(firstOptions);
+      instance.addOptions(secondOptions);
+
+      firstOptions.agent.should.not.equal(secondOptions.agent);
+    });
+
+    it('should return the same agent if parameter is present', function () {
+      var instance = new ClientSSLSecurity();
+      var firstOptions = {forever: true};
+      var secondOptions = {forever: true};
+
+      instance.addOptions(firstOptions);
+      instance.addOptions(secondOptions);
+
+      firstOptions.agent.should.equal(secondOptions.agent);
+    });
+
+    it('should return the same agent if set in defaults', function () {
+      var instance = new ClientSSLSecurity(null, null, null, {forever: true});
+      var firstOptions = {};
+      var secondOptions = {};
+
+      instance.addOptions(firstOptions);
+      instance.addOptions(secondOptions);
+
+      firstOptions.agent.should.equal(secondOptions.agent);
+    });
+  });
 });


### PR DESCRIPTION
It should be possible for SSL connections to reuse the tls session. Every request, the https agent is recreated.

This PR changes this:
If the `forever` flag is set in the options per request (3rd parameter) or by default when setting the security (4th parameter), it should reuse the same agent as the previous requests also using `forever`.

The `request`-Module handles everything else, like setting the `keep-alive`-flag to the agent and the https module will cache the tls-session to the agent. Because of this, it is important that the same agent is used.

Tests added