### PR TITLE
fix a problem about Multi-Byte character

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -217,7 +217,7 @@ Server.prototype._requestListener = function (req, res) {
       chunks.push(chunk);
     });
     source.on('end', function () {
-      var xml = chunks.join('');
+      var xml = Buffer.concat(chunks).toString();
       var result;
       var error;
       self._processRequestXml(req, res, xml);

--- a/test/post-data-concat-test.js
+++ b/test/post-data-concat-test.js
@@ -7,6 +7,16 @@ var http = require('http');
 
 
 describe('post data concat test', function () {
+    var server = http.createServer(function (req, res) { });
+
+    before(function () {
+        server.listen(51515);
+    });
+
+    after(function () {
+        server.close();
+    });
+
     it('should consider the situation about multi-byte character between two tcp packets', function (done) {
         var check = function (a, b) {
             if (a && b) {
@@ -16,7 +26,6 @@ describe('post data concat test', function () {
         };
 
         var wsdl = 'test/wsdl/default_namespace.wsdl';
-        var server = http.createServer(function (req, res) { });
         var xml = fs.readFileSync(wsdl, 'utf8');
         var service = {
             MyService: {
@@ -29,7 +38,6 @@ describe('post data concat test', function () {
             }
         };
 
-        server.listen(51515);
         soap.listen(server, '/wsdl', service, xml);
 
         var postdata = "";
@@ -42,7 +50,7 @@ describe('post data concat test', function () {
         }, function (error, client) {
             assert(!error);
             client.MyOperation(postdata, function (error, response) {
-                server.close();
+                assert(!error);
             });
         });
 

--- a/test/post-data-concat-test.js
+++ b/test/post-data-concat-test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var fs = require('fs');
+var soap = require('..');
+var assert = require('assert');
+var http = require('http');
+
+
+describe('post data concat test', function () {
+    it('should consider the situation about multi-byte character between two tcp packets', function (done) {
+        var check = function (a, b) {
+            if (a && b) {
+                assert(a === b);
+                done();
+            }
+        };
+
+        var wsdl = 'test/wsdl/default_namespace.wsdl';
+        var server = http.createServer(function (req, res) { });
+        var xml = fs.readFileSync(wsdl, 'utf8');
+        var service = {
+            MyService: {
+                MyServicePort: {
+                    MyOperation: function (arg) {
+                        console.log(arg);
+                        check(arg, postdata);
+                        return "0";
+                    }
+                }
+            }
+        };
+
+        server.listen(51515);
+        soap.listen(server, '/wsdl', service, xml);
+
+        var postdata = "";
+        for (var i = 0; i < 20000; i++) {
+            postdata += "测试";
+        }
+
+        soap.createClient(wsdl, {
+            endpoint: 'http://localhost:51515/wsdl'
+        }, function (error, client) {
+            assert(!error);
+            client.MyOperation(postdata, function (error, response) {
+                server.close();
+            });
+        });
+
+    });
+});
+

--- a/test/post-data-concat-test.js
+++ b/test/post-data-concat-test.js
@@ -22,7 +22,6 @@ describe('post data concat test', function () {
             MyService: {
                 MyServicePort: {
                     MyOperation: function (arg) {
-                        console.log(arg);
                         check(arg, postdata);
                         return "0";
                     }


### PR DESCRIPTION
If the data contains Multi-Byte character,it may be cut by the tcp packets,then the join function's result will contain some unintelligible text,because it turns the object in the array into string before the concat action.So,we should replace it with the Buffer class's member function concat.