### PR TITLE
Fix "TypeError: Path must be a string. Received undefined" 

### DIFF
--- a/lib/soap.js
+++ b/lib/soap.js
@@ -84,7 +84,7 @@ function listen(server, pathOrOptions, services, xml) {
     path = options.path;
     services = options.services;
     xml = options.xml;
-    uri = options.uri;
+    uri = options.uri || '';
   }
 
   var wsdl = new WSDL(xml || services, uri, options);


### PR DESCRIPTION
When starting up soap listener with two arguments, being 1st the server and 2nd wsdloptions, with no `uri` property like:

```
soap.listen(server, { 
    path: '/path',
    services: services,
    xml: wsdl,         
    attributesKey: '$attrs',
    valueKey: '$value',
    xmlKey: '$xml'
 });
```

throws a type error:

> path.js:28
    throw new TypeError('Path must be a string. Received ' + inspect(path));
    ^
TypeError: Path must be a string. Received undefined