### PR TITLE
Move @types/request to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "sax": ">=0.6",
     "serve-static": "^1.11.1",
     "strip-bom": "^3.0.0",
+    "@types/request": "^2.48.1",
     "uuid": "^3.1.0",
     "xml-crypto": "^1.2.0"
   },
@@ -51,7 +52,6 @@
     "@types/express": "^4.16.1",
     "@types/lodash": "^4.14.122",
     "@types/node": "^11.11.0",
-    "@types/request": "^2.48.1",
     "@types/sax": "^1.0.1",
     "@types/uuid": "^3.4.4",
     "body-parser": "^1.15.2",


### PR DESCRIPTION
soap's d.ts files depend on request. Unfortunately, since request doesn't ship its own types, that means consumers of soap also need @types/request. Currently @types/request is just a dev dependency, which doesn't get installed by `npm install`. The fix is to move `@types/request` to the dependencies list.

The error looks like this:

```
node_modules/soap/lib/client.d.ts(4,26): error TS7016: Could not find a declaration file for module 'request'. '../../../tests/cases/user/soap/node_modules/request/index.js' implicitly has an 'any' type.
```

Note that this only shows up when consumers compile with --strict, which is fairly common.  Typescript's user-code tests include soap and detected it after 0.27 shipped.