### PR TITLE
Add function support for server addSoapHeader

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -352,7 +352,35 @@ They provide the following methods to manage the headers.
 
 #### *addSoapHeader*(soapHeader[, name, namespace, xmlns]) - add soapHeader to soap:Header node
 ##### Parameters
- - `soapHeader`     Object({rootName: {name: 'value'}}) or strict xml-string
+ - `soapHeader`     Object({rootName: {name: 'value'}}), strict xml-string,
+                    or function (server only)
+
+For servers only, `soapHeader` can be a function, which allows headers to be
+dynamically generated from information in the request. This function will be
+called with the following arguments for each received request:
+
+ - `methodName`     The name of the request method
+ - `args`           The arguments of the request
+ - `headers`        The headers in the request
+ - `req`            The original request object
+
+The return value of the function must be an Object({rootName: {name: 'value'}})
+or strict xml-string, which will be inserted as an outgoing header of the
+response to that request.
+
+For example:
+
+``` javascript
+  server = soap.listen(...);
+  server.addSoapHeader(function(methodName, args, headers, req) {
+    console.log('Adding headers for method', methodName);
+    return {
+      MyHeader1: args.SomeValueFromArgs,
+      MyHeader2: headers.SomeRequestHeader
+    };
+    // or you can return "<MyHeader1>SomeValue</MyHeader1>"
+  });
+```
 
 ##### Returns
 The index where the header is inserted.
@@ -365,7 +393,10 @@ The index where the header is inserted.
 #### *changeSoapHeader*(index, soapHeader[, name, namespace, xmlns]) - change an already existing soapHeader
 ##### Parameters
  - `index`          index of the header to replace with provided new value
- - `soapHeader`     Object({rootName: {name: 'value'}}) or strict xml-string
+ - `soapHeader`     Object({rootName: {name: 'value'}}), strict xml-string
+                    or function (server only)
+
+See `addSoapHeader` for how to pass a function into `soapHeader`.
 
 #### *getSoapHeaders*() - return all defined headers
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -83,13 +83,32 @@ var Server = function (server, path, services, wsdl, options) {
 };
 util.inherits(Server, events.EventEmitter);
 
+Server.prototype._processSoapHeader = function (soapHeader, name, namespace, xmlns) {
+  var self = this;
+
+  switch (typeof soapHeader) {
+  case 'object':
+    return this.wsdl.objectToXML(soapHeader, name, namespace, xmlns, true);
+  case 'function':
+    return function() {
+      var result = soapHeader.apply(null, arguments);
+
+      if (typeof result === 'object') {
+        return self.wsdl.objectToXML(result, name, namespace, xmlns, true);
+      } else {
+        return result;
+      }
+    };
+  default:
+    return soapHeader;
+  }
+};
+
 Server.prototype.addSoapHeader = function (soapHeader, name, namespace, xmlns) {
   if (!this.soapHeaders) {
     this.soapHeaders = [];
   }
-  if (typeof soapHeader === 'object') {
-    soapHeader = this.wsdl.objectToXML(soapHeader, name, namespace, xmlns, true);
-  }
+  soapHeader = this._processSoapHeader(soapHeader, name, namespace, xmlns);
   return this.soapHeaders.push(soapHeader) - 1;
 };
 
@@ -97,9 +116,7 @@ Server.prototype.changeSoapHeader = function (index, soapHeader, name, namespace
   if (!this.soapHeaders) {
     this.soapHeaders = [];
   }
-  if (typeof soapHeader === 'object') {
-    soapHeader = this.wsdl.objectToXML(soapHeader, name, namespace, xmlns, true);
-  }
+  soapHeader = this._processSoapHeader(soapHeader, name, namespace, xmlns);
   this.soapHeaders[index] = soapHeader;
 };
 
@@ -320,7 +337,7 @@ Server.prototype._process = function (input, req, callback) {
 Server.prototype._executeMethod = function (options, req, callback, includeTimestamp) {
   options = options || {};
   var self = this,
-    method, body,
+    method, body, headers,
     serviceName = options.serviceName,
     portName = options.portName,
     methodName = options.methodName,
@@ -329,10 +346,20 @@ Server.prototype._executeMethod = function (options, req, callback, includeTimes
     style = options.style,
     handled = false;
 
+  if (this.soapHeaders) {
+    headers = this.soapHeaders.map(function(header) {
+      if (typeof header === 'function') {
+        return header(methodName, args, options.headers, req);
+      } else {
+        return header;
+      }
+    }).join("\n");
+  }
+
   try {
     method = this.services[serviceName][portName][methodName];
   } catch (error) {
-    return callback(this._envelope('', includeTimestamp));
+    return callback(this._envelope('', headers, includeTimestamp));
   }
 
   function handleResult(error, result) {
@@ -354,7 +381,7 @@ Server.prototype._executeMethod = function (options, req, callback, includeTimes
       var element = self.wsdl.definitions.services[serviceName].ports[portName].binding.methods[methodName].output;
       body = self.wsdl.objectToDocumentXML(outputName, result, element.targetNSAlias, element.targetNamespace);
     }
-    callback(self._envelope(body, includeTimestamp));
+    callback(self._envelope(body, headers, includeTimestamp));
   }
 
   if (!self.wsdl.definitions.services[serviceName].ports[portName].binding.methods[methodName].output) {
@@ -369,7 +396,7 @@ Server.prototype._executeMethod = function (options, req, callback, includeTimes
   }
 };
 
-Server.prototype._envelope = function (body, includeTimestamp) {
+Server.prototype._envelope = function (body, headers, includeTimestamp) {
   var defs = this.wsdl.definitions,
     ns = defs.$targetNamespace,
     encoding = '',
@@ -378,7 +405,8 @@ Server.prototype._envelope = function (body, includeTimestamp) {
     "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" " +
     encoding +
     this.wsdl.xmlnsInEnvelope + '>';
-  var headers = '';
+
+  headers = headers || '';
 
   if (includeTimestamp) {
     var now = new Date();
@@ -393,10 +421,6 @@ Server.prototype._envelope = function (body, includeTimestamp) {
       "      <u:Expires>" + expires + "</u:Expires>" +
       "    </u:Timestamp>" +
       "  </o:Security>\n";
-  }
-
-  if (this.soapHeaders) {
-    headers += this.soapHeaders.join("\n");
   }
 
   if (headers !== '') {
@@ -433,7 +457,7 @@ Server.prototype._sendError = function (soapFault, callback, includeTimestamp) {
     fault = self.wsdl.objectToDocumentXML("Fault", soapFault, "soap");
   }
 
-  return callback(self._envelope(fault, includeTimestamp), statusCode);
+  return callback(self._envelope(fault, '', includeTimestamp), statusCode);
 };
 
 exports.Server = Server;


### PR DESCRIPTION
The purpose of this enhancement is to allow outgoing server headers to be
customized with information from the associated request. For servers only,
the `soapHeader` to addSoapHeader and changeSoapHeader can be a function,
which is called with the following arguments for each received request:

 - `methodName`     The name of the request method
 - `args`           The arguments of the request
 - `headers`        The headers in the request
 - `req`            The original request object

The return value of the function must be an Object({rootName: {name: 'value'}})
or strict xml-string, which will be inserted as an outgoing header of the
response to that request.