### PR TITLE
Stringify wsdl-related error messages to avoid non-descriptive "[object Object]" output.

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1554,7 +1554,7 @@ WSDL.prototype.xmlToObject = function(xml, callback) {
         string = string || body.Fault.faultstring;
         detail = detail || body.Fault.detail;
 
-        var error = new Error(code + ': ' + string + (detail ? ': ' + detail : ''));
+        var error = new Error(code + ': ' + string + (detail ? ': ' + JSON.stringify(detail) : ''));
 
         error.root = root;
         throw error;

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -820,7 +820,7 @@ var fs = require('fs'),
             server.close();
             server = null;
             assert.ok(err);
-            assert.strictEqual(err.message, 'Test: test error: test detail');
+            assert.strictEqual(err.message, 'Test: test error: "test detail"');
             assert.ok(result);
             assert.ok(body);
             done();


### PR DESCRIPTION
It happens quite often that `body.Fault.detail` is an object. Right now I'm getting validation errors which I can't debug because I can't read into `[object Object]` and parsing `error.root` again only to get the same value of `detail` also doesn't make a lot of sense imo