### PR TITLE
added possibility to add action to content-type header

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -194,6 +194,7 @@ export class Client extends EventEmitter {
       this.wsdl.options.overrideRootElement = options.overrideRootElement;
     }
     this.wsdl.options.forceSoap12Headers = !!options.forceSoap12Headers;
+    this.wsdl.options.addHeadersAction = !!options.addHeadersAction;
   }
 
   private _defineService(service: ServiceElement, endpoint?: string) {
@@ -351,11 +352,6 @@ export class Client extends EventEmitter {
       return finish(obj, body, response);
     };
 
-    if (this.wsdl.options.forceSoap12Headers) {
-      headers['Content-Type'] = 'application/soap+xml; charset=utf-8';
-      xmlnsSoap = 'xmlns:' + envelopeKey + '="http://www.w3.org/2003/05/soap-envelope"';
-    }
-
     if (this.SOAPAction) {
       soapAction = this.SOAPAction;
     } else if (method.soapAction !== undefined && method.soapAction !== null) {
@@ -364,7 +360,13 @@ export class Client extends EventEmitter {
       soapAction = ((ns.lastIndexOf('/') !== ns.length - 1) ? ns + '/' : ns) + name;
     }
 
-    if (!this.wsdl.options.forceSoap12Headers) {
+    if (this.wsdl.options.forceSoap12Headers) {
+      headers['Content-Type'] = 'application/soap+xml; charset=utf-8';
+      if (this.wsdl.options.addHeadersAction) {
+        headers['Content-Type'] += '; action=' + soapAction;
+      }
+      xmlnsSoap = 'xmlns:' + envelopeKey + '="http://www.w3.org/2003/05/soap-envelope"';
+    } else {
       headers.SOAPAction = '"' + soapAction + '"';
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,6 +94,8 @@ export interface IWsdlBaseOptions {
   wsdl_options?: { [key: string]: any };
   /** set proper headers for SOAP v1.2. */
   forceSoap12Headers?: boolean;
+  /** set content type header action for SOAP v1.2 */
+  addHeadersAction?: boolean;
 }
 
 /** @deprecated use IOptions */

--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -1142,6 +1142,7 @@ export class WSDL {
 
     // Works only in client
     this.options.forceSoap12Headers = options.forceSoap12Headers;
+    this.options.addHeadersAction = options.addHeadersAction;
     this.options.customDeserializer = options.customDeserializer;
 
     if (options.overrideRootElement !== undefined) {

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -430,6 +430,23 @@ var fs = require('fs'),
         }, baseUrl);
       });
 
+      it('should add proper headers for soap12 with action in content type', function (done) {
+        soap.createClient(__dirname + '/wsdl/default_namespace_soap12.wsdl', _.assign({ forceSoap12Headers: true, addHeadersAction: true}, meta.options), function (err, client) {
+          assert.ok(client);
+          assert.ifError(err);
+
+          client.MyOperation({}, function (err, result) {
+            assert.ok(result);
+            assert.ok(client.lastRequestHeaders);
+            assert.ok(client.lastRequest);
+            assert.equal(client.lastRequestHeaders['Content-Type'], 'application/soap+xml; charset=utf-8; action=MyOperation');
+            assert.notEqual(client.lastRequest.indexOf('xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"'), -1);
+            assert(!client.lastRequestHeaders.SOAPAction);
+            done();
+          }, null, { 'test-header': 'test' });
+        }, baseUrl);
+      });
+
       it('should allow calling the method with args, callback, options and extra headers', function (done) {
         soap.createClient(__dirname + '/wsdl/json_response.wsdl', meta.options, function (err, client) {
           assert.ok(client);


### PR DESCRIPTION
I have added support to add soapAction to Content-Type header.

For example:
https://docs.intersystems.com/latest/csp/docbook/DocBook.UI.Page.cls?KEY=ROBJ_method_soapaction

It allows to set Content-Type to `'application/soap+xml; charset=utf-8'; action=Action`

Added option param: `addHeadersAction` that allows to turn this on/off.

