### PR TITLE
processRequestXml only if req.body is not empty object

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -203,7 +203,7 @@ Server.prototype._requestListener = function (req, res) {
 
     //request body is already provided by an express middleware
     //in this case unzipping should also be done by the express middleware itself
-    if (req.body) {
+    if (req.body && Object.keys(req.body).length > 0) {
       return self._processRequestXml(req, res, req.body.toString());
     }
 

--- a/test/express-server-test.js
+++ b/test/express-server-test.js
@@ -166,3 +166,58 @@ describe('Express server with middleware', function () {
   });
 
 });
+
+
+describe('Express server with bodyParser.json middleware', function () {
+
+  before(function (done) {
+    var wsdl = '<definitions name="HelloService" targetNamespace="http://www.examples.com/wsdl/HelloService.wsdl" xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://www.examples.com/wsdl/HelloService.wsdl" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><message name="SayHelloRequest"><part name="firstName" type="xsd:string"/></message><message name="SayHelloResponse"><part name="greeting" type="xsd:string"/></message><portType name="Hello_PortType"><operation name="sayHello"><input message="tns:SayHelloRequest"/><output message="tns:SayHelloResponse"/></operation></portType><binding name="Hello_Binding" type="tns:Hello_PortType"><soap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/><operation name="sayHello"><soap:operation soapAction="sayHello"/><input><soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:examples:helloservice" use="encoded"/></input><output><soap:body encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:examples:helloservice" use="encoded"/></output></operation></binding><service name="Hello_Service"><documentation>WSDL File for HelloService</documentation><port binding="tns:Hello_Binding" name="Hello_Port"><soap:address location="http://localhost:51515/SayHello/" /></port></service></definitions>';
+    var service = {
+      Hello_Service: {
+        Hello_Port: {
+          sayHello: function (args) {
+            return {
+              greeting: args.firstName
+            };
+          }
+        }
+      }
+    };
+    expressServer = express();
+    expressServer.use(bodyParser.json());
+
+    server = expressServer.listen(51515, function () {
+
+      var soapServer = soap.listen(expressServer, '/SayHello', service, wsdl);
+      url = 'http://' + server.address().address + ':' + server.address().port;
+
+      if (server.address().address === '0.0.0.0' || server.address().address === '::') {
+        url = 'http://127.0.0.1:' + server.address().port;
+      }
+
+      done();
+    });
+  });
+
+  after(function () {
+    server.close();
+  });
+
+  it('should not parse body on bodyParser.json middleware', function (done) {
+    request({
+      url: url + '/SayHello',
+      method: 'POST',
+      headers: {
+        SOAPAction: "sayHello",
+        "Content-Type": 'text/xml; charset="utf-8"'
+      },
+      body: requestXML
+    }, function (err, response, body) {
+      if (err) {
+        throw err;
+      }
+      assert.equal(body, responseXML);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
When using `bodyParser.json()` I get empty req.body object which translate to [Object object] and throws exception 
"Non-whitespace before first tag.\nLine: 0\nColumn: 1\nChar: ["

This PR only uses processRequestXml if req.body is not empty
