### PR TITLE
replace non identifier chars to underscore

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -132,7 +132,8 @@ The `options` argument allows you to customize the client with the following pro
 - wsdl_headers: custom HTTP headers to be sent on WSDL requests.
 - wsdl_options: custom options for the request module on WSDL requests.
 - disableCache: don't cache WSDL files, request them every time.
-- overridePromiseSuffix: If your wsdl operations contains names with Async suffix, you will need to override the default promise suffix to a custom one, default: `Async`.
+- overridePromiseSuffix: if your wsdl operations contains names with Async suffix, you will need to override the default promise suffix to a custom one, default: `Async`.
+- normalizeNames: if your wsdl operations contains names with non identifier characters (`[^a-z$_0-9]`), replace them with `_`. Note: if using this option, clients using wsdls with two operations like `soap:method` and `soap-method` will be overwritten. Then, use bracket notation instead (`client['soap:method']()`).
 
 Note: for versions of node >0.10.X, you may need to specify `{connection: 'keep-alive'}` in SOAP headers to avoid truncation of longer chunked responses.
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -17,6 +17,8 @@ var HttpClient = require('./http'),
   BluebirdPromise = require("bluebird"),
   uuid4 = require('uuid/v4');
 
+var nonIdentifierChars = /[^a-z$_0-9]/i;
+
 var Client = function(wsdl, endpoint, options) {
   events.EventEmitter.call(this);
   options = options || {};
@@ -151,7 +153,6 @@ Client.prototype._defineService = function(service, endpoint) {
   return def;
 };
 
-var nonIdentifierChars = /[^a-z$_0-9]/i;
 Client.prototype._definePort = function(port, endpoint) {
   var location = endpoint,
     binding = port.binding,

--- a/lib/client.js
+++ b/lib/client.js
@@ -126,6 +126,7 @@ Client.prototype._initializeServices = function(endpoint) {
 
 Client.prototype._initializeOptions = function(options) {
   this.streamAllowed = options.stream;
+  this.normalizeNames = options.normalizeNames;
   this.wsdl.options.attributesKey = options.attributesKey || 'attributes';
   this.wsdl.options.envelopeKey = options.envelopeKey || 'soap';
   this.wsdl.options.preserveWhitespace = !!options.preserveWhitespace;
@@ -160,8 +161,8 @@ Client.prototype._definePort = function(port, endpoint) {
     def = {};
   for (var name in methods) {
     def[name] = this._defineMethod(methods[name], location);
-    var normalizedName = name.replace(nonIdentifierChars, '_');
-    this[normalizedName] = def[name];
+    var methodName = this.normalizeNames ? name.replace(nonIdentifierChars, '_') : name;
+    this[methodName] = def[name];
   }
   return def;
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -151,6 +151,7 @@ Client.prototype._defineService = function(service, endpoint) {
   return def;
 };
 
+var nonIdentifierChars = /[^a-z$_0-9]/i;
 Client.prototype._definePort = function(port, endpoint) {
   var location = endpoint,
     binding = port.binding,
@@ -158,7 +159,8 @@ Client.prototype._definePort = function(port, endpoint) {
     def = {};
   for (var name in methods) {
     def[name] = this._defineMethod(methods[name], location);
-    this[name] = def[name];
+    var normalizedName = name.replace(nonIdentifierChars, '_');
+    this[normalizedName] = def[name];
   }
   return def;
 };

--- a/test/client-customHttp-test.js
+++ b/test/client-customHttp-test.js
@@ -91,7 +91,7 @@ it('should allow customization of httpClient and the wsdl file download should p
       });
     }
     //Now write the response with the wsdl
-    var state = httpResStream.write('HTTP/1.1 200 OK\r\nContent-Type: text/xml; charset=utf-8\r\nContent-Length: 1904\r\n\r\n'+wsdl);
+    var state = httpResStream.write('HTTP/1.1 200 OK\r\nContent-Type: text/xml; charset=utf-8\r\nContent-Length: 2497\r\n\r\n'+wsdl);
   });
 
   var httpCustomClient = new MyHttpClient({}, socketStream);
@@ -107,6 +107,12 @@ it('should allow customization of httpClient and the wsdl file download should p
         MyService: {
           MyServicePort: {
             MyOperation: {
+              input: {
+              },
+              output: {
+              }
+            },
+            'prefixed-MyOperation': {
               input: {
               },
               output: {

--- a/test/client-customHttp-test.js
+++ b/test/client-customHttp-test.js
@@ -91,7 +91,7 @@ it('should allow customization of httpClient and the wsdl file download should p
       });
     }
     //Now write the response with the wsdl
-    var state = httpResStream.write('HTTP/1.1 200 OK\r\nContent-Type: text/xml; charset=utf-8\r\nContent-Length: 2497\r\n\r\n'+wsdl);
+    var state = httpResStream.write('HTTP/1.1 200 OK\r\nContent-Type: text/xml; charset=utf-8\r\nContent-Length: 1904\r\n\r\n'+wsdl);
   });
 
   var httpCustomClient = new MyHttpClient({}, socketStream);
@@ -107,12 +107,6 @@ it('should allow customization of httpClient and the wsdl file download should p
         MyService: {
           MyServicePort: {
             MyOperation: {
-              input: {
-              },
-              output: {
-              }
-            },
-            'prefixed-MyOperation': {
               input: {
               },
               output: {

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -941,57 +941,6 @@ var fs = require('fs'),
           });
         });
       });
-
-      it('should create node-style method with normalized name (a valid Javascript identifier)', function (done) {
-        soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {
-          assert.ok(client);
-          assert.ifError(err);
-          client.prefixed_MyOperation({},function(err, result){
-              // only need to check that a valid request is generated, response isn't needed
-              assert.ok(client.lastRequest);
-              done();
-            });
-        });
-      });
-
-      it('should create node-style method with non-normalized name on Client.service.port.method style invocation', function (done) {
-        soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {
-          assert.ok(client);
-          assert.ifError(err);
-          /*jshint -W069 */
-          assert.throws(function(){client.MyService.MyServicePort['prefixed_MyOperation']({});},TypeError);
-          /*jshint +W069 */
-          client.MyService.MyServicePort['prefixed-MyOperation']({},function(err, result){
-            // only need to check that a valid request is generated, response isn't needed
-            assert.ok(client.lastRequest);
-            done();
-          });
-        });
-      });
-
-      it('should create promise-style method with normalized name (a valid Javascript identifier)', function (done) {
-        soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {
-          assert.ok(client);
-          assert.ifError(err);
-          client.prefixed_MyOperationAsync({})
-            .then(function(result){})
-            .catch(function(err){
-              // only need to check that a valid request is generated, response isn't needed
-              assert.ok(client.lastRequest);
-              done();
-            });
-        });
-      });
-
-      it('should not not create method with invalid Javascript identifier', function (done) {
-        soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {
-          assert.ok(client);
-          assert.ifError(err);
-          assert.throws(function() {client['prefixed-MyOperationAsync']({});}, TypeError);
-          assert.throws(function() {client['prefixed-MyOperation']({});}, TypeError);
-          done();
-        });
-      });
     });
     
     describe('Client created with createClientAsync', function () {
@@ -1156,6 +1105,81 @@ var fs = require('fs'),
         });
       });
 
