### PR TITLE
Bad description for MessageElement when reference a type

### DIFF
--- a/src/wsdl/elements.ts
+++ b/src/wsdl/elements.ts
@@ -665,8 +665,11 @@ export class MessageElement extends Element {
     if (this.element) {
       return this.element && this.element.description(definitions);
     }
-    const desc = {};
-    desc[this.$name] = this.parts;
+    var desc = {};
+    desc[this.$name] = {}
+    for (const part of Object.keys(this.parts)) {
+      desc[this.$name][part] = this.parts[part].description(definitions, this.parts[part].xmlns);
+    }
     return desc;
   }
 


### PR DESCRIPTION
When generating the description of MessageElement, the description of each parts are not call and return a return the object not the description. This issue happens when the part references a type.

With the wsdl-to-ts project, this generates bad interface : https://github.com/TimLuq/wsdl-to-ts/issues/7