### PR TITLE
Fixes bug where methodName would not be included in the response event

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -372,6 +372,8 @@ export class Server extends EventEmitter {
             this.emit('headers', headers, pair.methodName);
           }
 
+          methodName = pair.methodName;
+
           this._executeMethod({
             serviceName: serviceName,
             portName: portName,

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -379,6 +379,17 @@ describe('SOAP Server', function() {
     });
   });
 
+  it('should emit \'response\' event', function(done) {
+    test.soapServer.on('response', function requestManager(request, methodName) {
+      assert.equal(methodName, 'GetLastTradePrice');
+      done();
+    });
+    soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
+      assert.ifError(err);
+      client.GetLastTradePrice({ tickerSymbol: 'AAPL'}, function() {});
+    });
+  });
+
   it('should emit \'headers\' event', function(done) {
     test.soapServer.on('headers', function headersManager(headers, methodName) {
       assert.equal(methodName, 'GetLastTradePrice');


### PR DESCRIPTION
When the server was not being used in a `rpc` style, the method name would be `undefined` on the `response` event. This fixes that issue and adds a test to ensure that the method name is included when the response event is emitted.