### PR TITLE
Feature/enable ntlm negotiate

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -9,6 +9,7 @@ var url = require('url');
 var req = require('request');
 var debug = require('debug')('node-soap');
 var httpNtlm = require('httpntlm');
+var httpNtlmNegotiate = require('httpntlm-negotiate');
 
 var VERSION = require('../package.json').version;
 
@@ -117,7 +118,8 @@ HttpClient.prototype.request = function(rurl, data, callback, exheaders, exoptio
     // Not sure if this can be handled in a cleaner way rather than an if/else,
     // will to tidy up if I get chance later, patches welcome - insanityinside
     options.url = rurl;
-    httpNtlm[options.method.toLowerCase()](options, function (err, res) {
+    var http = options.negotiate ? httpNtlmNegotiate : httpNtlm;
+    http[options.method.toLowerCase()](options, function (err, res) {
       if (err) {
         return callback(err);
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -776,6 +776,15 @@
         "underscore": "~1.7.0"
       }
     },
+    "httpntlm-negotiate": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/httpntlm-negotiate/-/httpntlm-negotiate-1.7.6.tgz",
+      "integrity": "sha512-UpoYDo38nTOY77GysYwlhgyJQ5v/YAoIg6NO6K2cvlGARJewDVKrKtkWVjuusvf6gIGD2bx5tB5NqV1eIb3XbQ==",
+      "requires": {
+        "httpreq": ">=0.4.22",
+        "underscore": "~1.7.0"
+      }
+    },
     "httpreq": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.4.24.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "finalhandler": "^1.0.3",
     "lodash": "^4.17.5",
     "httpntlm": "^1.5.2",
+    "httpntlm-negotiate": "^1.7.6",
     "request": ">=2.9.0",
     "sax": ">=0.6",
     "serve-static": "^1.11.1",


### PR DESCRIPTION
Hey! If i tried to connect to a Microsoft Navision webservice, i got the error "Error: Couldn't find NTLM in the message type2 comming from the server".

I debugged, that its because in the Navision HTTP reply header there is no NTLM, instead it use the Negotiate string. Otherwise everything works exactly the same as a normal NTLM connection.

So with this small change, what i provided in this PR, we can use the negotiate option, and then connect to a Navision like this:
client.setSecurity(
    new Soap['NTLMSecurity']({
      username,
      password,
      domain,
      workstation,
      negotiate: true
    })
  );