### PR TITLE
WSDL: pass error from parsing XML as-is, not only its message

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1047,7 +1047,7 @@ var WSDL = function(definition, uri, options) {
     try {
       fromFunc.call(self, definition);
     } catch (e) {
-      return self.callback(e.message);
+      return self.callback(e);
     }
 
     self.processIncludes(function(err) {

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -51,6 +51,20 @@ wsdlStrictTests['should catch parse error'] = function(done) {
   });
 };
 
+wsdlNonStrictTests['should not give error as string'] = function(done) {
+  soap.createClient(__dirname+'/wsdl/bad.txt', function(err) {
+    assert.notEqual(typeof err, 'string');
+    done();
+  });
+};
+
+wsdlStrictTests['should not give error as string'] = function(done) {
+  soap.createClient(__dirname+'/wsdl/bad.txt', function(err) {
+    assert.notEqual(typeof err, 'string');
+    done();
+  });
+};
+
 wsdlStrictTests['should parse external wsdl'] = function(done) {
   soap.createClient(__dirname+'/wsdl/wsdlImport/main.wsdl', {strict: true}, function(err, client){
     assert.ifError(err);


### PR DESCRIPTION
By passing only error's message, callee losses information about stack,
which is helpful in debugging. Besides, passing string as error breaks
mocha. (See https://github.com/mochajs/mocha/issues/3320)

P.S.: I'm not sure if I should add the test to "should catch parse error" above instead of separating to its own test or not because the content of the new test is essentially copy-pasted from the above test.