### PR TITLE
Handle error http status code without response body

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -398,6 +398,13 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
 
     // If it's not HTML and Soap Body is empty
     if (!obj.html && !obj.Body) {
+      if (response.statusCode >= 400) {
+        var error = new Error('Error http status codes');
+        error.response = response;
+        error.body = body;
+        self.emit('soapError', error, eid);
+        return callback(error, obj, body, obj.Header);
+      }
       return callback(null, obj, body, obj.Header);
     }
 


### PR DESCRIPTION
Prior to v0.24.0 soap client reports error when server returns 404 error without body. This behavior was broken by #986.

And also I suspect that the test case 'Handle non-success http status codes' is invalid and doesn't cover the non-success http status code scenario. I added new test case but didn't remove the old one and let reviewer to check it.