### PR TITLE
fix double transformationentries in WSSecCert

### DIFF
--- a/lib/security/WSSecurityCert.js
+++ b/lib/security/WSSecurityCert.js
@@ -79,10 +79,14 @@ WSSecurityCert.prototype.postProcess = function (xml, envelopeKey) {
 
   var references = this.signatureTransformations;
 
-  this.signer.addReference("//*[name(.)='" + envelopeKey + ":Body']", references);
+  var bodyXpath = "//*[name(.)='" + envelopeKey + ":Body']";
+  if (!this.signer.references.filter(function(ref){ return ref.xpath === bodyXpath; }).length > 0) {
+    this.signer.addReference(bodyXpath, references);
+  }
 
-  if (this.hasTimeStamp) {
-    this.signer.addReference("//*[name(.)='wsse:Security']/*[local-name(.)='Timestamp']", references);
+  var timestampXpath = "//*[name(.)='wsse:Security']/*[local-name(.)='Timestamp']"
+  if (this.hasTimeStamp && !this.signer.references.filter(function(ref){ return ref.xpath === timestampXpath; }).length > 0) {
+    this.signer.addReference(timestampXpath, references);
   }
 
   this.signer.computeSignature(xmlWithSec);

--- a/test/security/WSSecurityCert.js
+++ b/test/security/WSSecurityCert.js
@@ -95,6 +95,13 @@ describe('WSSecurityCert', function() {
     xml.match(/<Reference URI="#/g).should.have.length(1);
   });
 
+  it('double post process should not add extra alments', function() {
+    var instance = new WSSecurityCert(key, cert, '');
+    var _ = instance.postProcess('<soap:Header></soap:Header><soap:Body><Body></Body><Timestamp></Timestamp></soap:Body>', 'soap');
+    var xml = instance.postProcess('<soap:Header></soap:Header><soap:Body><Body></Body><Timestamp></Timestamp></soap:Body>', 'soap');
+    xml.match(/<Reference URI="#/g).should.have.length(2);
+  });
+
   it('should have no timestamp when addTimestamp is false', function() {
     var instance = new WSSecurityCert(key, cert, '', {hasTimeStamp: false});
     var xml = instance.postProcess('<soap:Header></soap:Header><soap:Body><Body></Body><Timestamp></Timestamp></soap:Body>', 'soap');


### PR DESCRIPTION
Upon multiple client calls, everytime the reference is added. This is fixed by checking the xpath on already added references.

I was tempted to add it in the constructor, because it is not likely that one would change the body namespace on an existing client. It would also add some extra changes though ...