### PR TITLE
feat(client): add rawRequest to callback arguments

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -434,10 +434,11 @@ An instance of `Client` is passed to the `soap.createClient` callback.  It is us
 ### Client.*method*(args, callback, options) - call *method* on the SOAP service.
 
 ``` javascript
-  client.MyFunction({name: 'value'}, function(err, result, raw, soapHeader) {
+  client.MyFunction({name: 'value'}, function(err, result, rawResponse, soapHeader, rawRequest) {
       // result is a javascript object
-      // raw is the raw response
+      // rawResponse is the raw xml response string
       // soapHeader is the response soap header as a javascript object
+      // rawRequest is the raw xml request string
   })
 ```
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -184,8 +184,8 @@ Client.prototype._defineMethod = function(method, location) {
       extraHeaders = options;
       options = temp;
     }
-    self._invoke(method, args, location, function(error, result, raw, soapHeader) {
-      callback(error, result, raw, soapHeader);
+    self._invoke(method, args, location, function(error, result, rawResponse, soapHeader, rawRequest) {
+      callback(error, result, rawResponse, soapHeader, rawRequest);
     }, options, extraHeaders);
   };
 };
@@ -279,7 +279,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
   if(options && options.postProcess){
     xml = options.postProcess(xml);
   }
-  
+
   self.lastMessage = message;
   self.lastRequest = xml;
   self.lastEndpoint = location;
@@ -309,7 +309,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
       self.lastElapsedTime = null;
       self.emit('response', null, null, eid);
 
-      callback(err);
+      callback(err, undefined, undefined, undefined, xml);
     };
     req.on('error', onError);
     req.on('response', function (response) {
@@ -340,7 +340,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
           error.response = response;
           error.body = '<stream>';
           self.emit('soapError', error, eid);
-          return callback(error, response);
+          return callback(error, response, undefined, undefined, xml);
         }
 
         return finish(obj, '<stream>', response);
@@ -356,7 +356,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
     self.emit('response', body, response, eid);
 
     if (err) {
-      callback(err);
+      callback(err, undefined, undefined, undefined, xml);
     } else {
       return parseSync(body, response);
     }
@@ -374,13 +374,13 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
         //  If the response is JSON then return it as-is.
         var json = _.isObject(body) ? body : tryJSONparse(body);
         if (json) {
-          return callback(null, response, json);
+          return callback(null, response, json, undefined, xml);
         }
       }
       error.response = response;
       error.body = body;
       self.emit('soapError', error, eid);
-      return callback(error, response, body);
+      return callback(error, response, body, undefined, xml);
     }
     return finish(obj, body, response);
   }
@@ -390,19 +390,19 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
 
     if (!output){
       // one-way, no output expected
-      return callback(null, null, body, obj.Header);
+      return callback(null, null, body, obj.Header, xml);
     }
 
     if( typeof obj.Body !== 'object' ) {
       var error = new Error('Cannot parse response');
       error.response = response;
       error.body = body;
-      return callback(error, obj, body);
+      return callback(error, obj, body, undefined, xml);
     }
 
     // if Soap Body is empty
     if (!obj.Body) {
-      return callback(null, obj, body, obj.Header);
+      return callback(null, obj, body, obj.Header, xml);
     }
 
     result = obj.Body[output.$name];
@@ -420,7 +420,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
       });
     }
 
-    callback(null, result, body, obj.Header);
+    callback(null, result, body, obj.Header, xml);
   }
 
   // Added mostly for testability, but possibly useful for debugging

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -276,6 +276,20 @@ var fs = require('fs'),
         }, baseUrl);
       });
 
+      it('should have rawRequest available in the callback', function (done) {
+        soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {
+          assert.ok(client);
+          assert.ifError(err);
+
+          client.MyOperation({}, function (err, result, rawResponse, headers, rawRequest) {
+            assert.ok(rawRequest);
+            assert.ok(typeof rawRequest === 'string');
+
+            done();
+          }, null, { 'test-header': 'test' });
+        }, baseUrl);
+      });
+
       it('should have lastElapsedTime after a call with the time option passed', function (done) {
         soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {
           assert.ok(client);


### PR DESCRIPTION
__Use case:__ Allows clients who send requests asynchronously to accurately log the requests they are making.

Adds the XML raw request as an argument to the client callback. This allows correct tracking of the requests, as requests made asynchronously on the same client will overwrite the `client.lastRequest` attribute.

I added a test to the headers describe block as that is where it seemed similar code was being tested.
