### PR TITLE
add rsa-sha256 support for WSSecurityCert

### DIFF
--- a/src/security/WSSecurityCert.ts
+++ b/src/security/WSSecurityCert.ts
@@ -54,14 +54,14 @@ export class WSSecurityCert implements ISecurity {
       .replace(/(\r\n|\n|\r)/gm, '');
 
     this.signer = new SignedXml();
-    /*if (options.signatureAlgorithm === 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256') {
+    if (options.signatureAlgorithm === 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256') {
       this.signer.signatureAlgorithm = options.signatureAlgorithm;
       this.signer.addReference(
         "//*[name(.)='soap:Body']",
-        ['http://www.w3.org/2001/10/xml-exc-c14n#'], 
+        ['http://www.w3.org/2001/10/xml-exc-c14n#'],
         'http://www.w3.org/2001/04/xmlenc#sha256'
       );
-    }*/
+    }
     this.signer.signingKey = {
       key: privatePEM,
       passphrase: password,

--- a/src/security/WSSecurityCert.ts
+++ b/src/security/WSSecurityCert.ts
@@ -34,7 +34,6 @@ const oasisBaseUri = 'http://docs.oasis-open.org/wss/2004/01';
 export interface IWSSecurityCertOptions {
   hasTimeStamp?: boolean;
   signatureTransformations?: string[];
-  signatureAlgorithm?: string;
 }
 
 export class WSSecurityCert implements ISecurity {
@@ -54,14 +53,6 @@ export class WSSecurityCert implements ISecurity {
       .replace(/(\r\n|\n|\r)/gm, '');
 
     this.signer = new SignedXml();
-    if (options.signatureAlgorithm === 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256') {
-      this.signer.signatureAlgorithm = options.signatureAlgorithm;
-      this.signer.addReference(
-          "//*[name(.)='soap:Body']",
-          ['http://www.w3.org/2001/10/xml-exc-c14n#'], 
-          'http://www.w3.org/2001/04/xmlenc#sha256'
-      );
-    }
     this.signer.signingKey = {
       key: privatePEM,
       passphrase: password,

--- a/src/security/WSSecurityCert.ts
+++ b/src/security/WSSecurityCert.ts
@@ -57,7 +57,7 @@ export class WSSecurityCert implements ISecurity {
     if (options.signatureAlgorithm === 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256') {
       this.signer.signatureAlgorithm = options.signatureAlgorithm;
       this.signer.addReference(
-        "//*[name(.)='soap:Body']",
+        '//*[name(.)="soap:Body"]',
         ['http://www.w3.org/2001/10/xml-exc-c14n#'],
         'http://www.w3.org/2001/04/xmlenc#sha256',
       );

--- a/src/security/WSSecurityCert.ts
+++ b/src/security/WSSecurityCert.ts
@@ -59,7 +59,7 @@ export class WSSecurityCert implements ISecurity {
       this.signer.addReference(
         "//*[name(.)='soap:Body']",
         ['http://www.w3.org/2001/10/xml-exc-c14n#'],
-        'http://www.w3.org/2001/04/xmlenc#sha256'
+        'http://www.w3.org/2001/04/xmlenc#sha256',
       );
     }
     this.signer.signingKey = {

--- a/src/security/WSSecurityCert.ts
+++ b/src/security/WSSecurityCert.ts
@@ -34,6 +34,7 @@ const oasisBaseUri = 'http://docs.oasis-open.org/wss/2004/01';
 export interface IWSSecurityCertOptions {
   hasTimeStamp?: boolean;
   signatureTransformations?: string[];
+  signatureAlgorithm?: string;
 }
 
 export class WSSecurityCert implements ISecurity {
@@ -53,6 +54,14 @@ export class WSSecurityCert implements ISecurity {
       .replace(/(\r\n|\n|\r)/gm, '');
 
     this.signer = new SignedXml();
+    if (options.signatureAlgorithm === 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256') {
+      this.signer.signatureAlgorithm = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256';
+      this.signer.addReference(
+          "//*[name(.)='soap:Body']",
+          ['http://www.w3.org/2001/10/xml-exc-c14n#'], 
+          'http://www.w3.org/2001/04/xmlenc#sha256'
+      );
+    }
     this.signer.signingKey = {
       key: privatePEM,
       passphrase: password,

--- a/src/security/WSSecurityCert.ts
+++ b/src/security/WSSecurityCert.ts
@@ -55,7 +55,7 @@ export class WSSecurityCert implements ISecurity {
 
     this.signer = new SignedXml();
     if (options.signatureAlgorithm === 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256') {
-      this.signer.signatureAlgorithm = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256';
+      this.signer.signatureAlgorithm = options.signatureAlgorithm;
       this.signer.addReference(
           "//*[name(.)='soap:Body']",
           ['http://www.w3.org/2001/10/xml-exc-c14n#'], 

--- a/src/security/WSSecurityCert.ts
+++ b/src/security/WSSecurityCert.ts
@@ -34,6 +34,7 @@ const oasisBaseUri = 'http://docs.oasis-open.org/wss/2004/01';
 export interface IWSSecurityCertOptions {
   hasTimeStamp?: boolean;
   signatureTransformations?: string[];
+  signatureAlgorithm?: string;
 }
 
 export class WSSecurityCert implements ISecurity {
@@ -53,6 +54,14 @@ export class WSSecurityCert implements ISecurity {
       .replace(/(\r\n|\n|\r)/gm, '');
 
     this.signer = new SignedXml();
+    /*if (options.signatureAlgorithm === 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256') {
+      this.signer.signatureAlgorithm = options.signatureAlgorithm;
+      this.signer.addReference(
+        "//*[name(.)='soap:Body']",
+        ['http://www.w3.org/2001/10/xml-exc-c14n#'], 
+        'http://www.w3.org/2001/04/xmlenc#sha256'
+      );
+    }*/
     this.signer.signingKey = {
       key: privatePEM,
       passphrase: password,

--- a/test/security/WSSecurityCert.js
+++ b/test/security/WSSecurityCert.js
@@ -109,4 +109,10 @@ describe('WSSecurityCert', function() {
     xml.should.not.containEql('<Created>' + instance.created);
     xml.should.not.containEql('<Expires>' + instance.expires);
   });
+
+  it('should use rsa-256 when the signatureAlgorithm option is set to WSSecurityCert', function() {
+    var instance = new WSSecurityCert(key, cert, '', { hasTimeStamp: false, signatureAlgorithm: 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256' });
+    var xml = instance.postProcess('<soap:Header></soap:Header><soap:Body><Body></Body></soap:Body>', 'soap');
+    xml.should.containEql('SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"');
+  });
 });

--- a/test/security/WSSecurityCert.js
+++ b/test/security/WSSecurityCert.js
@@ -110,7 +110,7 @@ describe('WSSecurityCert', function() {
     xml.should.not.containEql('<Expires>' + instance.expires);
   });
 
-  it('should use rsa-256 when the signatureAlgorithm option is set to WSSecurityCert', function() {
+  it('should use rsa-sha256 signature method when the signatureAlgorithm option is set to WSSecurityCert', function() {
     var instance = new WSSecurityCert(key, cert, '', { hasTimeStamp: false, signatureAlgorithm: 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256' });
     var xml = instance.postProcess('<soap:Header></soap:Header><soap:Body><Body></Body></soap:Body>', 'soap');
     xml.should.containEql('SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"');


### PR DESCRIPTION
Looks like the only supported encryption currently supported is rsa-sha1 (default in xml-crypto)
http://www.w3.org/2000/09/xmldsig#rsa-sha1

Added option to specify rsa-sha256
http://www.w3.org/2001/04/xmldsig-more#rsa-sha256