### PR TITLE
server: send response to client with res.end()

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -219,6 +219,7 @@ Server options include the below:
 - `ca`: An array of strings or Buffers of trusted certificates in PEM format. If this is omitted several well known "root" CAs will be used, like VeriSign. These are used to authorize connections.
 - `crl` : Either a string or list of strings of PEM encoded CRLs (Certificate Revocation List)
 - `ciphers`: A string describing the ciphers to use or exclude, separated by  :. The default cipher suite is:
+- `enableChunkedEncoding`: A boolean for controlling chunked transfer encoding in response. Some client (such as Windows 10's MDM enrollment SOAP client) is sensitive to transfer-encoding mode and can't accept chunked response. This option let user disable chunked transfer encoding for such a client. Default to `true` for backward compatibility.
 
 ``` javascript
 var xml = require('fs').readFileSync('myservice.wsdl', 'utf8');

--- a/lib/server.js
+++ b/lib/server.js
@@ -40,6 +40,8 @@ var Server = function (server, path, services, wsdl, options) {
   this.suppressStack = options && options.suppressStack;
   this.returnFault = options && options.returnFault;
   this.onewayOptions = options && options.oneWay || {};
+  this.enableChunkedEncoding =
+    options.enableChunkedEncoding === undefined ? true : !!options.enableChunkedEncoding;
 
   if (path[path.length - 1] !== '/')
     path += '/';
@@ -144,11 +146,7 @@ Server.prototype._processRequestXml = function (req, res, xml) {
       self.log("received", xml);
     }
     self._process(xml, req, function (result, statusCode) {
-      if (statusCode) {
-        res.statusCode = statusCode;
-      }
-      res.write(result);
-      res.end();
+      self._sendHttpResponse(res, statusCode, result);
       if (typeof self.log === 'function') {
         self.log("replied", result);
       }
@@ -156,18 +154,14 @@ Server.prototype._processRequestXml = function (req, res, xml) {
   } catch (err) {
     if (err.Fault !== undefined) {
       return self._sendError(err.Fault, function (result, statusCode) {
-        res.statusCode = statusCode || 500;
-        res.write(result);
-        res.end();
+        self._sendHttpResponse(res, statusCode || 500, result);
         if (typeof self.log === 'function') {
           self.log("error", err);
         }
       }, new Date().toISOString());
     } else {
       error = err.stack ? (self.suppressStack === true ? err.message : err.stack) : err;
-      res.statusCode = 500;
-      res.write(error);
-      res.end();
+      self._sendHttpResponse(res, /* statusCode */ 500, error);
       if (typeof self.log === 'function') {
         self.log("error", error);
       }
@@ -516,5 +510,26 @@ Server.prototype._sendError = function (soapFault, callback, includeTimestamp) {
 
   return callback(self._envelope(fault, '', includeTimestamp), statusCode);
 };
+
+Server.prototype._sendHttpResponse = function (res, statusCode, result) {
+  if (statusCode) {
+    res.statusCode = statusCode;
+  }
+
+  /*
+   * Calling res.write(result) follow by res.end() will cause Node.js to use
+   * chunked encoding, while calling res.end(result) directly will cause
+   * Node.js to calculate and send Content-Length header. See
+   * nodejs/node#26005.
+   */
+
+  if (this.enableChunkedEncoding) {
+    res.write(result);
+    res.end();
+  }
+  else {
+    res.end(result);
+  }
+}
 
 exports.Server = Server;

--- a/lib/soap.d.ts
+++ b/lib/soap.d.ts
@@ -97,6 +97,7 @@ export interface IServerOptions extends IWsdlBaseOptions {
     uri?: string;
     suppressStack?: boolean;
     oneWay?: IOneWayOptions;
+    enableChunkedEncoding?: boolean;
     [key: string]: any;
 }
 


### PR DESCRIPTION
Using res.end() to write result instead of res.write() followed by
res.end() will cause node not to use chunked encoding and include
Content-Length header. (See nodejs/node#26005) This small distinction is
important with some client. For example, Windows 10's MDM enrollment
system will not accept chunked response
(https://docs.microsoft.com/en-us/windows/client-management/mdm/on-premise-authentication-device-enrollment).

This might improve compatibility with some other clients, too. However,
there's a small chance that some client may expect the response to be
chunked.