### PR TITLE
fix a problem about Multi-Byte character

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -217,7 +217,7 @@ Server.prototype._requestListener = function (req, res) {
       chunks.push(chunk);
     });
     source.on('end', function () {
-      var xml = chunks.join('');
+      var xml = Buffer.concat(chunks).toString();
       var result;
       var error;
       self._processRequestXml(req, res, xml);


### PR DESCRIPTION
If the data contains Multi-Byte character,it may be cut by the tcp packets,then the join function's result will contain some unintelligible text,because it turns the object in the array into string before the concat action.So,we should replace it with the Buffer class's member function concat.