### PR TITLE
Allow a fixed file path for local includes

### DIFF
--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -1170,7 +1170,12 @@ export class WSDL {
 
     let includePath: string;
     if (!/^https?:/i.test(this.uri) && !/^https?:/i.test(include.location)) {
-      includePath = path.resolve(path.dirname(this.uri), include.location);
+      const isFixed = (this.options.wsdl_options !== undefined && this.options.wsdl_options.hasOwnProperty('fixedPath')) ? this.options.wsdl_options.fixedPath : false;
+      if (isFixed) {
+        includePath = path.resolve(path.dirname(this.uri), path.parse(include.location).base);
+      } else {
+        includePath = path.resolve(path.dirname(this.uri), include.location);
+      }
     } else {
       includePath = url.resolve(this.uri || '', include.location);
     }

--- a/test/client-options-fixpath-test.js
+++ b/test/client-options-fixpath-test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var fs = require('fs'),
+    soap = require('..'),
+    http = require('http'),
+    assert = require('assert');
+
+describe('SOAP Client', function() {
+  var options = {
+    'attributesKey': "$attributes",
+    'namespaceArrayElements': false,
+    'wsdl_options': {
+      'fixedPath': true
+    }
+  };
+
+  it('should ignore relative paths from wsdl imports and use a single fixed directory', function(done) {
+    soap.createClient(__dirname+'/wsdl/fixedPath/netsuite.wsdl', options, function(err, client) {
+      assert.ok(client);
+      assert.ifError(err);
+
+      assert.ok(client.wsdl.options.wsdl_options.fixedPath === true);
+      done();
+    });
+  });
+});

--- a/test/wsdl/fixedPath/netsuite.wsdl
+++ b/test/wsdl/fixedPath/netsuite.wsdl
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:tns="urn:platform_2019_1.webservices.netsuite.com" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns="http://schemas.xmlsoap.org/wsdl/" targetNamespace="urn:platform_2019_1.webservices.netsuite.com">
+	<documentation>
+		Release Status: Generally Available
+	</documentation>
+	<types>
+		<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+			<xsd:import namespace="urn:core_2019_1.platform.webservices.netsuite.com" schemaLocation="../../xsd/platform.core.xsd"/>
+		</xsd:schema>
+	</types>
+	<portType name="NetSuitePortType">
+	</portType>
+	<binding name="NetSuiteBinding" type="tns:NetSuitePortType">
+	</binding>
+	<service name="NetSuiteService">
+		<port name="NetSuitePort" binding="tns:NetSuiteBinding">
+			<soap:address location="https://webservices.netsuite.com/services/NetSuitePort_2019_1"/>
+		</port>
+	</service>
+</definitions>

--- a/test/wsdl/fixedPath/platform.core.xsd
+++ b/test/wsdl/fixedPath/platform.core.xsd
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:platformCore="urn:core_2019_1.platform.webservices.netsuite.com" xmlns:platformCoreTyp="urn:types.core_2019_1.platform.webservices.netsuite.com" xmlns:platformFaultTyp="urn:types.faults_2019_1.platform.webservices.netsuite.com" targetNamespace="urn:core_2019_1.platform.webservices.netsuite.com" elementFormDefault="qualified" attributeFormDefault="unqualified">
+    <import namespace="urn:types.core_2019_1.platform.webservices.netsuite.com" schemaLocation="../../../xsd/platform.coreTypes.xsd"/>
+
+</schema>

--- a/test/wsdl/fixedPath/platform.coreTypes.xsd
+++ b/test/wsdl/fixedPath/platform.coreTypes.xsd
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:platformCoreTyp="urn:types.core_2019_1.platform.webservices.netsuite.com" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" targetNamespace="urn:types.core_2019_1.platform.webservices.netsuite.com" elementFormDefault="qualified" attributeFormDefault="unqualified">
+    <!-- Record Types -->
+    <simpleType name="RecordType">
+        <restriction base="xsd:string">          
+        </restriction>
+    </simpleType>
+</schema>


### PR DESCRIPTION
NetSuite wsdl uses relative paths but when downloaded NS flattens all files in a single directory and fails to load.
This option loads all the files from the directory as provided by NetSuite zip file.

Using with node-suitetalk
https://github.com/felipechang/node-suitetalk