### PR TITLE
adding promise support for server method handlers.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -159,11 +159,21 @@ Note: for versions of node >0.10.X, you may need to specify `{connection: 'keep-
                   };
               },
 
-              // This is how to define an asynchronous function.
+              // This is how to define an asynchronous function with a callback.
               MyAsyncFunction: function(args, callback) {
                   // do some work
                   callback({
                       name: args.name
+                  });
+              },
+
+              // This is how to define an asynchronous function with a Promise.
+              MyPromiseFunction: function(args) {
+                  return new Promise((resolve) => {
+                    // do some work
+                    resolve({
+                      name: args.name
+                    });
                   });
               },
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "cover": "nyc --reporter=lcov --reporter=html --reporter=text mocha --timeout 15000 --exit test/*-test.js test/security/*.js",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js -v",
     "docs": "typedoc --out docs",
-    "test": "mocha -r source-map-support/register --timeout 15000 --bail --exit test/*-test.js test/security/*.js"
+    "test": "mocha --timeout 15000 --bail --exit test/*-test.js test/security/*.js"
   },
   "keywords": [
     "soap"

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,4 @@
--R spec
--u exports
--r should
+--reporter spec
+--ui exports
+--require should
+--require source-map-support/register

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -19,6 +19,14 @@ test.service = {
           throw new Error('triggered server error');
         } else if (args.tickerSymbol === 'Async') {
           return cb({ price: 19.56 });
+        } else if (args.tickerSymbol === 'Promise Error') {
+          return new Promise((resolve, reject) => {
+            reject(new Error('triggered server error'));
+          });
+        } else if (args.tickerSymbol === 'Promise') {
+          return new Promise((resolve) => {
+            resolve({ price: 13.76 });
+          });
         } else if (args.tickerSymbol === 'SOAP Fault v1.2') {
           throw {
             Fault: {
@@ -283,6 +291,29 @@ describe('SOAP Server', function() {
       client.IsValidPrice({ price: 50000 }, function(err, result) {
         assert.ifError(err);
         assert.equal(true, !!(result.valid));
+        done();
+      });
+    });
+  });
+
+  it('should support Promise return result', function(done) {
+    soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
+      assert.ifError(err);
+      client.GetLastTradePrice({ tickerSymbol: 'Promise'}, function(err, result) {
+        assert.ifError(err);
+        assert.equal(13.76, parseFloat(result.price));
+        done();
+      });
+    });
+  });
+
+  it('should support Promise rejection (error)', function(done) {
+    soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
+      assert.ifError(err);
+      client.GetLastTradePrice({ tickerSymbol: 'Promise Error'}, function(err, response, body) {
+        assert.ok(err);
+        assert.strictEqual(err.response, response);
+        assert.strictEqual(err.body, body);
         done();
       });
     });


### PR DESCRIPTION
Allows service method handlers to return a promise.

- Added a test for promise return value.
- moved `--require source-map-support/register` to `mocha.opts` so that it's used all the time.
so running something like `npx mocha test/server-test.js` will also have ts mapping in stack traces.
- updated `Readme.md` with promise example