### PR TITLE
Remove `selectn` dependency

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -18,7 +18,6 @@ var assert = require('assert').ok;
 var stripBom = require('strip-bom');
 var debug = require('debug')('node-soap');
 var _ = require('lodash');
-var selectn = require('selectn');
 var utils = require('./utils');
 var TNS_PREFIX = utils.TNS_PREFIX;
 var findPrefix = utils.findPrefix;
@@ -1507,10 +1506,16 @@ WSDL.prototype.xmlToObject = function(xml, callback) {
     if (root.Envelope) {
       var body = root.Envelope.Body;
       if (body && body.Fault) {
-        var code = selectn('faultcode.$value', body.Fault) || selectn('faultcode', body.Fault);
-        var string = selectn('faultstring.$value', body.Fault) || selectn('faultstring', body.Fault);
-        var detail = selectn('detail.$value', body.Fault) || selectn('detail.message', body.Fault);
+        var code = body.Fault.faultcode && body.Fault.faultcode.$value;
+        var string = body.Fault.faultstring && body.Fault.faultstring.$value;
+        var detail = body.Fault.detail && body.Fault.detail.$value;
+
+        code = code || body.Fault.faultcode;
+        string = string || body.Fault.faultstring;
+        detail = detail || body.Fault.detail;
+
         var error = new Error(code + ': ' + string + (detail ? ': ' + detail : ''));
+
         error.root = root;
         throw error;
       }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "lodash": "^3.10.1",
     "request": ">=2.9.0",
     "sax": ">=0.6",
-    "selectn": "^0.9.6",
     "serve-static": "^1.11.1",
     "strip-bom": "~0.3.1",
     "uuid": "^3.1.0",


### PR DESCRIPTION
Including its transitive dependencies, `selectn` introduces five new dependencies. However it is only being used in three lines of code and is easily replaceable.