### PR TITLE
Added support for parsing of doubles and floats.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "soap",
-  "version": "0.27.1",
+  "version": "0.26.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -195,7 +195,8 @@
     "@types/caseless": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
-      "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A=="
+      "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A==",
+      "dev": true
     },
     "@types/connect": {
       "version": "3.4.32",
@@ -243,6 +244,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
       "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -306,7 +308,8 @@
     "@types/node": {
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.0.tgz",
-      "integrity": "sha512-D5Rt+HXgEywr3RQJcGlZUCTCx1qVbCZpVk3/tOOA6spLNZdGm8BU+zRgdRYDoF1pO3RuXLxADzMrF903JlQXqg=="
+      "integrity": "sha512-D5Rt+HXgEywr3RQJcGlZUCTCx1qVbCZpVk3/tOOA6spLNZdGm8BU+zRgdRYDoF1pO3RuXLxADzMrF903JlQXqg==",
+      "dev": true
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -318,6 +321,7 @@
       "version": "2.48.1",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.1.tgz",
       "integrity": "sha512-ZgEZ1TiD+KGA9LiAAPPJL68Id2UWfeSO62ijSXZjFJArVV+2pKcsVHmrcu+1oiE3q6eDGiFiSolRc4JHoerBBg==",
+      "dev": true,
       "requires": {
         "@types/caseless": "*",
         "@types/form-data": "*",
@@ -357,7 +361,8 @@
     "@types/tough-cookie": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
-      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg=="
+      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==",
+      "dev": true
     },
     "@types/uuid": {
       "version": "3.4.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "soap",
-  "version": "0.26.0",
+  "version": "0.27.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -195,8 +195,7 @@
     "@types/caseless": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
-      "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A==",
-      "dev": true
+      "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A=="
     },
     "@types/connect": {
       "version": "3.4.32",
@@ -244,7 +243,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
       "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -308,8 +306,7 @@
     "@types/node": {
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.0.tgz",
-      "integrity": "sha512-D5Rt+HXgEywr3RQJcGlZUCTCx1qVbCZpVk3/tOOA6spLNZdGm8BU+zRgdRYDoF1pO3RuXLxADzMrF903JlQXqg==",
-      "dev": true
+      "integrity": "sha512-D5Rt+HXgEywr3RQJcGlZUCTCx1qVbCZpVk3/tOOA6spLNZdGm8BU+zRgdRYDoF1pO3RuXLxADzMrF903JlQXqg=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -321,7 +318,6 @@
       "version": "2.48.1",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.1.tgz",
       "integrity": "sha512-ZgEZ1TiD+KGA9LiAAPPJL68Id2UWfeSO62ijSXZjFJArVV+2pKcsVHmrcu+1oiE3q6eDGiFiSolRc4JHoerBBg==",
-      "dev": true,
       "requires": {
         "@types/caseless": "*",
         "@types/form-data": "*",
@@ -361,8 +357,7 @@
     "@types/tough-cookie": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
-      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==",
-      "dev": true
+      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg=="
     },
     "@types/uuid": {
       "version": "3.4.4",

--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -432,6 +432,8 @@ export class WSDL {
       } else {
         if (name === 'int' || name === 'integer') {
           value = parseInt(text, 10);
+        } else if (name === 'double' || name === 'float') {
+          value = Number(text);
         } else if (name === 'bool' || name === 'boolean') {
           value = text.toLowerCase() === 'true' || text === '1';
         } else if (name === 'dateTime' || name === 'date') {

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -45,7 +45,7 @@ test.service = {
             }
           };
         } else {
-          return { price: 19.56 };
+          return { price: 19.56, tax: -1.23 };
         }
       },
 
@@ -256,7 +256,7 @@ describe('SOAP Server', function() {
     soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
       assert.ifError(err);
       var description = client.describe(),
-          expected = { input: { tickerSymbol: "string" }, output:{ price: "float" } };
+          expected = { input: { tickerSymbol: "string" }, output:{ price: "float", tax: "double" } };
       assert.deepEqual(expected , description.StockQuoteService.StockQuotePort.GetLastTradePrice);
       done();
     });
@@ -267,7 +267,8 @@ describe('SOAP Server', function() {
       assert.ifError(err);
       client.GetLastTradePrice({ tickerSymbol: 'AAPL'}, function(err, result) {
         assert.ifError(err);
-        assert.equal(19.56, parseFloat(result.price));
+        assert.strictEqual(19.56, result.price); // float
+        assert.strictEqual(-1.23, result.tax); // double
         done();
       });
     });
@@ -278,7 +279,7 @@ describe('SOAP Server', function() {
       assert.ifError(err);
       client.GetLastTradePrice({ tickerSymbol: 'Async'}, function(err, result) {
         assert.ifError(err);
-        assert.equal(19.56, parseFloat(result.price));
+        assert.strictEqual(19.56, result.price);
         done();
       });
     });
@@ -301,7 +302,7 @@ describe('SOAP Server', function() {
       assert.ifError(err);
       client.GetLastTradePrice({ tickerSymbol: 'Promise'}, function(err, result) {
         assert.ifError(err);
-        assert.equal(13.76, parseFloat(result.price));
+        assert.strictEqual(13.76, result.price);
         done();
       });
     });
@@ -349,7 +350,7 @@ describe('SOAP Server', function() {
       client.addSoapHeader('<SomeToken>123.45</SomeToken>');
       client.GetLastTradePrice({ tickerSymbol: 'AAPL'}, function(err, result) {
         assert.ifError(err);
-        assert.equal(123.45, parseFloat(result.price));
+        assert.strictEqual(123.45, result.price);
         done();
       });
     });
@@ -388,7 +389,7 @@ describe('SOAP Server', function() {
       client.addSoapHeader('<SomeToken>123.45</SomeToken>');
       client.GetLastTradePrice({ tickerSymbol: 'AAPL'}, function(err, result) {
         assert.ifError(err);
-        assert.equal(0, parseFloat(result.price));
+        assert.strictEqual(0, result.price);
         done();
       });
     });

--- a/test/wsdl/strict/stockquote.wsdl
+++ b/test/wsdl/strict/stockquote.wsdl
@@ -20,6 +20,7 @@
               <xsd:complexType>
                   <xsd:all>
                       <xsd:element name="price" type="float"/>
+                      <xsd:element name="tax" type="double"/>
                   </xsd:all>
               </xsd:complexType>
            </xsd:element>


### PR DESCRIPTION
Also package-lock updated due to out-of-date version currently checked into `master`.

Minor tweak to existing tests to better cover the parsing of double and float.

**Background:**

After reviewing the existing very old PR that fixes doubles and floats thought best to create a new one with a slightly different approach

See: https://github.com/vpulim/node-soap/pull/985

I've gone for `Number(text)` instead of `parseFloat(text)` as I think it's safer to throw an error on unexpected characters rather than allowing an assumption.

E.g. "1a" !== 1

There is a good explanation of the pro's con's of `Number()` vs `parseFloat()` here: https://stackoverflow.com/questions/12227594/which-is-better-numberx-or-parsefloatx