### PR TITLE
Handle SOAP 1.2 fault responses

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1515,8 +1515,20 @@ WSDL.prototype.xmlToObject = function(xml, callback) {
       var body = root.Envelope.Body;
       if (body && body.Fault) {
         var code = selectn('faultcode.$value', body.Fault) || selectn('faultcode', body.Fault);
-        var string = selectn('faultstring.$value', body.Fault) || selectn('faultstring', body.Fault);
-        var detail = selectn('detail.$value', body.Fault) || selectn('detail.message', body.Fault);
+        var string;
+        var detail;
+        if (code) {
+          string = selectn('faultstring.$value', body.Fault) || selectn('faultstring', body.Fault);
+          detail = selectn('detail.$value', body.Fault) || selectn('detail.message', body.Fault);
+        } else {   // If using SOAP 1.2 rather than 1.1 there won't be a faultcode element. Handle the newer structure.
+          code = selectn('Code.Value', body.Fault);
+          var subcode = selectn('Code.Value.Subcode', body.Fault);
+          if (subcode) {
+            code = code + ': ' + subcode;
+          }
+          string = selectn('Reason.Text.$value', body.Fault);
+          detail = selectn('Detail', body.Fault);
+        }
         var error = new Error(code + ': ' + string + (detail ? ': ' + detail : ''));
         error.root = root;
         throw error;


### PR DESCRIPTION
When handling fault responses from SOAP 1.2 servers the faultstring and
detail elements of version 1.1 are replaced with mandatory Code and
Reason elements. Use these if no faultstring element is found. Also
handle optional Subcode and Detail elements.