### PR TITLE
Error on custom deserializer example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -879,7 +879,7 @@ Example :
 ```javascript
 
    var wsdlOptions = {
-     customDeserializer = {
+     customDeserializer: {
 
        // this function will be used to any date found in soap responses
        date: function (text, context) {


### PR DESCRIPTION
Probably a typo, there is an assignment operator inside the wsdlOptions object where a colon is expected.