### PR TITLE
Moved wsse template compilation to function calls.

### DIFF
--- a/lib/security/WSSecurityCert.js
+++ b/lib/security/WSSecurityCert.js
@@ -5,8 +5,8 @@ var path = require('path');
 var ejs = require('ejs');
 var SignedXml = require('xml-crypto').SignedXml;
 var uuid4 = require('uuid/v4');
-var wsseSecurityHeaderTemplate = ejs.compile(fs.readFileSync(path.join(__dirname, 'templates', 'wsse-security-header.ejs')).toString());
-var wsseSecurityTokenTemplate = ejs.compile(fs.readFileSync(path.join(__dirname, 'templates', 'wsse-security-token.ejs')).toString());
+var wsseSecurityHeaderTemplate;
+var wsseSecurityTokenTemplate;
 
 function addMinutes(date, minutes) {
   return new Date(date.getTime() + minutes * 60000);
@@ -47,6 +47,10 @@ function WSSecurityCert(privatePEM, publicP12PEM, password) {
   var _this = this;
   this.signer.keyInfoProvider = {};
   this.signer.keyInfoProvider.getKeyInfo = function (key) {
+    if (!wsseSecurityTokenTemplate) {
+      wsseSecurityTokenTemplate = ejs.compile(fs.readFileSync(path.join(__dirname, 'templates', 'wsse-security-token.ejs')).toString());
+    }
+
     return wsseSecurityTokenTemplate({ x509Id: _this.x509Id });
   };
 }
@@ -54,6 +58,10 @@ function WSSecurityCert(privatePEM, publicP12PEM, password) {
 WSSecurityCert.prototype.postProcess = function (xml, envelopeKey) {
   this.created = generateCreated();
   this.expires = generateExpires();
+
+  if (!wsseSecurityHeaderTemplate) {
+    wsseSecurityHeaderTemplate = ejs.compile(fs.readFileSync(path.join(__dirname, 'templates', 'wsse-security-header.ejs')).toString());
+  }
 
   var secHeader = wsseSecurityHeaderTemplate({
     binaryToken: this.publicP12PEM,


### PR DESCRIPTION
This avoids throwing fatal errors upon require in environments where `__dirname` is unreliable (ex: Webpack with target node) by lazily loading and compiling the ejs templates.

This doesn't solve the problem of making everything work in a Webpack build, but it allows use of the library if you don't follow codepaths that use `__dirname`.