### PR TITLE
types: move forceSoap12Headers to IWsdlBaseOptions

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -92,6 +92,8 @@ export interface IWsdlBaseOptions {
   wsdl_headers?: { [key: string]: any };
   /** custom options for the request module on WSDL requests. */
   wsdl_options?: { [key: string]: any };
+  /** set proper headers for SOAP v1.2. */
+  forceSoap12Headers?: boolean;
 }
 
 /** @deprecated use IOptions */
@@ -109,8 +111,6 @@ export interface IOptions extends IWsdlBaseOptions {
   request?: req.RequestAPI<req.Request, req.CoreOptions, req.RequiredUriUrl>;
   stream?: boolean;
   // wsdl options that only work for client
-  /** set proper headers for SOAP v1.2. */
-  forceSoap12Headers?: boolean;
   customDeserializer?: any;
   /** if your wsdl operations contains names with Async suffix, you will need to override the default promise suffix to a custom one, default: Async. */
   overridePromiseSuffix?: string;


### PR DESCRIPTION
"forceSoap12Headers" works on server since bcc41e6. So, this option
should be available to server as well.