### PR TITLE
Fix description for recursive wsdl with extended element

### DIFF
--- a/src/wsdl/elements.ts
+++ b/src/wsdl/elements.ts
@@ -408,7 +408,7 @@ export class ExtensionElement extends Element {
 
         if (typeElement) {
           const base = typeElement.description(definitions, schema.xmlns);
-          desc = typeof base === 'string' ? base : _.defaultsDeep(base, desc);
+          desc = typeof base === 'string' ? base : _.defaults(base, desc);
         }
       }
     }

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -231,4 +231,14 @@ describe('WSDL Parser (non-strict)', () => {
       });
     });
   });
+  
+  it('should describe recursive wsdl with extended elements', (done) => {
+    soap.createClient(__dirname+'/wsdl/extended_recursive.wsdl', function(err, client) {
+      assert.ifError(err);
+      var desc = client.describe();		
+      var personDescription = desc.Service1.BasicHttpBinding_IService1.GetPerson.output.GetPersonResult;
+      assert.equal(personDescription, personDescription.Department.HeadOfDepartment);
+      done();
+    });
+  });  
 });

--- a/test/wsdl/extended_recursive.wsdl
+++ b/test/wsdl/extended_recursive.wsdl
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="Service1" targetNamespace="http://tempuri.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:tns="http://tempuri.org/" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://tempuri.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:import namespace="http://schemas.datacontract.org/2004/07/RecursiveService"/>
+      <xs:element name="GetPerson">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="name" nillable="true" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="GetPersonResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element minOccurs="0" name="GetPersonResult" nillable="true" type="q1:Person" xmlns:q1="http://schemas.datacontract.org/2004/07/RecursiveService"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    <xs:schema attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/">
+      <xs:element name="anyType" nillable="true" type="xs:anyType"/>
+      <xs:element name="anyURI" nillable="true" type="xs:anyURI"/>
+      <xs:element name="base64Binary" nillable="true" type="xs:base64Binary"/>
+      <xs:element name="boolean" nillable="true" type="xs:boolean"/>
+      <xs:element name="byte" nillable="true" type="xs:byte"/>
+      <xs:element name="dateTime" nillable="true" type="xs:dateTime"/>
+      <xs:element name="decimal" nillable="true" type="xs:decimal"/>
+      <xs:element name="double" nillable="true" type="xs:double"/>
+      <xs:element name="float" nillable="true" type="xs:float"/>
+      <xs:element name="int" nillable="true" type="xs:int"/>
+      <xs:element name="long" nillable="true" type="xs:long"/>
+      <xs:element name="QName" nillable="true" type="xs:QName"/>
+      <xs:element name="short" nillable="true" type="xs:short"/>
+      <xs:element name="string" nillable="true" type="xs:string"/>
+      <xs:element name="unsignedByte" nillable="true" type="xs:unsignedByte"/>
+      <xs:element name="unsignedInt" nillable="true" type="xs:unsignedInt"/>
+      <xs:element name="unsignedLong" nillable="true" type="xs:unsignedLong"/>
+      <xs:element name="unsignedShort" nillable="true" type="xs:unsignedShort"/>
+      <xs:element name="char" nillable="true" type="tns:char"/>
+      <xs:simpleType name="char">
+        <xs:restriction base="xs:int"/>
+      </xs:simpleType>
+      <xs:element name="duration" nillable="true" type="tns:duration"/>
+      <xs:simpleType name="duration">
+        <xs:restriction base="xs:duration">
+          <xs:pattern value="\-?P(\d*D)?(T(\d*H)?(\d*M)?(\d*(\.\d*)?S)?)?"/>
+          <xs:minInclusive value="-P10675199DT2H48M5.4775808S"/>
+          <xs:maxInclusive value="P10675199DT2H48M5.4775807S"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:element name="guid" nillable="true" type="tns:guid"/>
+      <xs:simpleType name="guid">
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:attribute name="FactoryType" type="xs:QName"/>
+      <xs:attribute name="Id" type="xs:ID"/>
+      <xs:attribute name="Ref" type="xs:IDREF"/>
+    </xs:schema>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://schemas.datacontract.org/2004/07/RecursiveService" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://schemas.datacontract.org/2004/07/RecursiveService">
+      <xs:complexType name="Person">
+        <xs:complexContent mixed="false">
+          <xs:extension base="tns:BaseClass">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="Department" nillable="true" type="tns:Department"/>
+              <xs:element minOccurs="0" name="Name" nillable="true" type="xs:string"/>
+            </xs:sequence>
+          </xs:extension>
+        </xs:complexContent>
+      </xs:complexType>
+      <xs:element name="Person" nillable="true" type="tns:Person"/>
+      <xs:complexType name="BaseClass">
+        <xs:sequence/>
+      </xs:complexType>
+      <xs:element name="BaseClass" nillable="true" type="tns:BaseClass"/>
+      <xs:complexType name="Department">
+        <xs:complexContent mixed="false">
+          <xs:extension base="tns:BaseClass">
+            <xs:sequence>
+              <xs:element minOccurs="0" name="HeadOfDepartment" nillable="true" type="tns:Person"/>
+              <xs:element minOccurs="0" name="Name" nillable="true" type="xs:string"/>
+            </xs:sequence>
+          </xs:extension>
+        </xs:complexContent>
+      </xs:complexType>
+      <xs:element name="Department" nillable="true" type="tns:Department"/>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="IService1_GetPerson_InputMessage">
+    <wsdl:part name="parameters" element="tns:GetPerson"/>
+  </wsdl:message>
+  <wsdl:message name="IService1_GetPerson_OutputMessage">
+    <wsdl:part name="parameters" element="tns:GetPersonResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="IService1">
+    <wsdl:operation name="GetPerson">
+      <wsdl:input wsaw:Action="http://tempuri.org/IService1/GetPerson" message="tns:IService1_GetPerson_InputMessage"/>
+      <wsdl:output wsaw:Action="http://tempuri.org/IService1/GetPersonResponse" message="tns:IService1_GetPerson_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="BasicHttpBinding_IService1" type="tns:IService1">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="GetPerson">
+      <soap:operation soapAction="http://tempuri.org/IService1/GetPerson" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="Service1">
+    <wsdl:port name="BasicHttpBinding_IService1" binding="tns:BasicHttpBinding_IService1">
+      <soap:address location="http://localhost:59117/Service1.svc"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
I found a bug when using a WSDL that includes recursive types combined with extended elements.
The description of recursive objects would be empty because `_.defaultsDeep` creates copies of child objects. Using `_.defaults` only creates the necessary object references and solves the issue.

The testcase shows the problem: We have the types `Person` -> `Department` -> `Person (HeadOfDepartment)`
`personDescription.Department.HeadOfDepartment` would be an empty object, but should be the same object as `personDescription`