### PR TITLE
Adjusts WSDL URL detection to be case insensitive

### DIFF
--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -1169,7 +1169,7 @@ export class WSDL {
     }
 
     let includePath: string;
-    if (!/^https?:/.test(this.uri) && !/^https?:/.test(include.location)) {
+    if (!/^https?:/i.test(this.uri) && !/^https?:/i.test(include.location)) {
       includePath = path.resolve(path.dirname(this.uri), include.location);
     } else {
       includePath = url.resolve(this.uri || '', include.location);
@@ -1368,7 +1368,7 @@ export function open_wsdl(uri: any, p2: WSDLCallback | IOptions, p3?: WSDLCallba
   const request_options = options.wsdl_options;
 
   let wsdl: WSDL;
-  if (!/^https?:/.test(uri)) {
+  if (!/^https?:/i.test(uri)) {
     debug('Reading file: %s', uri);
     fs.readFile(uri, 'utf8', (err, definition) => {
       if (err) {

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -20,6 +20,18 @@ var fs = require('fs'),
       });
     });
 
+    it('should detect uppercase schemas as urls', function(done) {
+      soap.createClient('HTTP://localhost:1', function(err, client) {
+        assert.ok(err)
+        // ECONNREFUSED indicates that the WSDL path is being evaluated as a URL
+        // If instead ENOENT is returned, the WSDL path is being evaluated (incorrectly)
+        // as a file system path
+        assert.equal(err.code, 'ECONNREFUSED');
+
+        done();
+      });
+    });
+
     it('should add and clear soap headers', function (done) {
       soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {
         assert.ok(client);


### PR DESCRIPTION
Per [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3.1), the URL schema (e.g., http:, https:) can be case insensitive. This PR adjusts the URL detection regex to ensure that capitalized schemas (e.g., HTTP, HTTPS) are supported.