+    });
+
+    describe('Client created with option normalizeNames', function(){
+
+      it('should create node-style method with normalized name (a valid Javascript identifier)', function (done) {
+        soap.createClient(__dirname + '/wsdl/non_identifier_chars_in_operation.wsdl', _.assign({ normalizeNames: true }, meta.options), function (err, client) {
+          assert.ok(client);
+          assert.ifError(err);
+          client.prefixed_MyOperation({},function(err, result){
+            // only need to check that a valid request is generated, response isn't needed
+            assert.ok(client.lastRequest);
+            done();
+          });
+        });
+      });
+
+      it('should create node-style method with non-normalized name on Client.service.port.method style invocation', function (done) {
+        soap.createClient(__dirname + '/wsdl/non_identifier_chars_in_operation.wsdl', meta.options, function (err, client) {
+          assert.ok(client);
+          assert.ifError(err);
+          /*jshint -W069 */
+          assert.throws(function(){client.MyService.MyServicePort['prefixed_MyOperation']({});},TypeError);
+          /*jshint +W069 */
+          client.MyService.MyServicePort['prefixed-MyOperation']({},function(err, result){
+            // only need to check that a valid request is generated, response isn't needed
+            assert.ok(client.lastRequest);
+            done();
+          });
+        });
+      });
+
+      it('should create promise-style method with normalized name (a valid Javascript identifier)', function (done) {
+        soap.createClient(__dirname + '/wsdl/non_identifier_chars_in_operation.wsdl', _.assign({ normalizeNames: true }, meta.options), function (err, client) {
+          assert.ok(client);
+          assert.ifError(err);
+          client.prefixed_MyOperationAsync({})
+            .then(function(result){})
+            .catch(function(err){
+              // only need to check that a valid request is generated, response isn't needed
+              assert.ok(client.lastRequest);
+              done();
+            });
+        });
+      });
+
+      it('should not create methods with invalid Javascript identifier', function (done) {
+        soap.createClient(__dirname + '/wsdl/non_identifier_chars_in_operation.wsdl', _.assign({ normalizeNames: true }, meta.options), function (err, client) {
+          assert.ok(client);
+          assert.ifError(err);
+          assert.throws(function() {client['prefixed-MyOperationAsync']({});}, TypeError);
+          assert.throws(function() {client['prefixed-MyOperation']({});}, TypeError);
+          done();
+        });
+      });
+
+      it('should create node-style method with invalid Javascript identifier if option normalizeNames is not used', function (done) {
+        soap.createClient(__dirname + '/wsdl/non_identifier_chars_in_operation.wsdl', meta.options, function (err, client) {
+          assert.ok(client);
+          assert.ifError(err);
+          client['prefixed-MyOperation']({}, function(err, result){
+            // only need to check that a valid request is generated, response isn't needed
+            assert.ok(client.lastRequest);
+            done();
+          });
+        });
+      });
+
+      it('does not create a promise-style method with invalid Javascript identifier if option normalizeNames is not used', function (done) {
+        soap.createClient(__dirname + '/wsdl/non_identifier_chars_in_operation.wsdl', meta.options, function (err, client) {
+          assert.ok(client);
+          assert.ifError(err);
+          assert.throws(function() {client['prefixed-MyOperationAsync']({});}, TypeError);
+          done();
+        });
+      });
     });
   });
 });

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -958,7 +958,9 @@ var fs = require('fs'),
         soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {
           assert.ok(client);
           assert.ifError(err);
+          /*jshint -W069 */
           assert.throws(function(){client.MyService.MyServicePort['prefixed_MyOperation']({});},TypeError);
+          /*jshint +W069 */
           client.MyService.MyServicePort['prefixed-MyOperation']({},function(err, result){
             // only need to check that a valid request is generated, response isn't needed
             assert.ok(client.lastRequest);
@@ -985,8 +987,8 @@ var fs = require('fs'),
         soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {
           assert.ok(client);
           assert.ifError(err);
-          assert.throws(function() {client['prefixed-MyOperationAsync']({})}, TypeError);
-          assert.throws(function() {client['prefixed-MyOperation']({})}, TypeError);
+          assert.throws(function() {client['prefixed-MyOperationAsync']({});}, TypeError);
+          assert.throws(function() {client['prefixed-MyOperation']({});}, TypeError);
           done();
         });
       });

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -941,6 +941,55 @@ var fs = require('fs'),
           });
         });
       });
