### PR TITLE
Namespace for referenced element was wrong.

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1824,7 +1824,7 @@ WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlns
               var resolvedChildSchemaObject;
               if (childSchemaObject.$type) {
                 var typeQName = splitQName(childSchemaObject.$type);
-                var typePrefix = typeQName.prefix;
+                var typePrefix = childSchemaObject.$baseNameSpace || typeQName.prefix;
                 var typeURI = schema.xmlns[typePrefix] || self.definitions.xmlns[typePrefix];
                 childNsURI = typeURI;
                 if (typeURI !== 'http://www.w3.org/2001/XMLSchema' && typePrefix !== TNS_PREFIX) {
@@ -2057,7 +2057,6 @@ WSDL.prototype.findChildSchemaObject = function(parameterTypeObj, childName, bac
 
           if (found) {
             found.$baseNameSpace = childNameSpace;
-            found.$type = childNameSpace + ':' + childName;
             break;
           }
         }

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1769,7 +1769,7 @@ WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlns
             //find sub namespace if not a primitive
             if (childSchemaObject &&
               ((childSchemaObject.$type && (childSchemaObject.$type.indexOf('xsd:') === -1)) ||
-                childSchemaObject.$ref || childSchemaObject.$name)) {
+                childSchemaObject.$ref || childSchemaObject.resolvedNameWithPrefix || childSchemaObject.$name)) {
               /*if the base name space of the children is not in the ingoredSchemaNamspaces we use it.
                This is because in some services the child nodes do not need the baseNameSpace.
                */
@@ -1779,7 +1779,7 @@ WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlns
               var childNsURI;
               var childXmlnsAttrib = '';
               
-              var elementQName = childSchemaObject.$ref || childSchemaObject.$name;
+              var elementQName = childSchemaObject.$ref || childSchemaObject.resolvedNameWithPrefix || childSchemaObject.$name;
               if (elementQName) {
                 elementQName = splitQName(elementQName);
                 childName = elementQName.name;
@@ -2018,7 +2018,7 @@ WSDL.prototype.findChildSchemaObject = function(parameterTypeObj, childName, bac
   var object = parameterTypeObj;
   if (object.$name === childName && object.name === 'element') {
     var objectInfo = splitQName(object.$name);
-    if (objectInfo.prefix === TNS_PREFIX) {
+    if (!object.resolvedNameWithPrefix && objectInfo.prefix === TNS_PREFIX) {
       for (var i = backtrace.length - 2; i >= 0; --i) {
         var current = backtrace[i];
   
@@ -2026,34 +2026,10 @@ WSDL.prototype.findChildSchemaObject = function(parameterTypeObj, childName, bac
           var currentInfo = splitQName(current.$type);
           if (currentInfo.prefix && currentInfo.prefix !== TNS_PREFIX) {
             // var prefix prefix = currentInfo.prefix;
-            object.$name = currentInfo.prefix + ":" + object.$name;
+            object.resolvedNameWithPrefix = currentInfo.prefix + ":" + object.$name;
             break;
           }
         }
-        //
-        // if (current.prefix && current.prefix !== TNS_PREFIX) {
-        //   object.prefix = current.prefix;
-        //   object.$name = object.prefix + ":" + object.$name;
-        //   break;
-        // }
-        //
-        // if (current.$name) {
-        //   var currentInfo = splitQName(current.$name);
-        //   if (currentInfo.prefix && currentInfo.prefix !== TNS_PREFIX) {
-        //     object.prefix = currentInfo.prefix;
-        //     object.$name = object.prefix + ":" + object.$name;
-        //     break;
-        //   }
-        // }
-		//
-        // if (current.$type) {
-        //   var typeInfo = splitQName(current.$type);
-        //   if (typeInfo.prefix && typeInfo.prefix !== TNS_PREFIX) {
-        //     object.prefix = typeInfo.prefix;
-        //     object.$name = object.prefix + ":" + object.$name;
-        //     break;
-        //   }
-        // }
       }
     }
     

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -61,7 +61,7 @@ var Primitives = {
 function splitQName(nsName) {
   var i = typeof nsName === 'string' ? nsName.indexOf(':') : -1;
   return i < 0 ? {prefix: TNS_PREFIX, name: nsName} :
-  {prefix: nsName.substring(0, i), name: nsName.substring(i + 1)};
+    {prefix: nsName.substring(0, i), name: nsName.substring(i + 1)};
 }
 
 function xmlEscape(obj) {
@@ -76,7 +76,7 @@ function xmlEscape(obj) {
       .replace(/"/g, '&quot;')
       .replace(/'/g, '&apos;');
   }
-
+  
   return obj;
 }
 
@@ -89,21 +89,21 @@ function trim(text) {
 
 function deepMerge(destination, source) {
   return _.merge(destination || {}, source, function(a, b) {
-      return _.isArray(a) ? a.concat(b) : undefined;
-    });
+    return _.isArray(a) ? a.concat(b) : undefined;
+  });
 }
 
 var Element = function(nsName, attrs, options) {
   var parts = splitQName(nsName);
-
+  
   this.nsName = nsName;
   this.prefix = parts.prefix;
   this.name = parts.name;
   this.children = [];
   this.xmlns = {};
-
+  
   this._initializeOptions(options);
-
+  
   for (var key in attrs) {
     var match = /^xmlns:?(.*)$/.exec(key);
     if (match) {
@@ -149,17 +149,17 @@ Element.prototype.startElement = function(stack, nsName, attrs, options) {
   if (!this.allowedChildren) {
     return;
   }
-
+  
   var ChildClass = this.allowedChildren[splitQName(nsName).name],
     element = null;
-
+  
   if (ChildClass) {
     stack.push(new ChildClass(nsName, attrs, options));
   }
   else {
     this.unexpected(nsName);
   }
-
+  
 };
 
 Element.prototype.endElement = function(stack, nsName) {
@@ -239,14 +239,14 @@ var ElementTypeMap = {
   restriction: [RestrictionElement, 'enumeration all choice sequence'],
   extension: [ExtensionElement, 'all sequence choice'],
   choice: [ChoiceElement, 'element sequence choice any'],
-    // group: [GroupElement, 'element group'],
+  // group: [GroupElement, 'element group'],
   enumeration: [EnumerationElement, ''],
   complexType: [ComplexTypeElement,  'annotation sequence all complexContent simpleContent choice'],
   complexContent: [ComplexContentElement,  'extension'],
   simpleContent: [SimpleContentElement,  'extension'],
   sequence: [SequenceElement, 'element sequence choice any'],
   all: [AllElement, 'element choice'],
-
+  
   service: [ServiceElement, 'port documentation'],
   port: [PortElement, 'address documentation'],
   binding: [BindingElement, '_binding SecuritySpec operation documentation'],
@@ -368,9 +368,9 @@ SchemaElement.prototype.addChild = function(child) {
 //fix#325
 TypesElement.prototype.addChild = function (child) {
   assert(child instanceof SchemaElement);
-
+  
   var targetNamespace = child.$targetNamespace;
-
+  
   if(!this.schemas.hasOwnProperty(targetNamespace)) {
     this.schemas[targetNamespace] = child;
   } else {
@@ -457,24 +457,24 @@ MessageElement.prototype.postProcess = function(definitions) {
   var nsName;
   var i;
   var type;
-
+  
   for (i in children) {
     if ((child = children[i]).name === 'part') {
       part = child;
       break;
     }
   }
-
+  
   if (!part) {
     return;
   }
-
+  
   if (part.$element) {
     var lookupTypes = [],
-        elementChildren ;
-
+      elementChildren ;
+    
     delete this.parts;
-
+    
     nsName = splitQName(part.$element);
     ns = nsName.prefix;
     var schema = definitions.schemas[definitions.xmlns[ns]];
@@ -485,52 +485,52 @@ MessageElement.prototype.postProcess = function(definitions) {
     }
     this.element.targetNSAlias = ns;
     this.element.targetNamespace = definitions.xmlns[ns];
-
+    
     // set the optional $lookupType to be used within `client#_invoke()` when
     // calling `wsdl#objectToDocumentXML()
     this.element.$lookupType = part.$element;
-
+    
     elementChildren = this.element.children;
-
+    
     // get all nested lookup types (only complex types are followed)
     if (elementChildren.length > 0) {
       for (i = 0; i < elementChildren.length; i++) {
         lookupTypes.push(this._getNestedLookupTypeString(elementChildren[i]));
       }
     }
-
+    
     // if nested lookup types where found, prepare them for furter usage
     if (lookupTypes.length > 0) {
       lookupTypes = lookupTypes.
-          join('_').
-          split('_').
-          filter(function removeEmptyLookupTypes (type) {
-            return type !== '^';
-          });
-
+                               join('_').
+                               split('_').
+                               filter(function removeEmptyLookupTypes (type) {
+        return type !== '^';
+      });
+      
       var schemaXmlns = definitions.schemas[this.element.targetNamespace].xmlns;
-
+      
       for (i = 0; i < lookupTypes.length; i++) {
         lookupTypes[i] = this._createLookupTypeObject(lookupTypes[i], schemaXmlns);
       }
     }
-
+    
     this.element.$lookupTypes = lookupTypes;
-
+    
     if (this.element.$type) {
       type = splitQName(this.element.$type);
       var typeNs = schema.xmlns && schema.xmlns[type.prefix] || definitions.xmlns[type.prefix];
-
+      
       if (typeNs) {
         if (type.name in Primitives) {
-            // this.element = this.element.$type;
+          // this.element = this.element.$type;
         }
         else {
           // first check local mapping of ns alias to namespace
           schema = definitions.schemas[typeNs];
           var ctype = schema.complexTypes[type.name] || schema.types[type.name] || schema.elements[type.name];
-
-
+          
+          
           if (ctype) {
             this.parts = ctype.description(definitions, schema.xmlns);
           }
@@ -541,8 +541,8 @@ MessageElement.prototype.postProcess = function(definitions) {
       var method = this.element.description(definitions, schema.xmlns);
       this.parts = method[nsName.name];
     }
-
-
+    
+    
     this.children.splice(0, 1);
   } else {
     // rpc encoding
@@ -563,12 +563,12 @@ MessageElement.prototype.postProcess = function(definitions) {
       } else {
         this.parts[part.$name] = part.$type;
       }
-
+      
       if (typeof this.parts[part.$name] === 'object') {
         this.parts[part.$name].prefix = nsName.prefix;
         this.parts[part.$name].xmlns = ns;
       }
-
+      
       this.children.splice(i--, 1);
     }
   }
@@ -588,16 +588,16 @@ MessageElement.prototype.postProcess = function(definitions) {
  */
 MessageElement.prototype._createLookupTypeObject = function (nsString, xmlns) {
   var splittedNSString = splitQName(nsString),
-      nsAlias = splittedNSString.prefix,
-      splittedName = splittedNSString.name.split('#'),
-      type = splittedName[0],
-      name = splittedName[1],
-      lookupTypeObj = {};
-
+    nsAlias = splittedNSString.prefix,
+    splittedName = splittedNSString.name.split('#'),
+    type = splittedName[0],
+    name = splittedName[1],
+    lookupTypeObj = {};
+  
   lookupTypeObj.$namespace = xmlns[nsAlias];
   lookupTypeObj.$type = nsAlias + ':' + type;
   lookupTypeObj.$name = name;
-
+  
   return lookupTypeObj;
 };
 
@@ -613,26 +613,26 @@ MessageElement.prototype._createLookupTypeObject = function (nsString, xmlns) {
  */
 MessageElement.prototype._getNestedLookupTypeString = function (element) {
   var resolvedType = '^',
-      excluded = this.ignoredNamespaces.concat('xs'); // do not process $type values wich start with
-
+    excluded = this.ignoredNamespaces.concat('xs'); // do not process $type values wich start with
+  
   if (element.hasOwnProperty('$type') && typeof element.$type === 'string') {
     if (excluded.indexOf(element.$type.split(':')[0]) === -1) {
       resolvedType += ('_' + element.$type + '#' + element.$name);
     }
   }
-
+  
   if (element.children.length > 0) {
     var self = this;
-
+    
     element.children.forEach(function (child) {
       var resolvedChildType = self._getNestedLookupTypeString(child).replace(/\^_/, '');
-
+      
       if (resolvedChildType && typeof resolvedChildType === 'string') {
         resolvedType += ('_' + resolvedChildType);
       }
     });
   }
-
+  
   return resolvedType;
 };
 
@@ -684,7 +684,7 @@ BindingElement.prototype.postProcess = function(definitions) {
   if (portType){
     portType.postProcess(definitions);
     this.methods = portType.methods;
-
+    
     for (var i = 0, child; child = children[i]; i++) {
       if (child.name !== 'operation')
         continue;
@@ -692,7 +692,7 @@ BindingElement.prototype.postProcess = function(definitions) {
       children.splice(i--, 1);
       child.style || (child.style = style);
       var method = this.methods[child.$name];
-
+      
       if (method) {
         method.style = child.style;
         method.soapAction = child.soapAction;
@@ -746,7 +746,7 @@ RestrictionElement.prototype.description = function(definitions, xmlns) {
   var desc;
   for (var i=0, child; child=children[i]; i++) {
     if (child instanceof SequenceElement ||
-            child instanceof ChoiceElement) {
+      child instanceof ChoiceElement) {
       desc = child.description(definitions, xmlns);
       break;
     }
@@ -757,14 +757,14 @@ RestrictionElement.prototype.description = function(definitions, xmlns) {
       ns = xmlns && xmlns[type.prefix] || definitions.xmlns[type.prefix],
       schema = definitions.schemas[ns],
       typeElement = schema && ( schema.complexTypes[typeName] || schema.types[typeName] || schema.elements[typeName] );
-
+    
     desc.getBase = function() {
       return typeElement.description(definitions, schema.xmlns);
     };
     return desc;
   }
-
-    // then simple element
+  
+  // then simple element
   var base = this.$base ? this.$base + "|" : "";
   return base + this.children.map(function(child) {
     return child.description();
@@ -785,14 +785,14 @@ ExtensionElement.prototype.description = function(definitions, xmlns) {
       typeName = type.name,
       ns = xmlns && xmlns[type.prefix] || definitions.xmlns[type.prefix],
       schema = definitions.schemas[ns];
-
+    
     if (typeName in Primitives) {
       return this.$base;
     }
     else {
       var typeElement = schema && ( schema.complexTypes[typeName] ||
         schema.types[typeName] || schema.elements[typeName] );
-
+      
       if (typeElement) {
         var base = typeElement.description(definitions, schema.xmlns);
         desc = _.defaultsDeep(base, desc);
@@ -814,7 +814,7 @@ ComplexTypeElement.prototype.description = function(definitions, xmlns) {
       child instanceof AllElement ||
       child instanceof SimpleContentElement ||
       child instanceof ComplexContentElement) {
-
+      
       return child.description(definitions, xmlns);
     }
   }
@@ -848,7 +848,7 @@ ElementElement.prototype.description = function(definitions, xmlns) {
   if (this.$minOccurs !== this.$maxOccurs && isMany) {
     name += '[]';
   }
-
+  
   if (xmlns && xmlns[TNS_PREFIX]) {
     this.$targetNamespace = xmlns[TNS_PREFIX];
   }
@@ -859,15 +859,15 @@ ElementElement.prototype.description = function(definitions, xmlns) {
       ns = xmlns && xmlns[type.prefix] || definitions.xmlns[type.prefix],
       schema = definitions.schemas[ns],
       typeElement = schema && ( this.$type? schema.complexTypes[typeName] || schema.types[typeName] : schema.elements[typeName] );
-
+    
     if (ns && definitions.schemas[ns]) {
       xmlns = definitions.schemas[ns].xmlns;
     }
-
+    
     if (typeElement && !(typeName in Primitives)) {
-
+      
       if (!(typeName in definitions.descriptions.types)) {
-
+        
         var elem = {};
         definitions.descriptions.types[typeName] = elem;
         var description = typeElement.description(definitions, xmlns);
@@ -879,19 +879,19 @@ ElementElement.prototype.description = function(definitions, xmlns) {
             elem[key] = description[key];
           });
         }
-
+        
         if (this.$ref) {
           element = elem;
         }
         else {
           element[name] = elem;
         }
-
+        
         if (typeof elem === 'object') {
           elem.targetNSAlias = type.prefix;
           elem.targetNamespace = ns;
         }
-
+        
         definitions.descriptions.types[typeName] = elem;
       }
       else {
@@ -902,7 +902,7 @@ ElementElement.prototype.description = function(definitions, xmlns) {
           element[name] = definitions.descriptions.types[typeName];
         }
       }
-
+      
     }
     else {
       element[name] = this.$type;
@@ -921,20 +921,20 @@ ElementElement.prototype.description = function(definitions, xmlns) {
 };
 
 AllElement.prototype.description =
-SequenceElement.prototype.description = function(definitions, xmlns) {
-  var children = this.children;
-  var sequence = {};
-  for (var i = 0, child; child = children[i]; i++) {
-    if (child instanceof AnyElement) {
-      continue;
+  SequenceElement.prototype.description = function(definitions, xmlns) {
+    var children = this.children;
+    var sequence = {};
+    for (var i = 0, child; child = children[i]; i++) {
+      if (child instanceof AnyElement) {
+        continue;
+      }
+      var description = child.description(definitions, xmlns);
+      for (var key in description) {
+        sequence[key] = description[key];
+      }
     }
-    var description = child.description(definitions, xmlns);
-    for (var key in description) {
-      sequence[key] = description[key];
-    }
-  }
-  return sequence;
-};
+    return sequence;
+  };
 
 ChoiceElement.prototype.description = function(definitions, xmlns) {
   var children = this.children;
@@ -995,18 +995,18 @@ ServiceElement.prototype.description = function(definitions) {
 
 var WSDL = function(definition, uri, options) {
   var self = this,
-      fromFunc;
-
+    fromFunc;
+  
   this.uri = uri;
   this.callback = function() {
   };
   this._includesWsdl = [];
-
+  
   // initialize WSDL cache
   this.WSDL_CACHE = (options || {}).WSDL_CACHE || {};
-
+  
   this._initializeOptions(options);
-
+  
   if (typeof definition === 'string') {
     definition = stripBom(definition);
     fromFunc = this._fromXML;
@@ -1017,20 +1017,20 @@ var WSDL = function(definition, uri, options) {
   else {
     throw new Error('WSDL constructor takes either an XML string or service definition');
   }
-
+  
   process.nextTick(function() {
     try {
       fromFunc.call(self, definition);
     } catch (e) {
       return self.callback(e.message);
     }
-
+    
     self.processIncludes(function(err) {
       var name;
       if (err) {
         return self.callback(err);
       }
-
+      
       self.definitions.deleteFixedAttrs();
       var services = self.services = self.definitions.services;
       if (services) {
@@ -1044,7 +1044,7 @@ var WSDL = function(definition, uri, options) {
           complexTypes[name].deleteFixedAttrs();
         }
       }
-
+      
       // for document style, for every binding, prepare input message element name to (methodName, output message element name) mapping
       var bindings = self.definitions.bindings;
       for (var bindingName in bindings) {
@@ -1066,13 +1066,13 @@ var WSDL = function(definition, uri, options) {
           }
         }
       }
-
+      
       // prepare soap envelope xmlns definition string
       self.xmlnsInEnvelope = self._xmlnsMap();
-
+      
       self.callback(err, self);
     });
-
+    
   });
 };
 
@@ -1086,11 +1086,11 @@ WSDL.prototype.xmlKey = '$xml';
 WSDL.prototype._initializeOptions = function (options) {
   this._originalIgnoredNamespaces = (options || {}).ignoredNamespaces;
   this.options = {};
-
+  
   var ignoredNamespaces = options ? options.ignoredNamespaces : null;
-
+  
   if (ignoredNamespaces &&
-      (Array.isArray(ignoredNamespaces.namespaces) || typeof ignoredNamespaces.namespaces === 'string')) {
+    (Array.isArray(ignoredNamespaces.namespaces) || typeof ignoredNamespaces.namespaces === 'string')) {
     if (ignoredNamespaces.override) {
       this.options.ignoredNamespaces = ignoredNamespaces.namespaces;
     } else {
@@ -1099,7 +1099,7 @@ WSDL.prototype._initializeOptions = function (options) {
   } else {
     this.options.ignoredNamespaces = this.ignoredNamespaces;
   }
-
+  
   this.options.valueKey = options.valueKey || this.valueKey;
   this.options.xmlKey = options.xmlKey || this.xmlKey;
   if (options.escapeXML !== undefined) {
@@ -1113,34 +1113,34 @@ WSDL.prototype._initializeOptions = function (options) {
     this.options.returnFault = false;
   }
   this.options.handleNilAsNull = !!options.handleNilAsNull;
-
+  
   // Allow any request headers to keep passing through
   this.options.wsdl_headers = options.wsdl_headers;
   this.options.wsdl_options = options.wsdl_options;
   if (options.httpClient) {
     this.options.httpClient = options.httpClient;
   }
-
+  
   // The supplied request-object should be passed through
   if (options.request) {
     this.options.request = options.request;
   }
-
+  
   var ignoreBaseNameSpaces = options ? options.ignoreBaseNameSpaces : null;
   if (ignoreBaseNameSpaces !== null && typeof ignoreBaseNameSpaces !== 'undefined') {
     this.options.ignoreBaseNameSpaces = ignoreBaseNameSpaces;
   } else {
     this.options.ignoreBaseNameSpaces = this.ignoreBaseNameSpaces;
   }
-
+  
   // Works only in client
   this.options.forceSoap12Headers = options.forceSoap12Headers;
   this.options.customDeserializer = options.customDeserializer;
-
+  
   if (options.overrideRootElement !== undefined) {
     this.options.overrideRootElement = options.overrideRootElement;
   }
-
+  
   this.options.useEmptyTag = !!options.useEmptyTag;
 };
 
@@ -1153,29 +1153,29 @@ WSDL.prototype._processNextInclude = function(includes, callback) {
   var self = this,
     include = includes.shift(),
     options;
-
+  
   if (!include)
     return callback();
-
+  
   var includePath;
   if (!/^https?:/.test(self.uri) && !/^https?:/.test(include.location)) {
     includePath = path.resolve(path.dirname(self.uri), include.location);
   } else {
     includePath = url.resolve(self.uri||'', include.location);
   }
-
+  
   options = _.assign({}, this.options);
   // follow supplied ignoredNamespaces option
   options.ignoredNamespaces = this._originalIgnoredNamespaces || this.options.ignoredNamespaces;
   options.WSDL_CACHE = this.WSDL_CACHE;
-
+  
   open_wsdl_recursive(includePath, options, function(err, wsdl) {
     if (err) {
       return callback(err);
     }
-
+    
     self._includesWsdl.push(wsdl);
-
+    
     if (wsdl.definitions instanceof DefinitionsElement) {
       _.merge(self.definitions, wsdl.definitions, function(a,b) {
         return (a instanceof SchemaElement) ? a.merge(b) : undefined;
@@ -1192,12 +1192,12 @@ WSDL.prototype._processNextInclude = function(includes, callback) {
 WSDL.prototype.processIncludes = function(callback) {
   var schemas = this.definitions.schemas,
     includes = [];
-
+  
   for (var ns in schemas) {
     var schema = schemas[ns];
     includes = includes.concat(schema.includes || []);
   }
-
+  
   this._processNextInclude(includes, callback);
 };
 
@@ -1240,13 +1240,13 @@ WSDL.prototype.xmlToObject = function(xml, callback) {
   };
   var stack = [{name: null, object: root, schema: schema}];
   var xmlns = {};
-
+  
   var refs = {}, id; // {id:{hrefs:[],obj:}, ...}
-
+  
   p.onopentag = function(node) {
     var nsName = node.name;
     var attrs  = node.attributes;
-
+    
     var name = splitQName(nsName).name,
       attributeName,
       top = stack[stack.length - 1],
@@ -1256,7 +1256,7 @@ WSDL.prototype.xmlToObject = function(xml, callback) {
       hasNilAttribute = false,
       obj = {};
     var originalName = name;
-
+    
     if (!objectName && top.name === 'Body' && name !== 'Fault') {
       var message = self.definitions.messages[name];
       // Support RPC/literal messages where response body contains one element named
@@ -1295,11 +1295,11 @@ WSDL.prototype.xmlToObject = function(xml, callback) {
           }
         }
       }
-
+      
       topSchema = message.description(self.definitions);
       objectName = originalName;
     }
-
+    
     if (attrs.href) {
       id = attrs.href.substr(1);
       if (!refs[id]) {
@@ -1312,7 +1312,7 @@ WSDL.prototype.xmlToObject = function(xml, callback) {
         refs[id] = {hrefs: [], obj: null};
       }
     }
-
+    
     //Handle element attributes
     for (attributeName in attrs) {
       if (/^xmlns:|^xmlns$/.test(attributeName)) {
@@ -1322,7 +1322,7 @@ WSDL.prototype.xmlToObject = function(xml, callback) {
       hasNonXmlnsAttribute = true;
       elementAttributes[attributeName] = attrs[attributeName];
     }
-
+    
     for(attributeName in elementAttributes){
       var res = splitQName(attributeName);
       if (res.name === 'nil' && xmlns[res.prefix] === 'http://www.w3.org/2001/XMLSchema-instance') {
@@ -1330,11 +1330,11 @@ WSDL.prototype.xmlToObject = function(xml, callback) {
         break;
       }
     }
-
+    
     if (hasNonXmlnsAttribute) {
       obj[self.options.attributesKey] = elementAttributes;
     }
-
+    
     // Pick up the schema for the type specified in element's xsi:type attribute.
     var xsiTypeSchema;
     var xsiType = elementAttributes['xsi:type'];
@@ -1352,13 +1352,13 @@ WSDL.prototype.xmlToObject = function(xml, callback) {
         xsiTypeSchema = typeDef.description(self.definitions);
       }
     }
-
+    
     if (topSchema && topSchema[name + '[]']) {
       name = name + '[]';
     }
     stack.push({name: originalName, object: obj, schema: (xsiTypeSchema || (topSchema && topSchema[name])), id: attrs.id, nil: hasNilAttribute});
   };
-
+  
   p.onclosetag = function(nsName) {
     var cur = stack.pop(),
       obj = cur.object,
@@ -1366,11 +1366,11 @@ WSDL.prototype.xmlToObject = function(xml, callback) {
       topObject = top.object,
       topSchema = top.schema,
       name = splitQName(nsName).name;
-
+    
     if (typeof cur.schema === 'string' && (cur.schema === 'string' || cur.schema.split(':')[1] === 'string')) {
       if (typeof obj === 'object' &&  Object.keys(obj).length === 0) obj = cur.object = '';
     }
-
+    
     if (cur.nil === true) {
       if (self.options.handleNilAsNull) {
         obj = null;
@@ -1378,11 +1378,11 @@ WSDL.prototype.xmlToObject = function(xml, callback) {
         return;
       }
     }
-
+    
     if (_.isPlainObject(obj) && !Object.keys(obj).length) {
       obj = null;
     }
-
+    
     if (topSchema && topSchema[name + '[]']) {
       if (!topObject[name]) {
         topObject[name] = [];
@@ -1396,19 +1396,19 @@ WSDL.prototype.xmlToObject = function(xml, callback) {
     } else {
       topObject[name] = obj;
     }
-
+    
     if (cur.id) {
       refs[cur.id].obj = obj;
     }
   };
-
+  
   p.oncdata = function (text) {
     var originalText = text;
     text = trim(text);
     if (!text.length) {
       return;
     }
-
+    
     if (/<\?xml[\s\S]+\?>/.test(text)) {
       var top = stack[stack.length - 1];
       var value = self.xmlToObject(text);
@@ -1421,7 +1421,7 @@ WSDL.prototype.xmlToObject = function(xml, callback) {
       p.ontext(originalText);
     }
   };
-
+  
   p.onerror = function(e) {
     p.resume();
     throw {
@@ -1433,14 +1433,14 @@ WSDL.prototype.xmlToObject = function(xml, callback) {
       }
     };
   };
-
+  
   p.ontext = function(text) {
     var originalText = text;
     text = trim(text);
     if (!text.length) {
       return;
     }
-
+    
     var top = stack[stack.length - 1];
     var name = splitQName(top.schema).name,
       value;
@@ -1466,14 +1466,14 @@ WSDL.prototype.xmlToObject = function(xml, callback) {
         }
       }
     }
-
+    
     if (top.object[self.options.attributesKey]) {
       top.object[self.options.valueKey] = value;
     } else {
       top.object = value;
     }
   };
-
+  
   if (typeof callback === 'function') {
     // we be streaming
     var saxStream = sax.createStream(true);
@@ -1482,24 +1482,24 @@ WSDL.prototype.xmlToObject = function(xml, callback) {
     saxStream.on('cdata', p.oncdata);
     saxStream.on('text', p.ontext);
     xml.pipe(saxStream)
-    .on('error', function (err) {
-      callback(err);
-    })
-    .on('end', function () {
-      var r;
-      try {
-        r = finish();
-      } catch (e) {
-        return callback(e);
-      }
-      callback(null, r);
-    });
+       .on('error', function (err) {
+         callback(err);
+       })
+       .on('end', function () {
+         var r;
+         try {
+           r = finish();
+         } catch (e) {
+           return callback(e);
+         }
+         callback(null, r);
+       });
     return;
   }
   p.write(xml).close();
-
+  
   return finish();
-
+  
   function finish() {
     // MultiRef support: merge objects instead of replacing
     for (var n in refs) {
@@ -1508,7 +1508,7 @@ WSDL.prototype.xmlToObject = function(xml, callback) {
         _.assign(ref.hrefs[i].obj, ref.obj);
       }
     }
-
+    
     if (root.Envelope) {
       var body = root.Envelope.Body;
       if (body && body.Fault) {
@@ -1535,22 +1535,22 @@ WSDL.prototype.findSchemaObject = function(nsURI, qname) {
   if (!nsURI || !qname) {
     return null;
   }
-
+  
   var def = null;
-
+  
   if (this.definitions.schemas) {
     var schema = this.definitions.schemas[nsURI];
     if (schema) {
       if (qname.indexOf(':') !== -1) {
         qname = qname.substring(qname.indexOf(':') + 1, qname.length);
       }
-
+      
       // if the client passed an input element which has a `$lookupType` property instead of `$type`
       // the `def` is found in `schema.elements`.
       def = schema.complexTypes[qname] || schema.types[qname] || schema.elements[qname];
     }
   }
-
+  
   return def;
 };
 
@@ -1585,14 +1585,14 @@ WSDL.prototype.objectToRpcXML = function(name, params, nsPrefix, nsURI,isParts) 
   var parts = [];
   var defs = this.definitions;
   var nsAttrName = '_xmlns';
-
+  
   nsPrefix = nsPrefix || findPrefix(defs.xmlns, nsURI);
-
+  
   nsURI = nsURI || defs.xmlns[nsPrefix];
   nsPrefix = nsPrefix === TNS_PREFIX ? '' : (nsPrefix + ':');
-
+  
   parts.push(['<', nsPrefix, name, '>'].join(''));
-
+  
   for (var key in params) {
     if (!params.hasOwnProperty(key)) {
       continue;
@@ -1645,23 +1645,23 @@ WSDL.prototype.filterOutIgnoredNameSpace = function(ns) {
 WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlnsAttr, schemaObject, nsContext) {
   var self = this;
   var schema = this.definitions.schemas[nsURI];
-
+  
   var parentNsPrefix = nsPrefix ? nsPrefix.parent : undefined;
   if (typeof parentNsPrefix !== 'undefined') {
     //we got the parentNsPrefix for our array. setting the namespace-variable back to the current namespace string
     nsPrefix = nsPrefix.current;
   }
-
+  
   parentNsPrefix = noColonNameSpace(parentNsPrefix);
   if (this.isIgnoredNameSpace(parentNsPrefix)) {
     parentNsPrefix = '';
   }
-
+  
   var soapHeader = !schema;
   var qualified = schema && schema.$elementFormDefault === 'qualified';
   var parts = [];
   var prefixNamespace = (nsPrefix || qualified) && nsPrefix !== TNS_PREFIX;
-
+  
   var xmlnsAttrib = '';
   if (nsURI && isFirst) {
     if(self.options.overrideRootElement && self.options.overrideRootElement.xmlnsAttributes) {
@@ -1677,39 +1677,39 @@ WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlns
       if (qualified || soapHeader) xmlnsAttrib += ' xmlns="' + nsURI + '"';
     }
   }
-
+  
   if (!nsContext) {
     nsContext = new NamespaceContext();
     nsContext.declareNamespace(nsPrefix, nsURI);
   } else {
     nsContext.pushContext();
   }
-
+  
   // explicitly use xmlns attribute if available
   if (xmlnsAttr && !(self.options.overrideRootElement && self.options.overrideRootElement.xmlnsAttributes)) {
     xmlnsAttrib = xmlnsAttr;
   }
-
+  
   var ns = '';
-
+  
   if (self.options.overrideRootElement && isFirst) {
     ns = self.options.overrideRootElement.namespace;
   } else if (prefixNamespace && (qualified || isFirst || soapHeader) && !this.isIgnoredNameSpace(nsPrefix)) {
     ns = nsPrefix;
   }
-
+  
   var i, n;
   // start building out XML string.
   if (Array.isArray(obj)) {
     for (i = 0, n = obj.length; i < n; i++) {
       var item = obj[i];
       var arrayAttr = self.processAttributes(item, nsContext),
-          correctOuterNsPrefix = parentNsPrefix || ns; //using the parent namespace prefix if given
-
+        correctOuterNsPrefix = parentNsPrefix || ns; //using the parent namespace prefix if given
+      
       var body = self.objectToXML(item, name, nsPrefix, nsURI, false, null, schemaObject, nsContext);
-
+      
       var openingTagParts = ['<', appendColon(correctOuterNsPrefix), name, arrayAttr, xmlnsAttrib];
-
+      
       if (body === '' && self.options.useEmptyTag) {
         // Use empty (self-closing) tags if no contents
         openingTagParts.push(' />');
@@ -1738,18 +1738,18 @@ WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlns
         nsContext.popContext();
         return xmlEscape(obj[name]);
       }
-
+      
       var child = obj[name];
       if (typeof child === 'undefined') {
         continue;
       }
-
+      
       var attr = self.processAttributes(child, nsContext);
-
+      
       var value = '';
       var nonSubNameSpace = '';
       var emptyNonSubNameSpace = false;
-
+      
       var nameWithNsRegex = /^([^:]+):([^:]+)$/.exec(name);
       if (nameWithNsRegex) {
         nonSubNameSpace = nameWithNsRegex[1] + ':';
@@ -1758,27 +1758,27 @@ WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlns
         emptyNonSubNameSpace = true;
         name = name.substr(1);
       }
-
+      
       if (isFirst) {
         value = self.objectToXML(child, name, nsPrefix, nsURI, false, null, schemaObject, nsContext);
       } else {
-
+        
         if (self.definitions.schemas) {
           if (schema) {
             var childSchemaObject = self.findChildSchemaObject(schemaObject, name);
             //find sub namespace if not a primitive
             if (childSchemaObject &&
               ((childSchemaObject.$type && (childSchemaObject.$type.indexOf('xsd:') === -1)) ||
-              childSchemaObject.$ref || childSchemaObject.$name)) {
+                childSchemaObject.$ref || childSchemaObject.$name)) {
               /*if the base name space of the children is not in the ingoredSchemaNamspaces we use it.
                This is because in some services the child nodes do not need the baseNameSpace.
                */
-
+              
               var childNsPrefix = '';
               var childName = '';
               var childNsURI;
               var childXmlnsAttrib = '';
-
+              
               var elementQName = childSchemaObject.$ref || childSchemaObject.$name;
               if (elementQName) {
                 elementQName = splitQName(elementQName);
@@ -1797,7 +1797,7 @@ WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlns
                   }
                   childNsURI = schema.xmlns[childNsPrefix] || self.definitions.xmlns[childNsPrefix];
                 }
-
+                
                 var unqualified = false;
                 // Check qualification form for local elements
                 if (childSchemaObject.$name && childSchemaObject.targetNamespace === undefined) {
@@ -1806,13 +1806,17 @@ WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlns
                   } else if (childSchemaObject.$form === 'qualified') {
                     unqualified = false;
                   } else {
-                    unqualified = schema.$elementFormDefault !== 'qualified';
+                    var resolvedSchema = schema;
+                    if (childSchemaObject.$targetNamespace) {
+                      resolvedSchema = this.definitions.schemas[childSchemaObject.$targetNamespace];
+                    }
+                    unqualified = resolvedSchema && resolvedSchema.$elementFormDefault !== 'qualified';
                   }
                 }
                 if (unqualified) {
                   childNsPrefix = '';
                 }
-
+                
                 if (childNsURI && childNsPrefix) {
                   if (nsContext.declareNamespace(childNsPrefix, childNsURI)) {
                     childXmlnsAttrib = ' xmlns:' + childNsPrefix + '="' + childNsURI + '"';
@@ -1820,7 +1824,7 @@ WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlns
                   }
                 }
               }
-
+              
               var resolvedChildSchemaObject;
               if (childSchemaObject.$type) {
                 var typeQName = splitQName(childSchemaObject.$type);
@@ -1837,19 +1841,19 @@ WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlns
                 resolvedChildSchemaObject =
                   self.findSchemaObject(childNsURI, childName) || childSchemaObject;
               }
-
+              
               if (childSchemaObject.$baseNameSpace && this.options.ignoreBaseNameSpaces) {
                 childNsPrefix = nsPrefix;
                 childNsURI = nsURI;
               }
-
+              
               if (this.options.ignoreBaseNameSpaces) {
                 childNsPrefix = '';
                 childNsURI = '';
               }
-
+              
               ns = childNsPrefix;
-
+              
               if (Array.isArray(child)) {
                 //for arrays, we need to remember the current namespace
                 childNsPrefix = {
@@ -1860,7 +1864,7 @@ WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlns
                 //parent (array) already got the namespace
                 childXmlnsAttrib = null;
               }
-
+              
               value = self.objectToXML(child, name, childNsPrefix, childNsURI,
                 false, childXmlnsAttrib, resolvedChildSchemaObject, nsContext);
             } else if (obj[self.options.attributesKey] && obj[self.options.attributesKey].xsi_type) {
@@ -1868,7 +1872,7 @@ WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlns
               var completeChildParamTypeObject = self.findChildSchemaObject(
                 obj[self.options.attributesKey].xsi_type.type,
                 obj[self.options.attributesKey].xsi_type.xmlns);
-
+              
               nonSubNameSpace = obj[self.options.attributesKey].xsi_type.prefix;
               nsContext.addNamespace(obj[self.options.attributesKey].xsi_type.prefix,
                 obj[self.options.attributesKey].xsi_type.xmlns);
@@ -1878,7 +1882,7 @@ WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlns
               if(Array.isArray(child)) {
                 name = nonSubNameSpace + name;
               }
-
+              
               value = self.objectToXML(child, name, nsPrefix, nsURI, false, null, null, nsContext);
             }
           } else {
@@ -1886,14 +1890,14 @@ WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlns
           }
         }
       }
-
+      
       ns = noColonNameSpace(ns);
       if (prefixNamespace && !qualified && isFirst && !self.options.overrideRootElement) {
         ns = nsPrefix;
       } else if (this.isIgnoredNameSpace(ns)) {
         ns = '';
       }
-
+      
       var useEmptyTag = !value && self.options.useEmptyTag;
       if (!Array.isArray(child)) {
         // start tag
@@ -1902,7 +1906,7 @@ WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlns
           useEmptyTag ? ' />' : '>'
         ].join(''));
       }
-
+      
       if (!useEmptyTag) {
         parts.push(value);
         if (!Array.isArray(child)) {
@@ -1920,15 +1924,15 @@ WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlns
 
 WSDL.prototype.processAttributes = function(child, nsContext) {
   var attr = '';
-
+  
   if(child === null) {
     child = [];
   }
-
+  
   var attrObj = child[this.options.attributesKey];
   if (attrObj && attrObj.xsi_type) {
     var xsiType = attrObj.xsi_type;
-
+    
     var prefix = xsiType.prefix || xsiType.namespace;
     // Generate a new namespace for complex extension if one not provided
     if (!prefix) {
@@ -1938,8 +1942,8 @@ WSDL.prototype.processAttributes = function(child, nsContext) {
     }
     xsiType.prefix = prefix;
   }
-
-
+  
+  
   if (attrObj) {
     for (var attrKey in attrObj) {
       //handle complex extension separately
@@ -1947,14 +1951,14 @@ WSDL.prototype.processAttributes = function(child, nsContext) {
         var attrValue = attrObj[attrKey];
         attr += ' xsi:type="' + attrValue.prefix + ':' + attrValue.type + '"';
         attr += ' xmlns:' + attrValue.prefix + '="' + attrValue.xmlns + '"';
-
+        
         continue;
       } else {
         attr += ' ' + attrKey + '="' + xmlEscape(attrObj[attrKey]) + '"';
       }
     }
   }
-
+  
   return attr;
 };
 
@@ -1968,12 +1972,12 @@ WSDL.prototype.findSchemaType = function(name, nsURI) {
   if (!this.definitions.schemas || !name || !nsURI) {
     return null;
   }
-
+  
   var schema = this.definitions.schemas[nsURI];
   if (!schema || !schema.complexTypes) {
     return null;
   }
-
+  
   return schema.complexTypes[name];
 };
 
@@ -1981,38 +1985,78 @@ WSDL.prototype.findChildSchemaObject = function(parameterTypeObj, childName, bac
   if (!parameterTypeObj || !childName) {
     return null;
   }
-
+  
   if (!backtrace) {
     backtrace = [];
   }
-
+  
   if (backtrace.indexOf(parameterTypeObj) >= 0) {
     // We've recursed back to ourselves; break.
     return null;
   } else {
     backtrace = backtrace.concat([parameterTypeObj]);
   }
-
+  
   var found = null,
-      i = 0,
-      child,
-      ref;
-
+    i = 0,
+    child,
+    ref;
+  
   if (Array.isArray(parameterTypeObj.$lookupTypes) && parameterTypeObj.$lookupTypes.length) {
     var types = parameterTypeObj.$lookupTypes;
-
+    
     for(i = 0; i < types.length; i++) {
       var typeObj = types[i];
-
+      
       if(typeObj.$name === childName) {
         found = typeObj;
         break;
       }
     }
   }
-
+  
   var object = parameterTypeObj;
   if (object.$name === childName && object.name === 'element') {
+    var objectInfo = splitQName(object.$name);
+    if (objectInfo.prefix === TNS_PREFIX) {
+      for (var i = backtrace.length - 2; i >= 0; --i) {
+        var current = backtrace[i];
+  
+        if (current.name === "element" && current.$type) {
+          var currentInfo = splitQName(current.$type);
+          if (currentInfo.prefix && currentInfo.prefix !== TNS_PREFIX) {
+            // var prefix prefix = currentInfo.prefix;
+            object.$name = currentInfo.prefix + ":" + object.$name;
+            break;
+          }
+        }
+        //
+        // if (current.prefix && current.prefix !== TNS_PREFIX) {
+        //   object.prefix = current.prefix;
+        //   object.$name = object.prefix + ":" + object.$name;
+        //   break;
+        // }
+        //
+        // if (current.$name) {
+        //   var currentInfo = splitQName(current.$name);
+        //   if (currentInfo.prefix && currentInfo.prefix !== TNS_PREFIX) {
+        //     object.prefix = currentInfo.prefix;
+        //     object.$name = object.prefix + ":" + object.$name;
+        //     break;
+        //   }
+        // }
+		//
+        // if (current.$type) {
+        //   var typeInfo = splitQName(current.$type);
+        //   if (typeInfo.prefix && typeInfo.prefix !== TNS_PREFIX) {
+        //     object.prefix = typeInfo.prefix;
+        //     object.$name = object.prefix + ":" + object.$name;
+        //     break;
+        //   }
+        // }
+      }
+    }
+    
     return object;
   }
   if (object.$ref) {
@@ -2021,9 +2065,9 @@ WSDL.prototype.findChildSchemaObject = function(parameterTypeObj, childName, bac
       return object;
     }
   }
-
+  
   var childNsURI;
-
+  
   // want to avoid unecessary recursion to improve performance
   if (object.$type && backtrace.length === 1) {
     var typeInfo = splitQName(object.$type);
@@ -2037,24 +2081,24 @@ WSDL.prototype.findChildSchemaObject = function(parameterTypeObj, childName, bac
       return this.findChildSchemaObject(typeDef, childName, backtrace);
     }
   }
-
+  
   if (object.children) {
     for (i = 0, child; child = object.children[i]; i++) {
       found = this.findChildSchemaObject(child, childName, backtrace);
       if (found) {
         break;
       }
-
+      
       if (child.$base) {
         var baseQName = splitQName(child.$base);
         var childNameSpace = baseQName.prefix === TNS_PREFIX ? '' : baseQName.prefix;
         childNsURI = child.xmlns[baseQName.prefix] || this.definitions.xmlns[baseQName.prefix];
-
+        
         var foundBase = this.findSchemaType(baseQName.name, childNsURI);
-
+        
         if (foundBase) {
           found = this.findChildSchemaObject(foundBase, childName, backtrace);
-
+          
           if (found) {
             found.$baseNameSpace = childNameSpace;
             break;
@@ -2062,13 +2106,13 @@ WSDL.prototype.findChildSchemaObject = function(parameterTypeObj, childName, bac
         }
       }
     }
-
+    
   }
-
+  
   if (!found && object.$name === childName) {
     return object;
   }
-
+  
   return found;
 };
 
@@ -2079,12 +2123,12 @@ WSDL.prototype._parse = function(xml) {
     root = null,
     types = null,
     schema = null,
-      options = self.options;
-
+    options = self.options;
+  
   p.onopentag = function(node) {
     var nsName = node.name;
     var attrs  = node.attributes;
-
+    
     var top = stack[stack.length - 1];
     var name;
     if (top) {
@@ -2115,16 +2159,16 @@ WSDL.prototype._parse = function(xml) {
       }
     }
   };
-
+  
   p.onclosetag = function(name) {
     var top = stack[stack.length - 1];
     assert(top, 'Unmatched close tag: ' + name);
-
+    
     top.endElement(stack, name);
   };
-
+  
   p.write(xml).close();
-
+  
   return root;
 };
 
@@ -2193,19 +2237,19 @@ WSDL.prototype._xmlnsMap = function() {
  */
 function open_wsdl_recursive(uri, options, callback) {
   var fromCache,
-      WSDL_CACHE;
-
+    WSDL_CACHE;
+  
   if (typeof options === 'function') {
     callback = options;
     options = {};
   }
-
+  
   WSDL_CACHE = options.WSDL_CACHE;
-
+  
   if (fromCache = WSDL_CACHE[ uri ]) {
     return callback.call(fromCache, null, fromCache);
   }
-
+  
   return open_wsdl(uri, options, callback);
 }
 
@@ -2214,12 +2258,12 @@ function open_wsdl(uri, options, callback) {
     callback = options;
     options = {};
   }
-
+  
   // initialize cache when calling open_wsdl directly
   var WSDL_CACHE = options.WSDL_CACHE || {};
   var request_headers = options.wsdl_headers;
   var request_options = options.wsdl_options;
-
+  
   var wsdl;
   if (!/^https?:/.test(uri)) {
     debug('Reading file: %s', uri);
@@ -2251,7 +2295,7 @@ function open_wsdl(uri, options, callback) {
       }
     }, request_headers, request_options);
   }
-
+  
   return wsdl;
 }
 

--- a/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/request.json
+++ b/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/request.json
@@ -3,9 +3,9 @@
     {
       "Item": {
         "Person": {
-          "name": "My name",
+          "blissiname": "My name",
           "Address": {
-            "streetName": "My street"
+            "blissiname2": "My street"
           }
         }
       }

--- a/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/request.json
+++ b/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/request.json
@@ -3,9 +3,9 @@
     {
       "Item": {
         "Person": {
-          "blissiname": "My name",
+          "name": "My name",
           "Address": {
-            "blissiname2": "My street"
+            "streetName": "My street"
           }
         }
       }

--- a/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/request.json
+++ b/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/request.json
@@ -3,9 +3,9 @@
     {
       "Item": {
         "Person": {
-          "name1": "My name",
+          "name": "My name",
           "Address": {
-            "name2": "My second name"
+            "streetName": "My street"
           }
         }
       }

--- a/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/request.xml
+++ b/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/request.xml
@@ -5,9 +5,9 @@
             <Order>
                 <Item>
                     <Person>
-                        <cis:name1 xmlns:cis="http://cf.de/webservice/cis">My name</cis:name1>
+                        <name>My name</name>
                         <Address xmlns:cis="http://cf.de/webservice/cis">
-                            <cis:name2>My second name</cis:name2>
+                            <cis:streetName>My street</cis:streetName>
                         </Address>
                     </Person>
                 </Item>

--- a/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/request.xml
+++ b/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/request.xml
@@ -5,9 +5,9 @@
             <Order>
                 <Item>
                     <Person>
-                        <blissiname>My name</blissiname>
+                        <name>My name</name>
                         <Address>
-                            <cis:blissiname2 xmlns:cis="http://cf.de/webservice/cis">My street</cis:blissiname2>
+                            <cis:streetName xmlns:cis="http://cf.de/webservice/cis">My street</cis:streetName>
                         </Address>
                     </Person>
                 </Item>

--- a/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/request.xml
+++ b/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/request.xml
@@ -5,9 +5,9 @@
             <Order>
                 <Item>
                     <Person>
-                        <name>My name</name>
-                        <Address xmlns:cis="http://cf.de/webservice/cis">
-                            <cis:streetName>My street</cis:streetName>
+                        <blissiname>My name</blissiname>
+                        <Address>
+                            <cis:blissiname2 xmlns:cis="http://cf.de/webservice/cis">My street</cis:blissiname2>
                         </Address>
                     </Person>
                 </Item>

--- a/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/small-wsdl-bcs.xsd
+++ b/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/small-wsdl-bcs.xsd
@@ -1,0 +1,54 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:bcs="http://cf.de/webservice/bcs"
+	xmlns:cis="http://cf.de/webservice/cis"
+	targetNamespace="http://cf.de/webservice/bcs">
+
+	<import namespace="http://cf.de/webservice/cis" schemaLocation="small-wsdl-cis.xsd"/>
+
+
+	<element name="doActionRequest">
+		<complexType>
+			<sequence>
+				<element name="Order" type="bcs:OrderType" maxOccurs="30" />
+			</sequence>
+		</complexType>
+	</element>
+
+
+	<element name="doActionResponse">
+		<complexType>
+			<sequence>
+				<element name="Field" type="xs:string" />
+			</sequence>
+		</complexType>
+	</element>
+
+
+	<complexType name="OrderType">
+		<sequence>
+			<element name="Item">
+				<complexType>
+					<sequence>
+						<element name="Person" type="bcs:PersonType" />
+					</sequence>
+				</complexType>
+			</element>
+		</sequence>
+	</complexType>
+
+
+	<complexType name="PersonType">
+		<complexContent>
+			<extension base="bcs:PersonTypeType"> </extension>
+		</complexContent>
+	</complexType>
+
+
+	<complexType name="PersonTypeType">
+		<sequence>
+            <element name="name" type="xs:string" />
+            <element name="Address" type="cis:PersonAddressType" />
+		</sequence>
+	</complexType>
+</schema>

--- a/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/small-wsdl-bcs.xsd
+++ b/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/small-wsdl-bcs.xsd
@@ -47,7 +47,7 @@
 
 	<complexType name="PersonTypeType">
 		<sequence>
-            <element name="name" type="xs:string" />
+            <element name="blissiname" type="xs:string" />
             <element name="Address" type="cis:PersonAddressType" />
 		</sequence>
 	</complexType>

--- a/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/small-wsdl-bcs.xsd
+++ b/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/small-wsdl-bcs.xsd
@@ -47,7 +47,7 @@
 
 	<complexType name="PersonTypeType">
 		<sequence>
-            <element name="blissiname" type="xs:string" />
+            <element name="name" type="xs:string" />
             <element name="Address" type="cis:PersonAddressType" />
 		</sequence>
 	</complexType>

--- a/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/small-wsdl-cis.xsd
+++ b/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/small-wsdl-cis.xsd
@@ -5,7 +5,7 @@
 
 	<xs:complexType name="PersonAddressType">
 		<xs:sequence>
-			<xs:element name="blissiname2" type="xs:string" />
+			<xs:element name="streetName" type="xs:string" />
 		</xs:sequence>
 	</xs:complexType>
 </xs:schema>

--- a/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/small-wsdl-cis.xsd
+++ b/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/small-wsdl-cis.xsd
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:cis="http://cf.de/webservice/cis"
+	targetNamespace="http://cf.de/webservice/cis" elementFormDefault="qualified"
+	attributeFormDefault="unqualified">
+
+	<xs:complexType name="PersonAddressType">
+		<xs:sequence>
+			<xs:element name="streetName" type="xs:string" />
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/small-wsdl-cis.xsd
+++ b/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/small-wsdl-cis.xsd
@@ -5,7 +5,7 @@
 
 	<xs:complexType name="PersonAddressType">
 		<xs:sequence>
-			<xs:element name="streetName" type="xs:string" />
+			<xs:element name="blissiname2" type="xs:string" />
 		</xs:sequence>
 	</xs:complexType>
 </xs:schema>

--- a/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/soap.wsdl
+++ b/test/request-response-samples/doAction__should_handle_namespaces_in_referenced_complex_type_correctly/soap.wsdl
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions
+		targetNamespace="http://cf.de/webservice/bcs"
+		xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+		xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
+		xmlns:xs="http://www.w3.org/2001/XMLSchema"
+		xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+		xmlns:cis="http://cf.de/webservice/cis"
+		xmlns:bcs="http://cf.de/webservice/bcs">
+
+	<wsdl:types>
+		<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified">
+			<xs:import namespace="http://cf.de/webservice/cis"
+					   schemaLocation="small-wsdl-cis.xsd"/>
+			<xs:import namespace="http://cf.de/webservice/bcs"
+					   schemaLocation="small-wsdl-bcs.xsd"/>
+		</xs:schema>
+	</wsdl:types>
+
+
+
+	<wsdl:message name="doActionRequestMessage">
+		<wsdl:part name="part1" element="bcs:doActionRequest"> </wsdl:part>
+	</wsdl:message>
+
+	<wsdl:message name="doActionResponseMessage">
+		<wsdl:part name="part1" element="bcs:doActionResponse"> </wsdl:part>
+	</wsdl:message>
+
+
+
+
+	<wsdl:portType name="CFAPIPortType">
+		<wsdl:operation name="doAction">
+			<wsdl:input message="bcs:doActionRequestMessage" />
+			<wsdl:output message="bcs:doActionResponseMessage" />
+		</wsdl:operation>
+	</wsdl:portType>
+
+
+
+
+
+	<wsdl:binding name="CFAPIBinding" type="bcs:CFAPIPortType">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+
+		<wsdl:operation name="doAction">
+			<soap:operation soapAction="urn:doAction" style="document"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+
+
+
+
+
+	<wsdl:service name="CFAPI">
+		<wsdl:port name="CFAPIport0" binding="bcs:CFAPIBinding">
+			<soap:address location="https://cig.dhl.de/services/production/soap"/>
+		</wsdl:port>
+	</wsdl:service>
+</wsdl:definitions>

--- a/test/request-response-samples/doAction__should_handle_namespaces_of_referenced_element_correctly/request.json
+++ b/test/request-response-samples/doAction__should_handle_namespaces_of_referenced_element_correctly/request.json
@@ -1,0 +1,15 @@
+{
+  "Order":  [
+    {
+      "Item": {
+        "Person": {
+          "name1": "My name",
+          "Address": {
+            "name2": "My second name",
+            "streetName": "My street"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/request-response-samples/doAction__should_handle_namespaces_of_referenced_element_correctly/request.xml
+++ b/test/request-response-samples/doAction__should_handle_namespaces_of_referenced_element_correctly/request.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cis="http://cf.de/webservice/cis" xmlns:bcs="http://cf.de/webservice/bcs">
+    <soap:Body>
+        <bcs:doActionRequest xmlns:bcs="http://cf.de/webservice/bcs">
+            <Order>
+                <Item>
+                    <Person>
+                        <cis:name1 xmlns:cis="http://cf.de/webservice/cis">My name</cis:name1>
+                        <Address xmlns:cis="http://cf.de/webservice/cis">
+                            <cis:name2>My second name</cis:name2>
+                            <cis:streetName>My street</cis:streetName>
+                        </Address>
+                    </Person>
+                </Item>
+            </Order>
+        </bcs:doActionRequest>
+    </soap:Body>
+</soap:Envelope>

--- a/test/request-response-samples/doAction__should_handle_namespaces_of_referenced_element_correctly/small-wsdl-bcs.xsd
+++ b/test/request-response-samples/doAction__should_handle_namespaces_of_referenced_element_correctly/small-wsdl-bcs.xsd
@@ -1,0 +1,54 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:bcs="http://cf.de/webservice/bcs"
+	xmlns:cis="http://cf.de/webservice/cis"
+	targetNamespace="http://cf.de/webservice/bcs">
+
+	<import namespace="http://cf.de/webservice/cis" schemaLocation="small-wsdl-cis.xsd"/>
+
+
+	<element name="doActionRequest">
+		<complexType>
+			<sequence>
+				<element name="Order" type="bcs:OrderType" maxOccurs="30" />
+			</sequence>
+		</complexType>
+	</element>
+
+
+	<element name="doActionResponse">
+		<complexType>
+			<sequence>
+				<element name="Field" type="xs:string" />
+			</sequence>
+		</complexType>
+	</element>
+
+
+	<complexType name="OrderType">
+		<sequence>
+			<element name="Item">
+				<complexType>
+					<sequence>
+						<element name="Person" type="bcs:PersonType" />
+					</sequence>
+				</complexType>
+			</element>
+		</sequence>
+	</complexType>
+
+
+	<complexType name="PersonType">
+		<complexContent>
+			<extension base="bcs:PersonTypeType"> </extension>
+		</complexContent>
+	</complexType>
+
+
+	<complexType name="PersonTypeType">
+		<sequence>
+			<element ref="cis:name1"/>
+            <element name="Address" type="cis:PersonAddressType" />
+		</sequence>
+	</complexType>
+</schema>

--- a/test/request-response-samples/doAction__should_handle_namespaces_of_referenced_element_correctly/small-wsdl-cis.xsd
+++ b/test/request-response-samples/doAction__should_handle_namespaces_of_referenced_element_correctly/small-wsdl-cis.xsd
@@ -6,7 +6,6 @@
 	<xs:complexType name="PersonAddressType">
 		<xs:sequence>
 			<xs:element ref="cis:name2" minOccurs="0"/>
-			<xs:element name="streetName" type="xs:string" />
 		</xs:sequence>
 	</xs:complexType>
 

--- a/test/request-response-samples/doAction__should_handle_namespaces_of_referenced_element_correctly/small-wsdl-cis.xsd
+++ b/test/request-response-samples/doAction__should_handle_namespaces_of_referenced_element_correctly/small-wsdl-cis.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:cis="http://cf.de/webservice/cis"
+	targetNamespace="http://cf.de/webservice/cis" elementFormDefault="qualified"
+	attributeFormDefault="unqualified">
+
+	<xs:complexType name="PersonAddressType">
+		<xs:sequence>
+			<xs:element ref="cis:name2" minOccurs="0"/>
+			<xs:element name="streetName" type="xs:string" />
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:element name="name1">
+		<xs:simpleType>
+			<xs:restriction base="xs:string">
+				<xs:maxLength value="50"/>
+			</xs:restriction>
+		</xs:simpleType>
+	</xs:element>
+
+	<xs:element name="name2">
+		<xs:simpleType>
+			<xs:restriction base="xs:string">
+				<xs:maxLength value="50"/>
+			</xs:restriction>
+		</xs:simpleType>
+	</xs:element>
+</xs:schema>

--- a/test/request-response-samples/doAction__should_handle_namespaces_of_referenced_element_correctly/soap.wsdl
+++ b/test/request-response-samples/doAction__should_handle_namespaces_of_referenced_element_correctly/soap.wsdl
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions
+		targetNamespace="http://cf.de/webservice/bcs"
+		xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+		xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
+		xmlns:xs="http://www.w3.org/2001/XMLSchema"
+		xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+		xmlns:cis="http://cf.de/webservice/cis"
+		xmlns:bcs="http://cf.de/webservice/bcs">
+
+	<wsdl:types>
+		<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified">
+			<xs:import namespace="http://cf.de/webservice/cis"
+					   schemaLocation="small-wsdl-cis.xsd"/>
+			<xs:import namespace="http://cf.de/webservice/bcs"
+					   schemaLocation="small-wsdl-bcs.xsd"/>
+		</xs:schema>
+	</wsdl:types>
+
+
+
+	<wsdl:message name="doActionRequestMessage">
+		<wsdl:part name="part1" element="bcs:doActionRequest"> </wsdl:part>
+	</wsdl:message>
+
+	<wsdl:message name="doActionResponseMessage">
+		<wsdl:part name="part1" element="bcs:doActionResponse"> </wsdl:part>
+	</wsdl:message>
+
+
+
+
+	<wsdl:portType name="CFAPIPortType">
+		<wsdl:operation name="doAction">
+			<wsdl:input message="bcs:doActionRequestMessage" />
+			<wsdl:output message="bcs:doActionResponseMessage" />
+		</wsdl:operation>
+	</wsdl:portType>
+
+
+
+
+
+	<wsdl:binding name="CFAPIBinding" type="bcs:CFAPIPortType">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+
+		<wsdl:operation name="doAction">
+			<soap:operation soapAction="urn:doAction" style="document"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+
+
+
+
+
+	<wsdl:service name="CFAPI">
+		<wsdl:port name="CFAPIport0" binding="bcs:CFAPIBinding">
+			<soap:address location="https://cig.dhl.de/services/production/soap"/>
+		</wsdl:port>
+	</wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
Hallo,
I found a bug with a wrong namespace for a referenced element. I think this only occurs under special circumstances - please have a look at the unit test that I've included. The bug was that the element "name2" didn't get the namespace prefix "cis:" and therefore the XML file was invalid.

There is still another bug in the library, though:
The "streetName"-node should also have the "cis:"-prefix, but that one is also omitted. That's the reason why the unit test still fails.

I tried to find out the cause of this bug but haven't been successful so far. I'll try again tomorrow, but if anybody has an idea where I have to look please give me a note.