### PR TITLE
Fix build error due to using dependecies not specified in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "author": "Vinay Pulim <v@pulim.com>",
   "dependencies": {
+    "@types/bluebird": "^3.5.24",
     "bluebird": "^3.5.0",
     "concat-stream": "^1.5.1",
     "debug": "^2.6.9",


### PR DESCRIPTION
This package relies upon bluebird types but does not depend on them, giving the error below that is now fixed:

```
node_modules/soap/lib/soap.d.ts(4,34): error TS7016: Could not find a declaration file for module 'bluebird'. 'node_modules/bluebird/js/release/bluebird.js' implicitly has an 'any' type.
  Try `npm install @types/bluebird` if it exists or add a new declaration (.d.ts) file containing `declare module 'bluebird';`
```