### PR TITLE
Fixed checking for empty obj.Body before further actions

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -389,16 +389,16 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
       return callback(null, null, body, obj.Header);
     }
 
+    // if Soap Body is empty
+    if (!obj.Body) {
+      return callback(null, obj, body, obj.Header);
+    }
+
     if( typeof obj.Body !== 'object' ) {
       var error = new Error('Cannot parse response');
       error.response = response;
       error.body = body;
       return callback(error, obj, body);
-    }
-
-    // if Soap Body is empty
-    if (!obj.Body) {
-      return callback(null, obj, body, obj.Header);
     }
 
     result = obj.Body[output.$name];


### PR DESCRIPTION
Moved check for empty obj.Body before further actions with it and before checking for type of obj.Body
It throws an error even if response was successfull, but without obj.Body.