### PR TITLE
parse double and floats

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1450,6 +1450,8 @@ WSDL.prototype.xmlToObject = function(xml, callback) {
     else {
       if (name === 'int' || name === 'integer') {
         value = parseInt(text, 10);
+      } else if (name === 'double' || name === 'float') {
+        value = parseFloat(text);
       } else if (name === 'bool' || name === 'boolean') {
         value = text.toLowerCase() === 'true' || text === '1';
       } else if (name === 'dateTime' || name === 'date') {


### PR DESCRIPTION
When type is xs:double or xs:float we use parseFloat to convert it to javascript.

I'm unsure why this hasn't been done.
Maybe you have a good reason as to why you are not converting floats or doubles.
But since usually people want the data in their native form, I thought I'd suggest this atleast.

Tests:
There were 28 failing tests in master, so I was unable to write any tests.
I'd gladly write tests once master is passing again.