### PR TITLE
npmignore cleanup; adding some types to Client

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ History.md
 PUBLISHING.md
 .*
 /src
+/docs

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
   "types": "./lib/soap.d.ts",
   "directories": {
     "lib": "./lib",
-    "test": "./test",
-    "example": "./src/examples"
+    "test": "./test"
   },
   "scripts": {
     "prepare": "npm run build",

--- a/src/client.ts
+++ b/src/client.ts
@@ -8,7 +8,9 @@ import * as BluebirdPromise from 'bluebird';
 import * as concatStream from 'concat-stream';
 import * as debugBuilder from 'debug';
 import { EventEmitter } from 'events';
+import { IncomingHttpHeaders } from 'http';
 import * as _ from 'lodash';
+import * as request from 'request';
 import { v4 as uuid4 } from 'uuid';
 import { HttpClient, Request } from './http';
 import { IHeaders, IOptions, ISecurity, SoapMethod } from './types';
@@ -46,7 +48,13 @@ export interface Client {
 export class Client extends EventEmitter {
   [method: string]: any;
   /** contains last full soap request for client logging */
-  public lastRequest: string;
+  public lastRequest?: string;
+  public lastMessage?: string;
+  public lastEndpoint?: string;
+  public lastRequestHeaders?: request.Headers;
+  public lastResponse?: any;
+  public lastResponseHeaders?: IncomingHttpHeaders;
+  public lastElapsedTime?: number;
 
   private wsdl: WSDL;
   private httpClient: HttpClient;
@@ -58,12 +66,6 @@ export class Client extends EventEmitter {
   private SOAPAction: string;
   private streamAllowed: boolean;
   private normalizeNames: boolean;
-  private lastMessage: string;
-  private lastEndpoint: string;
-  private lastRequestHeaders;
-  private lastResponse;
-  private lastResponseHeaders;
-  private lastElapsedTime: number;
 
   constructor(wsdl: WSDL, endpoint?: string, options?: IOptions) {
     super();

--- a/src/soap.ts
+++ b/src/soap.ts
@@ -8,7 +8,7 @@ import * as debugBuilder from 'debug';
 import { Client } from './client';
 import * as _security from './security';
 import { Server, ServerType } from './server';
-import { IOptions, IServerOptions } from './types';
+import { IOptions, IServerOptions, IServices } from './types';
 import { open_wsdl, WSDL } from './wsdl';
 
 const debug = debugBuilder('node-soap:soap');
@@ -98,9 +98,9 @@ export function createClientAsync(url: string, options: IOptions, endpoint?: str
   });
 }
 
-export function listen(server: ServerType, path: string, services: any, wsdl: string): Server;
+export function listen(server: ServerType, path: string, services: IServices, wsdl: string): Server;
 export function listen(server: ServerType, options: IServerOptions): Server;
-export function listen(server: ServerType, p2: string | IServerOptions, services?: any, xml?: string): Server {
+export function listen(server: ServerType, p2: string | IServerOptions, services?: IServices, xml?: string): Server {
   let options: IServerOptions;
   let path: string;
   let uri = '';


### PR DESCRIPTION
- Added examples - I personally find example code to be helpful in terms of getting up and running with a new library. I also think it gives the library developer an opportunity to define best practices since it will be copy/pasted by everyone.

- Added `/docs` to `.npmignore` - I think ultimately the project should use an npm white list.

- It looks like the `last*` properties of `Client` should be public so I changed that.