### PR TITLE
WSSecurityCert without Timestamp and only xml-exc-c14n#

### DIFF
--- a/lib/security/WSSecurityCert.js
+++ b/lib/security/WSSecurityCert.js
@@ -44,7 +44,7 @@ function WSSecurityCert(privatePEM, publicP12PEM, password, options) {
     passphrase: password
   };
   this.x509Id = "x509-" + generateId();
-  this.hasTimeStamp = typeof options.hasTimeStamp === 'undefined' ? true : !!options.hasTimestamp;
+  this.hasTimeStamp = typeof options.hasTimeStamp === 'undefined' ? true : !!options.hasTimeStamp;
   this.signatureTransformations = Array.isArray(options.signatureTransformations) ? options.signatureTransformations
     : ["http://www.w3.org/2000/09/xmldsig#enveloped-signature", "http://www.w3.org/2001/10/xml-exc-c14n#"];
 

--- a/lib/security/WSSecurityCert.js
+++ b/lib/security/WSSecurityCert.js
@@ -44,8 +44,8 @@ function WSSecurityCert(privatePEM, publicP12PEM, password, options) {
     passphrase: password
   };
   this.x509Id = "x509-" + generateId();
-  this.addTimestamp = options.addTimestamp !== undefined ? options.addTimestamp : true;
-  this.signatureTransformations = options.signatureTransformations !== undefined ? options.signatureTransformations
+  this.hasTimeStamp = options.hasTimeStamp || typeof options.hasTimeStamp === 'boolean' ? !!options.hasTimeStamp : true;
+  this.signatureTransformations = options.signatureTransformations && Array.isArray(options.signatureTransformations) ? options.signatureTransformations
     : ["http://www.w3.org/2000/09/xmldsig#enveloped-signature", "http://www.w3.org/2001/10/xml-exc-c14n#"];
 
   var _this = this;
@@ -71,7 +71,7 @@ WSSecurityCert.prototype.postProcess = function (xml, envelopeKey) {
     binaryToken: this.publicP12PEM,
     created: this.created,
     expires: this.expires,
-    addTimestamp: this.addTimestamp,
+    hasTimeStamp: this.hasTimeStamp,
     id: this.x509Id
   });
 
