### PR TITLE
fix for soap 1.2 content-type header, missing action key

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -194,7 +194,6 @@ export class Client extends EventEmitter {
       this.wsdl.options.overrideRootElement = options.overrideRootElement;
     }
     this.wsdl.options.forceSoap12Headers = !!options.forceSoap12Headers;
-    this.wsdl.options.addHeadersAction = !!options.addHeadersAction;
   }
 
   private _defineService(service: ServiceElement, endpoint?: string) {
@@ -361,10 +360,7 @@ export class Client extends EventEmitter {
     }
 
     if (this.wsdl.options.forceSoap12Headers) {
-      headers['Content-Type'] = 'application/soap+xml; charset=utf-8';
-      if (this.wsdl.options.addHeadersAction) {
-        headers['Content-Type'] += '; action=' + soapAction;
-      }
+      headers['Content-Type'] = `application/soap+xml; charset=utf-8; action="${soapAction}"`;
       xmlnsSoap = 'xmlns:' + envelopeKey + '="http://www.w3.org/2003/05/soap-envelope"';
     } else {
       headers.SOAPAction = '"' + soapAction + '"';

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,8 +94,6 @@ export interface IWsdlBaseOptions {
   wsdl_options?: { [key: string]: any };
   /** set proper headers for SOAP v1.2. */
   forceSoap12Headers?: boolean;
-  /** set content type header action for SOAP v1.2 */
-  addHeadersAction?: boolean;
 }
 
 /** @deprecated use IOptions */

--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -1142,7 +1142,6 @@ export class WSDL {
 
     // Works only in client
     this.options.forceSoap12Headers = options.forceSoap12Headers;
-    this.options.addHeadersAction = options.addHeadersAction;
     this.options.customDeserializer = options.customDeserializer;
 
     if (options.overrideRootElement !== undefined) {

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -422,24 +422,7 @@ var fs = require('fs'),
             assert.ok(result);
             assert.ok(client.lastRequestHeaders);
             assert.ok(client.lastRequest);
-            assert.equal(client.lastRequestHeaders['Content-Type'], 'application/soap+xml; charset=utf-8');
-            assert.notEqual(client.lastRequest.indexOf('xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"'), -1);
-            assert(!client.lastRequestHeaders.SOAPAction);
-            done();
-          }, null, { 'test-header': 'test' });
-        }, baseUrl);
-      });
-
-      it('should add proper headers for soap12 with action in content type', function (done) {
-        soap.createClient(__dirname + '/wsdl/default_namespace_soap12.wsdl', _.assign({ forceSoap12Headers: true, addHeadersAction: true}, meta.options), function (err, client) {
-          assert.ok(client);
-          assert.ifError(err);
-
-          client.MyOperation({}, function (err, result) {
-            assert.ok(result);
-            assert.ok(client.lastRequestHeaders);
-            assert.ok(client.lastRequest);
-            assert.equal(client.lastRequestHeaders['Content-Type'], 'application/soap+xml; charset=utf-8; action=MyOperation');
+            assert.equal(client.lastRequestHeaders['Content-Type'], 'application/soap+xml; charset=utf-8; action="MyOperation"');
             assert.notEqual(client.lastRequest.indexOf('xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\"'), -1);
             assert(!client.lastRequestHeaders.SOAPAction);
             done();


### PR DESCRIPTION
The simplified version which will always send `action` in `Content-Type`. Thanks to that many developers will avoid their headaches.

As because there is no information in official documentation if it is optional or when should we add this param, will be safer to send it always