### PR TITLE
fixed MTOM removing soap12header

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -87,8 +87,19 @@ export class HttpClient {
 
     if (attachments.length > 0) {
       const start = uuid();
+      let action = null;
+      if (headers['Content-Type'].indexOf("action") > -1) {
+           for (let ct of headers['Content-Type'].split("; ")){
+               if (ct.indexOf("action") > -1){
+                    action = ct;
+               }
+           }
+      }
       headers['Content-Type'] =
         'multipart/related; type="application/xop+xml"; start="<' + start + '>"; start-info="text/xml"; boundary=' + uuid();
+      if (action){
+          headers['Content-Type'] = headers['Content-Type'] + "; " + action;
+      }
       const multipart: any[] = [{
         'Content-Type': 'application/xop+xml; charset=UTF-8; type="text/xml"',
         'Content-ID': '<' + start + '>',

--- a/src/http.ts
+++ b/src/http.ts
@@ -85,20 +85,20 @@ export class HttpClient {
       followAllRedirects: true,
     };
 
-    if (attachments.length > 0) {
+    if (exoptions.alwaysMTOM || attachments.length > 0) {
       const start = uuid();
       let action = null;
-      if (headers['Content-Type'].indexOf("action") > -1) {
-           for (let ct of headers['Content-Type'].split("; ")){
-               if (ct.indexOf("action") > -1){
+      if (headers['Content-Type'].indexOf('action') > -1) {
+           for (const ct of headers['Content-Type'].split('; ')) {
+               if (ct.indexOf('action') > -1) {
                     action = ct;
                }
            }
       }
       headers['Content-Type'] =
         'multipart/related; type="application/xop+xml"; start="<' + start + '>"; start-info="text/xml"; boundary=' + uuid();
-      if (action){
-          headers['Content-Type'] = headers['Content-Type'] + "; " + action;
+      if (action) {
+          headers['Content-Type'] = headers['Content-Type'] + '; ' + action;
       }
       const multipart: any[] = [{
         'Content-Type': 'application/xop+xml; charset=UTF-8; type="text/xml"',


### PR DESCRIPTION
The attachment option added via https://github.com/vpulim/node-soap/pull/1054
was stripping the SOAP 1.2 action header added with _forceSoap12Headers_