@@ -81,7 +81,7 @@ WSSecurityCert.prototype.postProcess = function (xml, envelopeKey) {
 
   this.signer.addReference("//*[name(.)='" + envelopeKey + ":Body']", references);
 
-  if (this.addTimestamp) {
+  if (this.hasTimeStamp) {
     this.signer.addReference("//*[name(.)='wsse:Security']/*[local-name(.)='Timestamp']", references);
   }
 

--- a/lib/security/WSSecurityCert.js
+++ b/lib/security/WSSecurityCert.js
@@ -34,7 +34,8 @@ function generateId() {
   return uuid4().replace(/-/gm, '');
 }
 
-function WSSecurityCert(privatePEM, publicP12PEM, password) {
+function WSSecurityCert(privatePEM, publicP12PEM, password, options) {
+  options = options || { addTimestamp: true };
   this.publicP12PEM = publicP12PEM.toString().replace('-----BEGIN CERTIFICATE-----', '').replace('-----END CERTIFICATE-----', '').replace(/(\r\n|\n|\r)/gm, '');
 
   this.signer = new SignedXml();
@@ -43,6 +44,7 @@ function WSSecurityCert(privatePEM, publicP12PEM, password) {
     passphrase: password
   };
   this.x509Id = "x509-" + generateId();
+  this.addTimestamp = options.addTimestamp;
 
   var _this = this;
   this.signer.keyInfoProvider = {};
@@ -67,6 +69,7 @@ WSSecurityCert.prototype.postProcess = function (xml, envelopeKey) {
     binaryToken: this.publicP12PEM,
     created: this.created,
     expires: this.expires,
+    addTimestamp: this.addTimestamp,
     id: this.x509Id
   });
 
@@ -76,7 +79,10 @@ WSSecurityCert.prototype.postProcess = function (xml, envelopeKey) {
     "http://www.w3.org/2001/10/xml-exc-c14n#"];
 
   this.signer.addReference("//*[name(.)='" + envelopeKey + ":Body']", references);
-  this.signer.addReference("//*[name(.)='wsse:Security']/*[local-name(.)='Timestamp']", references);
+
+  if (this.addTimestamp) {
+    this.signer.addReference("//*[name(.)='wsse:Security']/*[local-name(.)='Timestamp']", references);
+  }
 
   this.signer.computeSignature(xmlWithSec);
 

--- a/lib/security/WSSecurityCert.js
+++ b/lib/security/WSSecurityCert.js
@@ -35,7 +35,7 @@ function generateId() {
 }
 
 function WSSecurityCert(privatePEM, publicP12PEM, password, options) {
-  options = options || { addTimestamp: true };
+  options = options || {};
   this.publicP12PEM = publicP12PEM.toString().replace('-----BEGIN CERTIFICATE-----', '').replace('-----END CERTIFICATE-----', '').replace(/(\r\n|\n|\r)/gm, '');
 
   this.signer = new SignedXml();
@@ -44,7 +44,9 @@ function WSSecurityCert(privatePEM, publicP12PEM, password, options) {
     passphrase: password
   };
   this.x509Id = "x509-" + generateId();
-  this.addTimestamp = options.addTimestamp;
+  this.addTimestamp = options.addTimestamp !== undefined ? options.addTimestamp : true;
+  this.signatureTransformations = options.signatureTransformations !== undefined ? options.signatureTransformations
+    : ["http://www.w3.org/2000/09/xmldsig#enveloped-signature", "http://www.w3.org/2001/10/xml-exc-c14n#"];
 
   var _this = this;
   this.signer.keyInfoProvider = {};
@@ -75,8 +77,7 @@ WSSecurityCert.prototype.postProcess = function (xml, envelopeKey) {
 
   var xmlWithSec = insertStr(secHeader, xml, xml.indexOf('</soap:Header>'));
 
-  var references = ["http://www.w3.org/2000/09/xmldsig#enveloped-signature",
-    "http://www.w3.org/2001/10/xml-exc-c14n#"];
+  var references = this.signatureTransformations;
 
   this.signer.addReference("//*[name(.)='" + envelopeKey + ":Body']", references);
 

--- a/lib/security/WSSecurityCert.js
+++ b/lib/security/WSSecurityCert.js
@@ -44,8 +44,8 @@ function WSSecurityCert(privatePEM, publicP12PEM, password, options) {
     passphrase: password
   };
   this.x509Id = "x509-" + generateId();
-  this.hasTimeStamp = options.hasTimeStamp || typeof options.hasTimeStamp === 'boolean' ? !!options.hasTimeStamp : true;
-  this.signatureTransformations = options.signatureTransformations && Array.isArray(options.signatureTransformations) ? options.signatureTransformations
+  this.hasTimeStamp = typeof options.hasTimeStamp === 'undefined' ? true : !!options.hasTimestamp;
+  this.signatureTransformations = Array.isArray(options.signatureTransformations) ? options.signatureTransformations
     : ["http://www.w3.org/2000/09/xmldsig#enveloped-signature", "http://www.w3.org/2001/10/xml-exc-c14n#"];
 
   var _this = this;

--- a/lib/security/templates/wsse-security-header.ejs
+++ b/lib/security/templates/wsse-security-header.ejs
@@ -5,7 +5,7 @@
                EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary" 
                ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3" 
                wsu:Id="<%-id%>"><%-binaryToken%></wsse:BinarySecurityToken>
-    <% if (addTimestamp === true) { %><Timestamp xmlns="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" Id="_1">
+    <% if (hasTimeStamp === true) { %><Timestamp xmlns="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" Id="_1">
     	<Created><%-created%></Created>
     	<Expires><%-expires%></Expires>
     </Timestamp> <% } %>

--- a/lib/security/templates/wsse-security-header.ejs
+++ b/lib/security/templates/wsse-security-header.ejs
@@ -5,8 +5,8 @@
                EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary" 
                ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3" 
                wsu:Id="<%-id%>"><%-binaryToken%></wsse:BinarySecurityToken>
-    <Timestamp xmlns="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" Id="_1"> 
+    <% if (addTimestamp === true) { %><Timestamp xmlns="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" Id="_1">
     	<Created><%-created%></Created>
     	<Expires><%-expires%></Expires>
-    </Timestamp>
+    </Timestamp> <% } %>
 </wsse:Security>

--- a/lib/security/templates/wsse-security-header.ejs
+++ b/lib/security/templates/wsse-security-header.ejs
@@ -4,8 +4,8 @@
  	<wsse:BinarySecurityToken   
                EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary" 
                ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3" 
-               wsu:Id="<%-id%>"><%-binaryToken%></wsse:BinarySecurityToken>
-    <% if (hasTimeStamp === true) { %><Timestamp xmlns="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" Id="_1">
+               wsu:Id="<%-id%>"><%-binaryToken%></wsse:BinarySecurityToken><% if (hasTimeStamp === true) { %>
+    <Timestamp xmlns="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" Id="_1">
     	<Created><%-created%></Created>
     	<Expires><%-expires%></Expires>
     </Timestamp> <% } %>

--- a/lib/soap.d.ts
+++ b/lib/soap.d.ts
@@ -304,7 +304,7 @@ export class WSSecurity implements ISecurity {
 }
 
 export class WSSecurityCert implements ISecurity {
-    constructor(privatePEM: any, publicP12PEM: any, password: any);
+    constructor(privatePEM: any, publicP12PEM: any, password: any, options?: any);
     addOptions(options: any): void;
     toXML(): string;
 }

--- a/test/security/WSSecurityCert.js
+++ b/test/security/WSSecurityCert.js
@@ -90,13 +90,13 @@ describe('WSSecurityCert', function() {
   });
 
   it('should only add one Reference elements, for Soap Body wsse:Security element when addTimestamp is false', function() {
-    var instance = new WSSecurityCert(key, cert, '', {addTimestamp: false});
+    var instance = new WSSecurityCert(key, cert, '', {hasTimeStamp: false});
     var xml = instance.postProcess('<soap:Header></soap:Header><soap:Body><Body></Body><Timestamp></Timestamp></soap:Body>', 'soap');
     xml.match(/<Reference URI="#/g).should.have.length(1);
   });
 
   it('should have no timestamp when addTimestamp is false', function() {
-    var instance = new WSSecurityCert(key, cert, '', {addTimestamp: false});
+    var instance = new WSSecurityCert(key, cert, '', {hasTimeStamp: false});
     var xml = instance.postProcess('<soap:Header></soap:Header><soap:Body><Body></Body><Timestamp></Timestamp></soap:Body>', 'soap');
     xml.should.not.containEql('<Timestamp xmlns="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" Id="_1">');
     xml.should.not.containEql('<Created>' + instance.created);

--- a/test/security/WSSecurityCert.js
+++ b/test/security/WSSecurityCert.js
@@ -86,7 +86,20 @@ describe('WSSecurityCert', function() {
   it('should only add two Reference elements, for Soap Body and Timestamp inside wsse:Security element', function() {
     var instance = new WSSecurityCert(key, cert, '');
     var xml = instance.postProcess('<soap:Header></soap:Header><soap:Body><Body></Body><Timestamp></Timestamp></soap:Body>', 'soap');
-
     xml.match(/<Reference URI="#/g).should.have.length(2);
+  });
+
+  it('should only add one Reference elements, for Soap Body wsse:Security element when addTimestamp is false', function() {
+    var instance = new WSSecurityCert(key, cert, '', {addTimestamp: false});
+    var xml = instance.postProcess('<soap:Header></soap:Header><soap:Body><Body></Body><Timestamp></Timestamp></soap:Body>', 'soap');
+    xml.match(/<Reference URI="#/g).should.have.length(1);
+  });
+
+  it('should have no timestamp when addTimestamp is false', function() {
+    var instance = new WSSecurityCert(key, cert, '', {addTimestamp: false});
+    var xml = instance.postProcess('<soap:Header></soap:Header><soap:Body><Body></Body><Timestamp></Timestamp></soap:Body>', 'soap');
+    xml.should.not.containEql('<Timestamp xmlns="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" Id="_1">');
+    xml.should.not.containEql('<Created>' + instance.created);
+    xml.should.not.containEql('<Expires>' + instance.expires);
   });
 });


### PR DESCRIPTION
For a client we are writing a Timestamp field is not allowed, and also http://www.w3.org/2000/09/xmldsig#enveloped-signature is not supported. Therefore I made some changes to make both configurable: { hasTimeStamp: false, signatureTransformations: [] }

It should have no breaking changes, and should be fully backwards compatible.