### PR TITLE
Fixes issue with unknown ReadableStream type

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -22,7 +22,7 @@ export interface IAttachment {
   name: string;
   contentId: string;
   mimetype: string;
-  body: ReadableStream;
+  body: NodeJS.ReadableStream;
 }
 
 export type Request = req.Request;


### PR DESCRIPTION
When using the latest `soap` version 0.27.1, I am getting the following error:

```
node_modules/soap/lib/http.d.ts:10:11 - error TS2304: Cannot find name 'ReadableStream'.

10     body: ReadableStream;
```

The proposed change is fixing it. Typescript version 3.5.1