### PR TITLE
Fixes for ONVIF Server methods

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -482,7 +482,7 @@ export class Server extends EventEmitter {
         body = this.wsdl.objectToRpcXML(outputName, result, '', this.wsdl.definitions.$targetNamespace);
       } else {
         const element = this.wsdl.definitions.services[serviceName].ports[portName].binding.methods[methodName].output;
-        body = this.wsdl.objectToDocumentXML(outputName, result, element.targetNSAlias, element.targetNamespace);
+        body = this.wsdl.objectToDocumentXML(outputName, result, element.targetNSAlias, element.targetNamespace, outputName);
       }
       callback(this._envelope(body, headers, includeTimestamp));
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,6 +92,8 @@ export interface IWsdlBaseOptions {
   wsdl_headers?: { [key: string]: any };
   /** custom options for the request module on WSDL requests. */
   wsdl_options?: { [key: string]: any };
+  /** set proper headers for SOAP v1.2. */
+  forceSoap12Headers?: boolean;
 }
 
 /** @deprecated use IOptions */
@@ -109,8 +111,6 @@ export interface IOptions extends IWsdlBaseOptions {
   request?: req.RequestAPI<req.Request, req.CoreOptions, req.RequiredUriUrl>;
   stream?: boolean;
   // wsdl options that only work for client
-  /** set proper headers for SOAP v1.2. */
-  forceSoap12Headers?: boolean;
   customDeserializer?: any;
   /** if your wsdl operations contains names with Async suffix, you will need to override the default promise suffix to a custom one, default: Async. */
   overridePromiseSuffix?: string;

--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -793,7 +793,7 @@ export class WSDL {
                     // Local element
                     childNsURI = childSchemaObject.$targetNamespace;
                     childNsPrefix = nsContext.registerNamespace(childNsURI);
-                    if (this.isIgnoredNameSpace(childNsPrefix)) {
+                    if (this.isIgnoredNameSpace(childNsPrefix) || !childNsURI) {
                       childNsPrefix = nsPrefix;
                     }
                   } else {


### PR DESCRIPTION
I was trying to use this library to create an ONVIF server (similar to the `breeze/rpos` project) and was having similar issues to them as to what this library was doing to some of the XML elements.

These changes pass the tests but I don't know whether they'd affect anyone else's applications. They certainly fixed mine! :-)