### PR TITLE
Twice soap action qoute

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -365,7 +365,7 @@ export class Client extends EventEmitter {
     }
 
     if (!this.wsdl.options.forceSoap12Headers) {
-      headers.SOAPAction = '"' + soapAction + '"';
+      headers.SOAPAction = soapAction;
     }
 
     options = options || {};


### PR DESCRIPTION
I have issue with soap client, it send bad requests
I inspect network and see that SOAPAction header qouted twice

```
SOAPAction: "\"SOAPAction\""

```

I know that my PR is not good fix, As there is no issue option I make a PR
Sorry for that