### PR TITLE
Enable multiArgs during promisification

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -448,7 +448,10 @@ Interesting properties might be:
 
 ``` javascript
   client.MyFunctionAsync({name: 'value'}).then((result) => {
+    // result is a javascript array containing result, raw and soapheader
     // result is a javascript object
+    // raw is the raw response
+    // soapHeader is the response soap header as a javascript object
   })
 ```
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -26,8 +26,11 @@ var Client = function(wsdl, endpoint, options) {
   this._initializeOptions(options);
   this._initializeServices(endpoint);
   this.httpClient = options.httpClient || new HttpClient(options);
-  var suffixOption = options.overridePromiseSuffix ? { suffix: options.overridePromiseSuffix } : null;
-  BluebirdPromise.promisifyAll(this, suffixOption);
+  var promiseOptions = { multiArgs: true };
+  if (options.overridePromiseSuffix) {
+    promiseOptions.suffix = options.overridePromiseSuffix;
+  }
+  BluebirdPromise.promisifyAll(this, promiseOptions);
 };
 util.inherits(Client, events.EventEmitter);
 


### PR DESCRIPTION
Because the `multiArgs` parameters wasn't enabled when promisification was implemented on #956, it is impossible to have access to the `raw` and `soapHeader` parameters that are passed when the response is received. Enabling `multiArgs` causes the promisified function to return an array with all but the first callback parameters, solving the issue.

**Example `multiArgs: false`**
```
let response = await client.someMethodAsync();
console.log(response); // { attr1: value1, attr2: value2 }
```

**Example `multiArgs: true`**
```
let response = await client.someMethodAsync();
console.log(response); // [{ attr1: value1, attr2: value2 }, '<xml>...</xml>', soapHeaders]
```

Please note, **this is a breaking change**.