### PR TITLE
Make `HttpClient#buildRequest` headers and options parameter mandatory

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -66,9 +66,7 @@ HttpClient.prototype.buildRequest = function(rurl, data, exheaders, exoptions) {
     followAllRedirects: true
   };
 
-
   options.body = data;
-
 
   for (attr in exoptions) {
     if (mergeOptions.indexOf(attr) !== -1) {

--- a/lib/http.js
+++ b/lib/http.js
@@ -55,7 +55,6 @@ HttpClient.prototype.buildRequest = function(rurl, data, exheaders, exoptions) {
     headers['Content-Type'] = 'application/x-www-form-urlencoded';
   }
 
-  exheaders = exheaders || {};
   for (attr in exheaders) {
     headers[attr] = exheaders[attr];
   }
@@ -71,7 +70,6 @@ HttpClient.prototype.buildRequest = function(rurl, data, exheaders, exoptions) {
   options.body = data;
 
 
-  exoptions = exoptions || {};
   for (attr in exoptions) {
     if (mergeOptions.indexOf(attr) !== -1) {
       for (header in exoptions[attr]) {

--- a/lib/soap.d.ts
+++ b/lib/soap.d.ts
@@ -159,7 +159,7 @@ export function listen(server: any, options: IServerOptions): Server;
 
 export class HttpClient {
     constructor(options?: IOptions);
-    buildRequest(rurl: string, data: any | string, exheaders?: { [key: string]: any }, exoptions?: { [key: string]: any }): any;
+    buildRequest(rurl: string, data: any | string, exheaders: { [key: string]: any }, exoptions: { [key: string]: any }): any;
     handleResponse(req: any, res: any, body: any | string): any | string;
     request(rurl: string, data: any | string, callback: (err: any, res: any, body: any | string) => void, exheaders?: { [key: string]: any }, exoptions?: { [key: string]: any }): any;
     requestStream(rurl: string, data: any | string, exheaders?: { [key: string]: any }, exoptions?: { [key: string]: any }): any;

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -2218,8 +2218,8 @@ function open_wsdl(uri, options, callback) {
 
   // initialize cache when calling open_wsdl directly
   var WSDL_CACHE = options.WSDL_CACHE || {};
-  var request_headers = options.wsdl_headers;
-  var request_options = options.wsdl_options;
+  var request_headers = options.wsdl_headers || {};
+  var request_options = options.wsdl_options || {};
 
   var wsdl;
   if (!/^https?:/.test(uri)) {


### PR DESCRIPTION
With #979 I sadly introduced a bug, because the two parameters are optional, despite the fact that they are not marked as such in the jsdoc comment.

This commit makes them mandatory and should fix the tests.