### PR TITLE
Lock xml-crypto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "soap",
-  "version": "0.26.0",
+  "version": "0.27.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -195,8 +195,7 @@
     "@types/caseless": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
-      "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A==",
-      "dev": true
+      "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A=="
     },
     "@types/connect": {
       "version": "3.4.32",
@@ -244,7 +243,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
       "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -308,8 +306,7 @@
     "@types/node": {
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.0.tgz",
-      "integrity": "sha512-D5Rt+HXgEywr3RQJcGlZUCTCx1qVbCZpVk3/tOOA6spLNZdGm8BU+zRgdRYDoF1pO3RuXLxADzMrF903JlQXqg==",
-      "dev": true
+      "integrity": "sha512-D5Rt+HXgEywr3RQJcGlZUCTCx1qVbCZpVk3/tOOA6spLNZdGm8BU+zRgdRYDoF1pO3RuXLxADzMrF903JlQXqg=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -321,7 +318,6 @@
       "version": "2.48.1",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.1.tgz",
       "integrity": "sha512-ZgEZ1TiD+KGA9LiAAPPJL68Id2UWfeSO62ijSXZjFJArVV+2pKcsVHmrcu+1oiE3q6eDGiFiSolRc4JHoerBBg==",
-      "dev": true,
       "requires": {
         "@types/caseless": "*",
         "@types/form-data": "*",
@@ -361,8 +357,7 @@
     "@types/tough-cookie": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
-      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==",
-      "dev": true
+      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg=="
     },
     "@types/uuid": {
       "version": "3.4.4",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "strip-bom": "^3.0.0",
     "@types/request": "^2.48.1",
     "uuid": "^3.1.0",
-    "xml-crypto": "^1.2.0"
+    "xml-crypto": "1.2.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
XML crypto  version 1.4.0 has a breaking change
Locked version to 1.2.0 as that still works with the current version of node soap

This is a less invasive option to Pull request #1066 I submitted