### PR TITLE
added quote to action, updated docs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -134,6 +134,7 @@ The `options` argument allows you to customize the client with the following pro
 - suppressStack: suppress the full stack trace for error messages.
 - returnFault: return an `Invalid XML` SOAP fault on a bad request, default: `false`.
 - forceSoap12Headers: to set proper headers for SOAP v1.2.
+- addHeadersAction: set soapAction in Content-Type header. Works for SOAP 1.2.
 - httpClient: to provide your own http client that implements `request(rurl, data, callback, exheaders, exoptions)`.
 - request: to override the [request](https://github.com/request/request) module.
 - wsdl_headers: custom HTTP headers to be sent on WSDL requests.

--- a/src/client.ts
+++ b/src/client.ts
@@ -363,7 +363,7 @@ export class Client extends EventEmitter {
     if (this.wsdl.options.forceSoap12Headers) {
       headers['Content-Type'] = 'application/soap+xml; charset=utf-8';
       if (this.wsdl.options.addHeadersAction) {
-        headers['Content-Type'] += '; action=' + soapAction;
+        headers['Content-Type'] += `; action="${soapAction}"`;
       }
       xmlnsSoap = 'xmlns:' + envelopeKey + '="http://www.w3.org/2003/05/soap-envelope"';
     } else {

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -439,7 +439,7 @@ var fs = require('fs'),
             assert.ok(result);
             assert.ok(client.lastRequestHeaders);
             assert.ok(client.lastRequest);
-            assert.equal(client.lastRequestHeaders['Content-Type'], 'application/soap+xml; charset=utf-8; action=MyOperation');
+            assert.equal(client.lastRequestHeaders['Content-Type'], 'application/soap+xml; charset=utf-8; action="MyOperation"');
             assert.notEqual(client.lastRequest.indexOf('xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"'), -1);
             assert(!client.lastRequestHeaders.SOAPAction);
             done();


### PR DESCRIPTION
I missed quotes in header action. 

it should be like this
```
'Content-Type': 'application/soap+xml; charset=utf-8; action="soapAction"'
```

Also updated Readme with option `addHeadersAction`