### PR TITLE
add option to remove element-by-element namespacing of json arrays

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -139,6 +139,7 @@ The `options` argument allows you to customize the client with the following pro
 - disableCache: don't cache WSDL files, request them every time.
 - overridePromiseSuffix: if your wsdl operations contains names with Async suffix, you will need to override the default promise suffix to a custom one, default: `Async`.
 - normalizeNames: if your wsdl operations contains names with non identifier characters (`[^a-z$_0-9]`), replace them with `_`. Note: if using this option, clients using wsdls with two operations like `soap:method` and `soap-method` will be overwritten. Then, use bracket notation instead (`client['soap:method']()`).
+- namespaceArrayElements: provides support for nonstandard array semantics.  If true, JSON arrays of the form `{list: [{elem: 1}, {elem: 2}]}` are marshalled into xml as `<list><elem>1</elem></list> <list><elem>2</elem></list>`. If false, marshalls into `<list> <elem>1</elem> <elem>2</elem> </list>`. Default: `true`.
 
 Note: for versions of node >0.10.X, you may need to specify `{connection: 'keep-alive'}` in SOAP headers to avoid truncation of longer chunked responses.
 

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1114,6 +1114,12 @@ WSDL.prototype._initializeOptions = function (options) {
   }
   this.options.handleNilAsNull = !!options.handleNilAsNull;
 
+  if (options.namespaceArrayElements !== undefined) {
+    this.options.namespaceArrayElements = options.namespaceArrayElements;
+  } else {
+    this.options.namespaceArrayElements = true;
+  }
+
   // Allow any request headers to keep passing through
   this.options.wsdl_headers = options.wsdl_headers;
   this.options.wsdl_options = options.wsdl_options;
@@ -1718,9 +1724,13 @@ WSDL.prototype.objectToXML = function(obj, name, nsPrefix, nsURI, isFirst, xmlns
         parts.push(openingTagParts.join(''));
       } else {
         openingTagParts.push('>');
-        parts.push(openingTagParts.join(''));
+        if(self.options.namespaceArrayElements || i === 0) {
+          parts.push(openingTagParts.join(''));
+        }
         parts.push(body);
-        parts.push(['</', appendColon(correctOuterNsPrefix), name, '>'].join(''));
+        if(self.options.namespaceArrayElements || i === n-1) {
+          parts.push(['</', appendColon(correctOuterNsPrefix), name, '>'].join(''));
+        }
       }
     }
   } else if (typeof obj === 'object') {

--- a/test/client-options-test.js
+++ b/test/client-options-test.js
@@ -15,7 +15,8 @@ describe('SOAP Client', function() {
       'namespace': 'tns'
     },
     'overridePromiseSuffix': 'Test',
-    'request': 'customRequest'
+    'request': 'customRequest',
+    'namespaceArrayElements': true
   };
 
   it('should set WSDL options to those specified in createClient', function(done) {
@@ -27,6 +28,7 @@ describe('SOAP Client', function() {
       assert.ok(client.wsdl.options.overrideRootElement.namespace === 'tns');
       assert.ok(typeof client.MyOperationTest === 'function');
       assert.ok(client.wsdl.options.request, "customRequest");
+      assert.ok(client.wsdl.options.namespaceArrayElements === true);
       done();
     });
   });

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -891,6 +891,37 @@ var fs = require('fs'),
         });
       });
 
+      it('shall generate correct payload for methods with array parameter when individual array elements are not namespaced', function (done) {
+        // used for servers that cannot aggregate individually namespaced array elements
+        soap.createClient(__dirname + '/wsdl/list_parameter.wsdl', {disableCache: true, namespaceArrayElements: false}, function(err, client) {
+          assert.ok(client);
+          var pathToArrayContainer = 'TimesheetV201511Mobile.TimesheetV201511MobileSoap.AddTimesheet.input.input.PeriodList';
+          var arrayParameter = _.get(client.describe(), pathToArrayContainer)['PeriodType[]'];
+          assert.ok(arrayParameter);
+          client.AddTimesheet({input: {PeriodList: {PeriodType: [{PeriodId: '1'}, {PeriodId: '2'}]}}}, function() {
+            var sentInputContent = client.lastRequest.substring(client.lastRequest.indexOf('<input>') + '<input>'.length, client.lastRequest.indexOf('</input>'));
+            assert.equal(sentInputContent, '<PeriodList><PeriodType><PeriodId>1</PeriodId><PeriodId>2</PeriodId></PeriodType></PeriodList>');
+            done();
+          });
+        });
+      });
+
+      it('shall generate correct payload for methods with array parameter when individual array elements are namespaced', function (done) {
+        // this is the default behavior for array element namespacing
+        soap.createClient(__dirname + '/wsdl/list_parameter.wsdl', {disableCache: true, namespaceArrayElements: true}, function(err, client) {
+          assert.ok(client);
+          assert.ok(client.wsdl.options.namespaceArrayElements === true);
+          var pathToArrayContainer = 'TimesheetV201511Mobile.TimesheetV201511MobileSoap.AddTimesheet.input.input.PeriodList';
+          var arrayParameter = _.get(client.describe(), pathToArrayContainer)['PeriodType[]'];
+          assert.ok(arrayParameter);
+          client.AddTimesheet({input: {PeriodList: {PeriodType: [{PeriodId: '1'}, {PeriodId: '2'}]}}}, function() {
+            var sentInputContent = client.lastRequest.substring(client.lastRequest.indexOf('<input>') + '<input>'.length, client.lastRequest.indexOf('</input>'));
+            assert.equal(sentInputContent, '<PeriodList><PeriodType><PeriodId>1</PeriodId></PeriodType><PeriodType><PeriodId>2</PeriodId></PeriodType></PeriodList>');
+            done();
+          });
+        });
+      });
+
       it('shall generate correct payload for recursively-defined types', function (done) {
         soap.createClient(__dirname + '/wsdl/recursive2.wsdl', function (err, client) {
           if (err) {


### PR DESCRIPTION
By default the wsdl marshalling code converts JSON arrays of the form:
`
{
  PeriodList: {
    PeriodType: [
      {PeriodId: '1'},
      {PeriodId: '2'}
    ]
  }
}
`
Into xml documents of the form
` <PeriodList>
<PeriodType><PeriodId>1</PeriodId></PeriodType><PeriodType><PeriodId>2</PeriodId></PeriodType></PeriodList>`

However, certain web services are unable to correctly recognize that the various "PeriodType" elements are intended to be part of the same array, resulting in the unmarshalling:

`{
  PeriodList: [
    PeriodType: [
      {PeriodId: '1'}
    ],
   PeriodType: [
      {PeriodId: '2'}
    ]
  ]
}`

To remedy this, a new client/wsdl option "namespaceArrayElements" has been added.  The default (true) is the current behavior.  If namespaceArrayElements is set to false, however, the following xml will be generated, which allows for correct array construction on the server side:

`<PeriodList><PeriodType><PeriodId>1</PeriodId><PeriodId>2</PeriodId></PeriodType></PeriodList>`


  