### PR TITLE
Add one-way response configuration options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,6 +20,7 @@ This module lets you connect to web services using SOAP.  It also provides a ser
   - [Options](#options)
   - [Server Logging](#server-logging)
   - [Server Events](#server-events)
+  - [Server Response on one-way calls](#server-response-on-one-way-calls)
   - [SOAP Fault](#soap-fault)
   - [Server security example using PasswordDigest](#server-security-example-using-passworddigest)
   - [Server connection authorization](#server-connection-authorization)
@@ -257,6 +258,16 @@ Server instances emit the following events:
 
 The sequence order of the calls is `request`, `headers` and then the dedicated
 service method.
+
+### Server Response on one-way calls
+
+The so called one-way (or asynchronous) calls occur when an operation is called with no output defined in WSDL.
+The server sends a response (defaults to status code 200 with no body) to the client disregarding the result of the operation.
+
+You can configure the response to match the appropriate client expectation to the SOAP standard implementation.
+Pass in `oneWay` object in server options. Use the following keys:
+`emptyBody`: if true, returns an empty body, otherwise no content at all (default is false)
+`responseCode`: default statusCode is 200, override it with this options (for example 202 for SAP standard compliant response)
 
 ### SOAP Fault
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -39,6 +39,7 @@ var Server = function (server, path, services, wsdl, options) {
   this.wsdl = wsdl;
   this.suppressStack = options && options.suppressStack;
   this.returnFault = options && options.returnFault;
+  this.onewayOptions = options && options.oneWay || {};
 
   if (path[path.length - 1] !== '/')
     path += '/';
@@ -130,6 +131,8 @@ Server.prototype.clearSoapHeaders = function () {
 
 Server.prototype._initializeOptions = function (options) {
   this.wsdl.options.attributesKey = options.attributesKey || 'attributes';
+  this.onewayOptions.statusCode = this.onewayOptions.responseCode || 200;
+  this.onewayOptions.emptyBody = !!this.onewayOptions.emptyBody;
 };
 
 Server.prototype._processRequestXml = function (req, res, xml) {
@@ -387,7 +390,11 @@ Server.prototype._executeMethod = function (options, req, callback, includeTimes
   if (!self.wsdl.definitions.services[serviceName].ports[portName].binding.methods[methodName].output) {
     // no output defined = one-way operation so return empty response
     handled = true;
-    callback('');
+    body = '';
+    if (this.onewayOptions.emptyBody) {
+      body = self._envelope('', headers, includeTimestamp);
+    }
+    callback(body, this.onewayOptions.responseCode);
   }
 
   var result = method(args, handleResult, options.headers, req);
@@ -432,10 +439,9 @@ Server.prototype._envelope = function (body, headers, includeTimestamp) {
     xml += "<soap:Header>" + headers + "</soap:Header>";
   }
 
-  xml += "<soap:Body>" +
-    body +
-    "</soap:Body>" +
-    "</soap:Envelope>";
+  xml += body ? "<soap:Body>" + body + "</soap:Body>" : "<soap:Body/>";
+
+  xml += "</soap:Envelope>";
   return xml;
 };
 

--- a/lib/soap.d.ts
+++ b/lib/soap.d.ts
@@ -85,12 +85,18 @@ export interface IOptions extends IWsdlBaseOptions {
     [key: string]: any;
 }
 
+export interface IOneWayOptions {
+    responseCode?: number;
+    emptyBody?: boolean;
+}
+
 export interface IServerOptions extends IWsdlBaseOptions {
     path: string;
     services: IServices;
     xml?: string;
     uri?: string;
     suppressStack?: boolean;
+    oneWay?: IOneWayOptions;
     [key: string]: any;
 }
 

--- a/test/server-options-test.js
+++ b/test/server-options-test.js
@@ -398,4 +398,66 @@ describe('SOAP Server with Options', function() {
       });
     });
   });
+  it('should return configured statusCode on one-way operations', function (done) {
+    test.server.listen(15099, null, null, function() {
+      test.soapServer = soap.listen(test.server, {
+        path: '/stockquote',
+        services: test.service,
+        xml: test.wsdl,
+        oneWay: {
+          responseCode: 202
+        }
+      }, test.service, test.wsdl);
+      test.baseUrl = 'http://' + test.server.address().address + ":" + test.server.address().port;
+
+      //windows return 0.0.0.0 as address and that is not
+      //valid to use in a request
+      if (test.server.address().address === '0.0.0.0' || test.server.address().address === '::') {
+        test.baseUrl = 'http://127.0.0.1:' + test.server.address().port;
+      }
+
+      soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
+        assert.ifError(err);
+        client.on('response', function (xml, response) {
+          assert.equal(response.statusCode, 202);
+          done();
+        });
+
+        client.SetTradePrice({ tickerSymbol: 'GOOG' }, function(err, result, body) {
+          assert.ifError(err);
+          assert.equal(result,null);
+          assert.equal(body,'');
+        });
+      });
+    });
+  });
+  it('should return empty body on one-way operations if configured', function (done) {
+    var responseData = '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"  xmlns:tns="http://example.com/stockquote.wsdl" xmlns:xsd1="http://example.com/stockquote.xsd"><soap:Body/></soap:Envelope>';
+    test.server.listen(15099, null, null, function() {
+      test.soapServer = soap.listen(test.server, {
+        path: '/stockquote',
+        services: test.service,
+        xml: test.wsdl,
+        oneWay: {
+          emptyBody: true
+        }
+      }, test.service, test.wsdl);
+      test.baseUrl = 'http://' + test.server.address().address + ":" + test.server.address().port;
+
+      //windows return 0.0.0.0 as address and that is not
+      //valid to use in a request
+      if (test.server.address().address === '0.0.0.0' || test.server.address().address === '::') {
+        test.baseUrl = 'http://127.0.0.1:' + test.server.address().port;
+      }
+
+      soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
+        assert.ifError(err);
+        client.SetTradePrice({ tickerSymbol: 'GOOG' }, function(err, result, body) {
+          assert.ifError(err);
+          assert.strictEqual(body, responseData);
+          done();
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Some clients, for instance SAP SOAP Client, expect different behavior when calling one-way operations. For example SAP expects a 202 status code with no body or an empty body with a status code 200.
This little change makes it possible to configure both options.

This is my first contribution to this project, so please give me a constructive feedback ;-)