### PR TITLE
added forceMTOM option and updated the Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -500,6 +500,19 @@ The `options` object is optional and is passed to the `request`-module.
 Interesting properties might be:
 * `timeout`: Timeout in milliseconds
 * `forever`: Enables keep-alive connections and pools them
+* `attachments`: array of attachment objects. This converts the request into MTOM: _headers['Content-Type']='multipart/related; type="application/xop+xml"; start= ... '_
+  ```
+  [{
+        mimetype: content mimetype,
+        contentId: part id,
+        name: file name,
+        body: binary data
+   },
+    ...
+  ]
+  ```
+* `forceMTOM`: set to True if you want to send the request as MTOM even if you don't have attachments
+    
 
 ### Client.*method*Async(args) - call *method* on the SOAP service.
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -87,8 +87,19 @@ export class HttpClient {
 
     if (attachments.length > 0) {
       const start = uuid();
+      let action = null;
+      if (headers['Content-Type'].indexOf("action") > -1) {
+           for (let ct of headers['Content-Type'].split("; ")){
+               if (ct.indexOf("action") > -1){
+                    action = ct;
+               }
+           }
+      }
       headers['Content-Type'] =
         'multipart/related; type="application/xop+xml"; start="<' + start + '>"; start-info="text/xml"; boundary=' + uuid();
+      if (action){
+          headers['Content-Type'] = headers['Content-Type'] + "; " + action;
+      }
       const multipart: any[] = [{
         'Content-Type': 'application/xop+xml; charset=UTF-8; type="text/xml"',
         'Content-ID': '<' + start + '>',

--- a/src/http.ts
+++ b/src/http.ts
@@ -85,20 +85,20 @@ export class HttpClient {
       followAllRedirects: true,
     };
 
-    if (attachments.length > 0) {
+    if (exoptions.alwaysMTOM || attachments.length > 0) {
       const start = uuid();
       let action = null;
-      if (headers['Content-Type'].indexOf("action") > -1) {
-           for (let ct of headers['Content-Type'].split("; ")){
-               if (ct.indexOf("action") > -1){
+      if (headers['Content-Type'].indexOf('action') > -1) {
+           for (const ct of headers['Content-Type'].split('; ')) {
+               if (ct.indexOf('action') > -1) {
                     action = ct;
                }
            }
       }
       headers['Content-Type'] =
         'multipart/related; type="application/xop+xml"; start="<' + start + '>"; start-info="text/xml"; boundary=' + uuid();
-      if (action){
-          headers['Content-Type'] = headers['Content-Type'] + "; " + action;
+      if (action) {
+          headers['Content-Type'] = headers['Content-Type'] + '; ' + action;
       }
       const multipart: any[] = [{
         'Content-Type': 'application/xop+xml; charset=UTF-8; type="text/xml"',

--- a/src/http.ts
+++ b/src/http.ts
@@ -68,7 +68,7 @@ export class HttpClient {
     const mergeOptions = ['headers'];
     const attachments: IAttachment[] = exoptions.attachments || [];
 
-    if (typeof data === 'string' && attachments.length === 0) {
+    if (typeof data === 'string' && attachments.length === 0 && !exoptions.forceMTOM) {
       headers['Content-Length'] = Buffer.byteLength(data, 'utf8');
       headers['Content-Type'] = 'application/x-www-form-urlencoded';
     }
@@ -85,7 +85,7 @@ export class HttpClient {
       followAllRedirects: true,
     };
 
-    if (exoptions.alwaysMTOM || attachments.length > 0) {
+    if (exoptions.forceMTOM || attachments.length > 0) {
       const start = uuid();
       let action = null;
       if (headers['Content-Type'].indexOf('action') > -1) {
@@ -105,6 +105,7 @@ export class HttpClient {
         'Content-ID': '<' + start + '>',
         'body': data,
       }];
+
       attachments.forEach((attachment) => {
         multipart.push({
           'Content-Type': attachment.mimetype,
@@ -163,7 +164,6 @@ export class HttpClient {
   ) {
     const options = this.buildRequest(rurl, data, exheaders, exoptions);
     let req: req.Request;
-
     if (exoptions !== undefined && exoptions.hasOwnProperty('ntlm')) {
       // sadly when using ntlm nothing to return
       // Not sure if this can be handled in a cleaner way rather than an if/else,


### PR DESCRIPTION
* cleaned some of the previous code (lame console.log leftover)
* added forceMTOM in the request options so that you can send MTOM request even without having binary attachments to the request. Magically enough some services always use MTOM.
* updated the Readme with some info on the `attachments` and `forceMTOM` options