+
+      it('should create node-style method with normalized name (a valid Javascript identifier)', function (done) {
+        soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {
+          assert.ok(client);
+          assert.ifError(err);
+          client.prefixed_MyOperation({},function(err, result){
+              // only need to check that a valid request is generated, response isn't needed
+              assert.ok(client.lastRequest);
+              done();
+            });
+        });
+      });
+
+      it('should create node-style method with non-normalized name on Client.service.port.method style invocation', function (done) {
+        soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {
+          assert.ok(client);
+          assert.ifError(err);
+          assert.throws(function(){client.MyService.MyServicePort['prefixed_MyOperation']({});},TypeError);
+          client.MyService.MyServicePort['prefixed-MyOperation']({},function(err, result){
+            // only need to check that a valid request is generated, response isn't needed
+            assert.ok(client.lastRequest);
+            done();
+          });
+        });
+      });
+
+      it('should create promise-style method with normalized name (a valid Javascript identifier)', function (done) {
+        soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {
+          assert.ok(client);
+          assert.ifError(err);
+          client.prefixed_MyOperationAsync({})
+            .then(function(result){})
+            .catch(function(err){
+              // only need to check that a valid request is generated, response isn't needed
+              assert.ok(client.lastRequest);
+              done();
+            });
+        });
+      });
+
+      it('should not not create method with invalid Javascript identifier', function (done) {
+        soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {
+          assert.ok(client);
+          assert.ifError(err);
+          assert.throws(function() {client['prefixed-MyOperationAsync']({})}, TypeError);
+          assert.throws(function() {client['prefixed-MyOperation']({})}, TypeError);
+          done();
+        });
+      });
     });
     
     describe('Client created with createClientAsync', function () {

--- a/test/server-compress-test.js
+++ b/test/server-compress-test.js
@@ -9,7 +9,7 @@ var zlib = require('zlib');
 
 var path = 'test/request-response-samples/DefaultNamespace__no_xmlns_prefix_used_for_default_namespace/';
 
-var wsdl = path + 'soap.wsdl'
+var wsdl = path + 'soap.wsdl';
 
 var xml = fs.readFileSync(path + '/soap.wsdl', 'utf8');
 var json = fs.readFileSync(path + '/request.json', 'utf8');
@@ -40,7 +40,7 @@ describe('SOAP Server', function () {
         assert(a === b);
         done();
       }
-    }
+    };
 
     server.listen(8000);
     soap.listen(server, '/wsdl', service, xml);

--- a/test/wsdl/default_namespace.wsdl
+++ b/test/wsdl/default_namespace.wsdl
@@ -24,12 +24,27 @@
       <wsdl:output message="OutputMessage">
     </wsdl:output>
     </wsdl:operation>
+    <wsdl:operation name="prefixed-MyOperation">
+      <wsdl:input message="InputMessage">
+      </wsdl:input>
+      <wsdl:output message="OutputMessage">
+      </wsdl:output>
+    </wsdl:operation>
   </wsdl:portType>
 
   <wsdl:binding name="MyServiceBinding" type="MyServicePortType">
     <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
     <wsdl:operation name="MyOperation">
       <soap:operation soapAction="MyOperation"/>
+      <wsdl:input>
+        <soap:body use="literal" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="prefixed-MyOperation">
+      <soap:operation soapAction="prefixed-MyOperation"/>
       <wsdl:input>
         <soap:body use="literal" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
       </wsdl:input>

--- a/test/wsdl/non_identifier_chars_in_operation.wsdl
+++ b/test/wsdl/non_identifier_chars_in_operation.wsdl
@@ -24,12 +24,27 @@
       <wsdl:output message="OutputMessage">
     </wsdl:output>
     </wsdl:operation>
+    <wsdl:operation name="prefixed-MyOperation">
+      <wsdl:input message="InputMessage">
+      </wsdl:input>
+      <wsdl:output message="OutputMessage">
+      </wsdl:output>
+    </wsdl:operation>
   </wsdl:portType>
 
   <wsdl:binding name="MyServiceBinding" type="MyServicePortType">
     <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
     <wsdl:operation name="MyOperation">
       <soap:operation soapAction="MyOperation"/>
+      <wsdl:input>
+        <soap:body use="literal" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="prefixed-MyOperation">
+      <soap:operation soapAction="prefixed-MyOperation"/>
       <wsdl:input>
         <soap:body use="literal" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
       </wsdl:input>


### PR DESCRIPTION
Hi vpulim, I have a wsdl with operation names like `prefix-methodname`. node-soap creates functions on the Client object with these names, but these can only be called like `client['prefix-methodname']()` instead of `client.prefix-methodname()`, because `-` is not allowed as identifier name in Javascript. While this works for node-style functions, this isn't working for Promise style functions. Bluebird doesn't promisify these invalid function names, so no `prefix-methodnameAsync` methods will be available.

I chose to change the invalid chars to `_` for both node-style and promise-style functions names. This is simpler and more explicit and consistent to the user than changing invalid characters only for promise-style functions.