### PR TITLE
Use assert.ifError function in tests

### DIFF
--- a/test/client-customHttp-test.js
+++ b/test/client-customHttp-test.js
@@ -100,7 +100,7 @@ it('should allow customization of httpClient and the wsdl file download should p
     {httpClient: httpCustomClient},
     function(err, client) {
       assert.ok(client);
-      assert.ok(!err);
+      assert.ifError(err);
       assert.equal(client.httpClient, httpCustomClient);
       var description = (client.describe());
       assert.deepEqual(client.describe(), {

--- a/test/client-customHttp-xsdinclude-test.js
+++ b/test/client-customHttp-xsdinclude-test.js
@@ -69,7 +69,7 @@ it('should allow customization of httpClient, the wsdl file, and associated data
     {httpClient: httpCustomClient},
     function(err, client) {
       assert.ok(client);
-      assert.ok(!err);
+      assert.ifError(err);
       assert.equal(client.httpClient, httpCustomClient);
       var description = (client.describe());
       assert.deepEqual(client.describe(), {

--- a/test/client-options-test.js
+++ b/test/client-options-test.js
@@ -21,7 +21,7 @@ describe('SOAP Client', function() {
   it('should set WSDL options to those specified in createClient', function(done) {
     soap.createClient(__dirname+'/wsdl/json_response.wsdl', options, function(err, client) {
       assert.ok(client);
-      assert.ok(!err);
+      assert.ifError(err);
 
       assert.ok(client.wsdl.options.ignoredNamespaces[0] === 'ignoreThisNS');
       assert.ok(client.wsdl.options.overrideRootElement.namespace === 'tns');

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -47,7 +47,7 @@ var fs = require('fs'),
       var called = false;
       soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {
         assert.ok(client);
-        assert.ok(!err);
+        assert.ifError(err);
         called = true;
         done();
       });
@@ -62,7 +62,7 @@ var fs = require('fs'),
         _.assign({ httpClient: myHttpClient }, meta.options),
         function (err, client) {
           assert.ok(client);
-          assert.ok(!err);
+          assert.ifError(err);
           assert.equal(client.httpClient, myHttpClient);
           done();
         });
@@ -75,7 +75,7 @@ var fs = require('fs'),
         _.assign({ request: myRequest }, meta.options),
         function (err, client) {
           assert.ok(client);
-          assert.ok(!err);
+          assert.ifError(err);
           assert.equal(client.httpClient._request, myRequest);
           done();
         });
@@ -85,7 +85,7 @@ var fs = require('fs'),
     it('should allow customization of envelope', function (done) {
       soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', _.assign({ envelopeKey: 'soapenv' }, meta.options), function (err, client) {
         assert.ok(client);
-        assert.ok(!err);
+        assert.ifError(err);
 
         client.MyOperation({}, function (err, result) {
           assert.notEqual(client.lastRequest.indexOf('xmlns:soapenv='), -1);
@@ -98,7 +98,7 @@ var fs = require('fs'),
     it('should allow passing in XML strings', function (done) {
       soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', _.assign({ envelopeKey: 'soapenv' }, meta.options), function (err, client) {
         assert.ok(client);
-        assert.ok(!err);
+        assert.ifError(err);
         
         var xmlStr = '<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n\t<head>\n\t\t<title>404 - Not Found</title>\n\t</head>\n\t<body>\n\t\t<h1>404 - Not Found</h1>\n\t\t<script type="text/javascript" src="http://gp1.wpc.edgecastcdn.net/00222B/beluga/pilot_rtm/beluga_beacon.js"></script>\n\t</body>\n</html>';
         client.MyOperation({_xml: xmlStr}, function (err, result, raw, soapHeader) {
@@ -112,7 +112,7 @@ var fs = require('fs'),
     it('should set binding style to "document" by default if not explicitly set in WSDL, per SOAP spec', function (done) {
       soap.createClient(__dirname + '/wsdl/binding_document.wsdl', meta.options, function (err, client) {
         assert.ok(client);
-        assert.ok(!err);
+        assert.ifError(err);
 
         assert.ok(client.wsdl.definitions.bindings.mySoapBinding.style === 'document');
         done();
@@ -163,7 +163,7 @@ var fs = require('fs'),
       it('should append `:' + port + '` to the Host header on for a request to a service on that port', function (done) {
         soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {
           assert.ok(client);
-          assert.ok(!err);
+          assert.ifError(err);
 
           client.MyOperation({}, function (err, result) {
             assert.notEqual(client.lastRequestHeaders.Host.indexOf(':' + port), -1);
@@ -176,7 +176,7 @@ var fs = require('fs'),
       it('should not append `:80` to the Host header on for a request to a service without a port explicitly defined', function (done) {
         soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {
           assert.ok(client);
-          assert.ok(!err);
+          assert.ifError(err);
 
           client.MyOperation({}, function (err, result) {
             assert.equal(client.lastRequestHeaders.Host.indexOf(':80'), -1);
@@ -189,7 +189,7 @@ var fs = require('fs'),
       it('should not append `:443` to the Host header if endpoints runs on `https`', function (done) {
         soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {
           assert.ok(client);
-          assert.ok(!err);
+          assert.ifError(err);
 
           client.MyOperation({}, function () {
             assert.equal(client.lastRequestHeaders.Host.indexOf(':443'), -1);
@@ -201,7 +201,7 @@ var fs = require('fs'),
       it('should append a port to the Host header if explicitly defined', function (done) {
         soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {
           assert.ok(client);
-          assert.ok(!err);
+          assert.ifError(err);
 
           client.MyOperation({}, function () {
             assert.ok(client.lastRequestHeaders.Host.indexOf(':443') > -1);
@@ -214,7 +214,7 @@ var fs = require('fs'),
       it('should have xml request modified', function (done) {
           soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function(err, client) {
               assert.ok(client);
-              assert.ok(!err);
+              assert.ifError(err);
 
               client.MyOperation({}, function(err, result) {
                       assert.ok(result);
@@ -234,7 +234,7 @@ var fs = require('fs'),
       it('should have the correct extra header in the request', function (done) {
         soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {
           assert.ok(client);
-          assert.ok(!err);
+          assert.ifError(err);
 
           client.MyOperation({}, function (err, result) {
             assert.ok(result);
@@ -249,7 +249,7 @@ var fs = require('fs'),
       it('should have the wrong extra header in the request', function (done) {
         soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {
           assert.ok(client);
-          assert.ok(!err);
+          assert.ifError(err);
 
           client.MyOperation({}, function (err, result) {
             assert.ok(result);
@@ -264,7 +264,7 @@ var fs = require('fs'),
       it('should have lastResponse and lastResponseHeaders after the call', function (done) {
         soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {
           assert.ok(client);
-          assert.ok(!err);
+          assert.ifError(err);
 
           client.MyOperation({}, function (err, result) {
             assert.ok(result);
@@ -279,7 +279,7 @@ var fs = require('fs'),
       it('should have lastElapsedTime after a call with the time option passed', function (done) {
         soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {
           assert.ok(client);
-          assert.ok(!err);
+          assert.ifError(err);
 
           client.MyOperation({}, function (err, result) {
             assert.ok(result);
@@ -295,7 +295,7 @@ var fs = require('fs'),
       it('should add http headers in method call options', function (done) {
         soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {
           assert.ok(client);
-          assert.ok(!err);
+          assert.ifError(err);
 
           client.MyOperation({}, function (err, result) {
             assert.ok(result);
@@ -310,11 +310,11 @@ var fs = require('fs'),
       it('should not return error in the call and return the json in body', function (done) {
         soap.createClient(__dirname + '/wsdl/json_response.wsdl', meta.options, function (err, client) {
           assert.ok(client);
-          assert.ok(!err);
+          assert.ifError(err);
 
           client.MyOperation({}, function (err, result, body) {
             assert.ok(result);
-            assert.ok(!err);
+            assert.ifError(err);
             assert.ok(body);
             done();
           }, null, { "test-header": 'test' });
@@ -324,7 +324,7 @@ var fs = require('fs'),
       it('should add proper headers for soap12', function (done) {
         soap.createClient(__dirname + '/wsdl/default_namespace_soap12.wsdl', _.assign({ forceSoap12Headers: true }, meta.options), function (err, client) {
           assert.ok(client);
-          assert.ok(!err);
+          assert.ifError(err);
 
           client.MyOperation({}, function (err, result) {
             assert.ok(result);
@@ -341,10 +341,10 @@ var fs = require('fs'),
       it('should allow calling the method with args, callback, options and extra headers', function (done) {
         soap.createClient(__dirname + '/wsdl/json_response.wsdl', meta.options, function (err, client) {
           assert.ok(client);
-          assert.ok(!err);
+          assert.ifError(err);
 
           client.MyOperation({}, function (err, result, body) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.ok(result);
             assert.ok(body.tempResponse === 'temp');
             assert.ok(client.lastResponseHeaders.status === 'pass');
@@ -358,10 +358,10 @@ var fs = require('fs'),
       it('should allow calling the method with only a callback', function (done) {
         soap.createClient(__dirname + '/wsdl/json_response.wsdl', meta.options, function (err, client) {
           assert.ok(client);
-          assert.ok(!err);
+          assert.ifError(err);
 
           client.MyOperation(function (err, result, body) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.ok(result);
             assert.ok(body.tempResponse === 'temp');
             assert.ok(client.lastResponseHeaders.status === 'fail');
@@ -374,10 +374,10 @@ var fs = require('fs'),
       it('should allow calling the method with args, options and callback last', function (done) {
         soap.createClient(__dirname + '/wsdl/json_response.wsdl', meta.options, function (err, client) {
           assert.ok(client);
-          assert.ok(!err);
+          assert.ifError(err);
 
           client.MyOperation({}, { headers: { 'options-test-header': 'test' } }, function (err, result, body) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.ok(result);
             assert.ok(body.tempResponse === 'temp');
             assert.ok(client.lastResponseHeaders.status === 'fail');
@@ -391,10 +391,10 @@ var fs = require('fs'),
       it('should allow calling the method with args, options, extra headers and callback last', function (done) {
         soap.createClient(__dirname + '/wsdl/json_response.wsdl', meta.options, function (err, client) {
           assert.ok(client);
-          assert.ok(!err);
+          assert.ifError(err);
 
           client.MyOperation({}, { headers: { 'options-test-header': 'test' } }, { 'test-header': 'test' }, function (err, result, body) {
-            assert.ok(!err);
+            assert.ifError(err);
             assert.ok(result);
             assert.ok(body.tempResponse === 'temp');
             assert.ok(client.lastResponseHeaders.status === 'pass');
@@ -800,7 +800,7 @@ var fs = require('fs'),
       }).listen(port, hostname, function () {
         soap.createClient(__dirname + '/wsdl/json_response.wsdl', meta.options, function (err, client) {
           assert.ok(client);
-          assert.ok(!err);
+          assert.ifError(err);
 
           client.MyOperation({}, function (err, result, body) {
             server.close();
@@ -829,12 +829,12 @@ var fs = require('fs'),
       }).listen(port, hostname, function () {
         soap.createClient(__dirname + '/wsdl/empty_body.wsdl', meta.options, function (err, client) {
           assert.ok(client);
-          assert.ok(!err);
+          assert.ifError(err);
 
           client.MyOperation({}, function (err, result, body, responseSoapHeaders) {
             server.close();
             server = null;
-            assert.ok(!err);
+            assert.ifError(err);
             assert.ok(!responseSoapHeaders);
             assert.ok(result);
             assert.ok(body);

--- a/test/server-options-test.js
+++ b/test/server-options-test.js
@@ -80,7 +80,7 @@ test.service = {
 describe('SOAP Server with Options', function() {
   before(function(done) {
     fs.readFile(__dirname + '/wsdl/strict/stockquote.wsdl', 'utf8', function(err, data) {
-      assert.ok(!err);
+      assert.ifError(err);
       test.wsdl = data;
       done();
     });
@@ -122,7 +122,7 @@ describe('SOAP Server with Options', function() {
       }
       // console.log(test.baseUrl);
       request(test.baseUrl, function(err, res, body) {
-        assert.ok(!err);
+        assert.ifError(err);
         console.log(body);
         done();
       });
@@ -148,7 +148,7 @@ describe('SOAP Server with Options', function() {
           'http://127.0.0.1:' + test.server.address().port;
       }
       request(test.baseUrl, function(err, res, body) {
-        assert.ok(!err);
+        assert.ifError(err);
         console.log(body);
         done();
       });
@@ -175,9 +175,9 @@ describe('SOAP Server with Options', function() {
       }
 
       soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
-        assert.ok(!err);
+        assert.ifError(err);
         client.GetLastTradePrice({ tickerSymbol: 'xml response' }, function(err, response, body) {
-          assert.ok(!err);
+          assert.ifError(err);
           assert.strictEqual(body, responseData);
           done();
         });
@@ -204,9 +204,9 @@ describe('SOAP Server with Options', function() {
       }
 
       soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
-        assert.ok(!err);
+        assert.ifError(err);
         client.GetLastTradePrice({ tickerSymbol: 'xml response' }, function(err, response, body) {
-          assert.ok(!err);
+          assert.ifError(err);
           assert.strictEqual(body, responseData);
           done();
         });
@@ -243,7 +243,7 @@ describe('SOAP Server with Options', function() {
                 '</soapenv:Envelope>',
         headers: {'Content-Type': 'text/xml'}
       }, function(err, res, body) {
-        assert.ok(!err);
+        assert.ifError(err);
         assert.equal(res.statusCode, 500);
         assert.ok(body.indexOf('\n    at') !== -1);
         done();
@@ -282,7 +282,7 @@ describe('SOAP Server with Options', function() {
                 '</soapenv:Envelope>',
         headers: {'Content-Type': 'text/xml'}
       }, function(err, res, body) {
-        assert.ok(!err);
+        assert.ifError(err);
         assert.equal(res.statusCode, 500);
         assert.equal(body.indexOf('\n    at'), -1);
         done();
@@ -321,7 +321,7 @@ describe('SOAP Server with Options', function() {
                 '</soapenv:Envelope>',
         headers: {'Content-Type': 'text/xml'}
       }, function(err, res, body) {
-        assert.ok(!err);
+        assert.ifError(err);
         assert.equal(res.statusCode, 500);
         assert.ok(body.match(/<faultcode>.*<\/faultcode>/g),
           "Invalid XML");

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -78,7 +78,7 @@ test.service = {
 describe('SOAP Server', function() {
   before(function(done) {
     fs.readFile(__dirname + '/wsdl/strict/stockquote.wsdl', 'utf8', function(err, data) {
-      assert.ok(!err);
+      assert.ifError(err);
       test.wsdl = data;
       done();
     });
@@ -168,14 +168,14 @@ describe('SOAP Server', function() {
 
   it('should be running', function(done) {
     request(test.baseUrl, function(err, res, body) {
-      assert.ok(!err);
+      assert.ifError(err);
       done();
     });
   });
 
   it('should 404 on non-WSDL path', function(done) {
     request(test.baseUrl, function(err, res, body) {
-      assert.ok(!err);
+      assert.ifError(err);
       assert.equal(res.statusCode, 404);
       done();
     });
@@ -194,7 +194,7 @@ describe('SOAP Server', function() {
                 '</soapenv:Envelope>',
         headers: {'Content-Type': 'text/xml'}
       }, function(err, res, body) {
-        assert.ok(!err);
+        assert.ifError(err);
         assert.equal(res.statusCode, 500);
         assert.ok(body.length);
         done();
@@ -208,7 +208,7 @@ describe('SOAP Server', function() {
         body : '',
         headers: {'Content-Type': undefined}
       }, function(err, res, body) {
-        assert.ok(!err);
+        assert.ifError(err);
         assert.equal(res.statusCode, 500);
         assert.ok(body.length);
         done();
@@ -227,7 +227,7 @@ describe('SOAP Server', function() {
                 '</soapenv:Envelope>',
         headers: {'Content-Type': 'text/xml'}
       }, function(err, res, body) {
-        assert.ok(!err);
+        assert.ifError(err);
         assert.equal(res.statusCode, 500);
         assert.ok(body.length);
         done();
@@ -237,7 +237,7 @@ describe('SOAP Server', function() {
 
   it('should server up WSDL', function(done) {
     request(test.baseUrl + '/stockquote?wsdl', function(err, res, body) {
-      assert.ok(!err);
+      assert.ifError(err);
       assert.equal(res.statusCode, 200);
       assert.ok(body.length);
       done();
@@ -246,7 +246,7 @@ describe('SOAP Server', function() {
 
   it('should return complete client description', function(done) {
     soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
-      assert.ok(!err);
+      assert.ifError(err);
       var description = client.describe(),
           expected = { input: { tickerSymbol: "string" }, output:{ price: "float" } };
       assert.deepEqual(expected , description.StockQuoteService.StockQuotePort.GetLastTradePrice);
@@ -256,9 +256,9 @@ describe('SOAP Server', function() {
 
   it('should return correct results', function(done) {
     soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
-      assert.ok(!err);
+      assert.ifError(err);
       client.GetLastTradePrice({ tickerSymbol: 'AAPL'}, function(err, result) {
-        assert.ok(!err);
+        assert.ifError(err);
         assert.equal(19.56, parseFloat(result.price));
         done();
       });
@@ -267,9 +267,9 @@ describe('SOAP Server', function() {
 
   it('should return correct async results (single argument callback style)', function(done) {
     soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
-      assert.ok(!err);
+      assert.ifError(err);
       client.GetLastTradePrice({ tickerSymbol: 'Async'}, function(err, result) {
-        assert.ok(!err);
+        assert.ifError(err);
         assert.equal(19.56, parseFloat(result.price));
         done();
       });
@@ -279,9 +279,9 @@ describe('SOAP Server', function() {
 
   it('should return correct async results (double argument callback style)', function(done) {
     soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
-      assert.ok(!err);
+      assert.ifError(err);
       client.IsValidPrice({ price: 50000 }, function(err, result) {
-        assert.ok(!err);
+        assert.ifError(err);
         assert.equal(true, !!(result.valid));
         done();
       });
@@ -290,7 +290,7 @@ describe('SOAP Server', function() {
 
   it('should pass the original req to async methods', function(done) {
     soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
-      assert.ok(!err);
+      assert.ifError(err);
       client.IsValidPrice({ price: 50000 }, function(err, result) {
         // node V3.x+ reports addresses as IPV6
         var addressParts = lastReqAddress.split(':');
@@ -302,7 +302,7 @@ describe('SOAP Server', function() {
 
   it('should return correct async errors', function(done) {
     soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
-      assert.ok(!err);
+      assert.ifError(err);
       client.IsValidPrice({ price: "invalid_price"}, function(err, result) {
         assert.ok(err);
         assert.ok(err.root.Envelope.Body.Fault);
@@ -314,10 +314,10 @@ describe('SOAP Server', function() {
 
   it('should handle headers in request', function(done) {
     soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
-      assert.ok(!err);
+      assert.ifError(err);
       client.addSoapHeader('<SomeToken>123.45</SomeToken>');
       client.GetLastTradePrice({ tickerSymbol: 'AAPL'}, function(err, result) {
-        assert.ok(!err);
+        assert.ifError(err);
         assert.equal(123.45, parseFloat(result.price));
         done();
       });
@@ -326,10 +326,10 @@ describe('SOAP Server', function() {
 
   it('should return security timestamp in response', function(done) {
     soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
-      assert.ok(!err);
+      assert.ifError(err);
       client.addSoapHeader('<Security><Timestamp><Created>2015-02-23T12:00:00.000Z</Created><Expires>2015-02-23T12:05:00.000Z</Expires></Timestamp></Security>');
       client.GetLastTradePrice({ tickerSymbol: 'AAPL'}, function(err, result, raw, soapHeader) {
-        assert.ok(!err);
+        assert.ifError(err);
         assert.ok(soapHeader && soapHeader.Security && soapHeader.Security.Timestamp);
         done();
       });
@@ -342,7 +342,7 @@ describe('SOAP Server', function() {
       done();
     });
     soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
-      assert.ok(!err);
+      assert.ifError(err);
       client.GetLastTradePrice({ tickerSymbol: 'AAPL'}, function() {});
     });
   });
@@ -353,10 +353,10 @@ describe('SOAP Server', function() {
       headers.SomeToken = 0;
     });
     soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
-      assert.ok(!err);
+      assert.ifError(err);
       client.addSoapHeader('<SomeToken>123.45</SomeToken>');
       client.GetLastTradePrice({ tickerSymbol: 'AAPL'}, function(err, result) {
-        assert.ok(!err);
+        assert.ifError(err);
         assert.equal(0, parseFloat(result.price));
         done();
       });
@@ -368,9 +368,9 @@ describe('SOAP Server', function() {
       assert.ok(false);
     });
     soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
-      assert.ok(!err);
+      assert.ifError(err);
       client.GetLastTradePrice({ tickerSymbol: 'AAPL'}, function(err, result) {
-        assert.ok(!err);
+        assert.ifError(err);
         done();
       });
     });
@@ -378,7 +378,7 @@ describe('SOAP Server', function() {
 
   it('should include response and body in error object', function(done) {
     soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
-      assert.ok(!err);
+      assert.ifError(err);
       client.GetLastTradePrice({ tickerSymbol: 'trigger error' }, function(err, response, body) {
         assert.ok(err);
         assert.strictEqual(err.response, response);
@@ -390,7 +390,7 @@ describe('SOAP Server', function() {
 
   it('should return SOAP Fault body for SOAP 1.2', function(done) {
     soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
-      assert.ok(!err);
+      assert.ifError(err);
       client.GetLastTradePrice({ tickerSymbol: 'SOAP Fault v1.2' }, function(err, response, body) {
         assert.ok(err);
         var fault = err.root.Envelope.Body.Fault;
@@ -410,7 +410,7 @@ describe('SOAP Server', function() {
 
   it('should return SOAP Fault body for SOAP 1.1', function(done) {
     soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
-      assert.ok(!err);
+      assert.ifError(err);
       client.GetLastTradePrice({ tickerSymbol: 'SOAP Fault v1.1' }, function(err, response, body) {
         assert.ok(err);
         var fault = err.root.Envelope.Body.Fault;
@@ -451,10 +451,10 @@ describe('SOAP Server', function() {
 
   it('should accept attributes as a string on the body element', function(done) {
     soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
-      assert.ok(!err);
+      assert.ifError(err);
       client.addBodyAttribute('xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="######################"');
       client.GetLastTradePrice({ tickerSymbol: 'AAPL' }, function(err, response, body) {
-        assert.ok(!err);
+        assert.ifError(err);
         done();
       });
     });
@@ -462,11 +462,11 @@ describe('SOAP Server', function() {
 
   it('should accept attributes as an object on the body element', function(done) {
     soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
-      assert.ok(!err);
+      assert.ifError(err);
       var attributes = { 'xmlns:wsu': 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd', 'wsu:Id': '######################' };
       client.addBodyAttribute(attributes);
       client.GetLastTradePrice({ tickerSymbol: 'AAPL' }, function(err, response, body) {
-        assert.ok(!err);
+        assert.ifError(err);
         done();
       });
     });
@@ -474,9 +474,9 @@ describe('SOAP Server', function() {
 
   it('should handle one-way operations', function(done) {
     soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
-      assert.ok(!err);
+      assert.ifError(err);
       client.SetTradePrice({ tickerSymbol: 'GOOG', price: 575.33 }, function(err, result) {
-        assert.ok(!err);
+        assert.ifError(err);
         assert.equal(result,null);
         done();
       });
@@ -487,7 +487,7 @@ describe('SOAP Server', function() {
 /*
 it('should return a valid error if the server stops responding': function(done) {
   soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
-    assert.ok(!err);
+    assert.ifError(err);
     server.close(function() {
       server = null;
       client.GetLastTradePrice({ tickerSymbol: 'trigger error' }, function(err, response, body) {

--- a/test/server-xsd-include-test.js
+++ b/test/server-xsd-include-test.js
@@ -27,7 +27,7 @@ test.service = {
 describe('SOAP Server(XSD include)', function () {
   before(function (done) {
     fs.readFile(__dirname + '/wsdl/strict/stockquote-url.wsdl', 'utf8', function (err, data) {
-      assert.ok(!err);
+      assert.ifError(err);
       test.wsdl = data;
       done();
     });
@@ -67,7 +67,7 @@ describe('SOAP Server(XSD include)', function () {
     var url = __dirname + '/wsdl/strict/stockquote-url.wsdl';
     
     soap.createClient(url, function (err, client) {
-      assert.ok(!err);
+      assert.ifError(err);
       assert.ok(client);
       done();
     });

--- a/test/ssl-test.js
+++ b/test/ssl-test.js
@@ -29,7 +29,7 @@ test.sslOptions = {
 describe('SOAP Client(SSL)', function() {
   before(function(done) {
     fs.readFile(__dirname + '/wsdl/strict/stockquote.wsdl', 'utf8', function(err, data) {
-      assert.ok(!err);
+      assert.ifError(err);
       test.wsdl = data;
       done();
     });
@@ -63,7 +63,7 @@ describe('SOAP Client(SSL)', function() {
 
   it('should connect to an SSL server', function(done) {
     soap.createClient(__dirname + '/wsdl/strict/stockquote.wsdl', function(err, client) {
-      assert.ok(!err);
+      assert.ifError(err);
       client.setEndpoint(test.baseUrl + '/stockquote');
       client.setSecurity({
         addOptions:function(options){
@@ -78,7 +78,7 @@ describe('SOAP Client(SSL)', function() {
       });
 
       client.GetLastTradePrice({ tickerSymbol: 'AAPL'}, function(err, result) {
-        assert.ok(!err);
+        assert.ifError(err);
         assert.equal(19.56, parseFloat(result.price));
         done();
       });

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -12,7 +12,7 @@ fs.readdirSync(__dirname+'/wsdl/strict').forEach(function(file) {
   if (!/.wsdl$/.exec(file)) return;
   wsdlStrictTests['should parse and describe '+file] = function(done) {
     soap.createClient(__dirname+'/wsdl/strict/'+file, {strict: true}, function(err, client) {
-      assert.ok(!err);
+      assert.ifError(err);
       client.describe();
       done();
     });
@@ -23,7 +23,7 @@ fs.readdirSync(__dirname+'/wsdl').forEach(function(file) {
   if (!/.wsdl$/.exec(file)) return;
   wsdlNonStrictTests['should parse and describe '+file] = function(done) {
     soap.createClient(__dirname+'/wsdl/'+file, function(err, client) {
-      assert.ok(!err);
+      assert.ifError(err);
       client.describe();
       done();
     });
@@ -53,7 +53,7 @@ wsdlStrictTests['should catch parse error'] = function(done) {
 
 wsdlStrictTests['should parse external wsdl'] = function(done) {
   soap.createClient(__dirname+'/wsdl/wsdlImport/main.wsdl', {strict: true}, function(err, client){
-    assert.ok(!err);
+    assert.ifError(err);
     assert.deepEqual(Object.keys(client.wsdl.definitions.schemas),
       ['http://example.com/', 'http://schemas.microsoft.com/2003/10/Serialization/Arrays']);
     assert.equal(typeof client.getLatestVersion, 'function');
@@ -63,7 +63,7 @@ wsdlStrictTests['should parse external wsdl'] = function(done) {
 
 wsdlStrictTests['should get the parent namespace when parent namespace is empty string'] = function(done) {
   soap.createClient(__dirname+'/wsdl/marketo.wsdl', {strict: true}, function(err, client){
-    assert.ok(!err);
+    assert.ifError(err);
     client.getLeadChanges({
         batchSize: 1,
         startPosition: {activityCreatedAt: '2014-04-14T22:03:48.587Z'},
@@ -77,7 +77,7 @@ wsdlStrictTests['should get the parent namespace when parent namespace is empty 
 wsdlStrictTests['should describe extended elements in correct order'] = function(done) {
   var expected = '{"DummyService":{"DummyPortType":{"Dummy":{"input":{"DummyRequest":{"DummyField1":"xs:string","DummyField2":"xs:string"},"ExtendedDummyField":"xs:string"},"output":{"DummyResult":"c:DummyResult"}}}}}';
   soap.createClient(__dirname+'/wsdl/extended_element.wsdl', function(err, client){
-    assert.ok(!err);
+    assert.ifError(err);
     assert.equal(JSON.stringify(client.describe()), expected);
     done();
   });
@@ -91,7 +91,7 @@ wsdlStrictTests['should handle element ref'] = function(done) {
     '<bar1:requestUID>001</bar1:requestUID></bar1:bankSvcRq>' +
     '</bar1:paymentRq></ns1:fooRq>';
   soap.createClient(__dirname + '/wsdl/elementref/foo.wsdl', {strict: true}, function(err, client) {
-    assert.ok(!err);
+    assert.ifError(err);
     client.fooOp({paymentRq: {bankSvcRq: {requestUID: '001'}}}, function(err, result) {
       assert.equal(client.lastMessage, expectedMsg);
       done();
@@ -103,7 +103,7 @@ wsdlStrictTests['should handle type ref'] = function(done) {
   var expectedMsg = require('./wsdl/typeref/request.xml.js');
   var reqJson = require('./wsdl/typeref/request.json');
   soap.createClient(__dirname + '/wsdl/typeref/order.wsdl', {strict: true}, function(err, client) {
-    assert.ok(!err);
+    assert.ifError(err);
     client.order(reqJson, function(err, result) {
       assert.equal(client.lastMessage, expectedMsg);
       done();
@@ -119,7 +119,7 @@ wsdlStrictTests['should parse POJO into xml without making unnecessary recursion
   soap.createClient(__dirname + '/wsdl/perf/order.wsdl', {strict: true}, function(err, client) {
     var i, spyCall;
 
-    assert.ok(!err);
+    assert.ifError(err);
     client.order(reqJson, function(err, result) {
       assert.equal(client.lastMessage, expectedMsg);
 
@@ -151,7 +151,7 @@ wsdlStrictTests['should get empty namespace prefix'] = function(done) {
   // var expectedMsg = 'gg';
 
   soap.createClient(__dirname + '/wsdl/elementref/foo.wsdl', {strict: true}, function(err, client) {
-    assert.ok(!err);
+    assert.ifError(err);
     client.fooOp({paymentRq: {bankSvcRq: {':requestUID': '001'}}}, function(err, result) {
       assert.equal(client.lastMessage, expectedMsg);
       done();
@@ -162,7 +162,7 @@ wsdlStrictTests['should get empty namespace prefix'] = function(done) {
 wsdlNonStrictTests['should load same namespace from included xsd'] = function(done) {
   var expected = '{"DummyService":{"DummyPortType":{"Dummy":{"input":{"ID":"IdType|xs:string|pattern","Name":"NameType|xs:string|minLength,maxLength"},"output":{"Result":"dummy:DummyList"}}}}}';
   soap.createClient(__dirname + '/wsdl/xsdinclude/xsd_include.wsdl', function(err, client) {
-    assert.ok(!err);
+    assert.ifError(err);
     assert.equal(JSON.stringify(client.describe()), expected);
     done();
   });


### PR DESCRIPTION
All instances of `assert.ok(!err)` were replaced with `assert.ifError(err);`,
which provides better output when errors are encountered during testruns.
The former would only output the less-than-useful message,
"Uncaught AssertionError [ERR_ASSERTION]: false == true", while the latter
would output the actual error object that caused the assert to fail.