### PR TITLE
Do not explicitly set Connection-Header.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -441,7 +441,7 @@ The `args` argument allows you to supply arguments that generate an XML document
 The `options` object is optional and is passed to the `request`-module.
 Interesting properties might be:
 * `timeout`: Timeout in milliseconds
-* `forever`: Enables keep alive connections
+* `forever`: Enables keep-alive connections and pools them
 
 ### Client.*method*Async(args) - call *method* on the SOAP service.
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -43,7 +43,7 @@ HttpClient.prototype.buildRequest = function(rurl, data, exheaders, exoptions) {
     'Accept': 'text/html,application/xhtml+xml,application/xml,text/xml;q=0.9,*/*;q=0.8',
     'Accept-Encoding': 'none',
     'Accept-Charset': 'utf-8',
-    'Connection': 'close',
+    'Connection': !!exoptions.forever ? 'keep-alive' : 'close',
     'Host': host + (isNaN(port) ? '' : ':' + port)
   };
   var attr;


### PR DESCRIPTION
This commit is a follow up  to #974 

The Connection-Header should not be explicitly set, because the core modules are handling them (see https://github.com/nodejs/node/blob/master/lib/_http_outgoing.js, everything connected to the `shouldKeepAlive` field).

This might be a breaking change, because connections are keep-alive by default (see https://github.com/nodejs/node/issues/10774) as long as there are running requests. The forever parameter, which sets the keep-alive flag for the agent, activates pooling (see https://github.com/nodejs/node/blob/2043944a4c62de60e7a04e8c914b565114c4b11b/lib/_http_agent.js#L78-L103), which offers a great performance gain on top.

I did not find a possibility to test this in node, because I've only got problems when connecting to SOAP-Servers written in another language, where every second request fails.