### PR TITLE
New XML Signing Options, extra tags to sign and small bug fix

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -864,6 +864,20 @@ WS-Security X509 Certificate support.
   var privateKey = fs.readFileSync(privateKeyPath);
   var publicKey = fs.readFileSync(publicKeyPath);
   var password = ''; // optional password
+  var options = {
+    hasTimeStamp: true,
+    additionalReferences: [
+        'wsa:Action',
+        'wsa:ReplyTo',
+        'wsa:To',
+    ],
+    signerOptions: {
+        prefix: 'ds',
+        attrs: { Id: 'Signature' },
+        existingPrefixes: {
+            wsse: 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd',
+        }
+  }
   var wsSecurity = new soap.WSSecurityCert(privateKey, publicKey, password, options);
   client.setSecurity(wsSecurity);
 ```
@@ -872,8 +886,12 @@ the `options` object is optional and can contain the following properties:
 * `hasTimeStamp`: adds Timestamp element (default: `true`)
 * `signatureTransformations`: sets the Reference Transforms Algorithm (default ['http://www.w3.org/2000/09/xmldsig#enveloped-signature', 'http://www.w3.org/2001/10/xml-exc-c14n#']). Type is a string array
 * `signatureAlgorithm`: set to `http://www.w3.org/2001/04/xmldsig-more#rsa-sha256` to use sha256
-* `signerOptions`: passed options to the XML Signer package - from (https://github.com/yaronn/xml-crypto) 
+* `additionalReferences` : Array of Soap headers that need to be signed.  This need to be added using `client.addSoapHeader('header')`
+* `signerOptions`: passes options to the XML Signer package - from (https://github.com/yaronn/xml-crypto) 
   * `existingPrefixes`: A hash of prefixes and namespaces prefix: namespace that shouldn't be in the signature because they already exist in the xml (default: `{ 'wsse': 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd' }`)
+  * `prefix`: Adds this value as a prefix for the generated signature tags.
+  * `attrs`: A hash of attributes and values attrName: value to add to the signature root node 
+  
 
 ### NTLMSecurity
 

--- a/Readme.md
+++ b/Readme.md
@@ -882,16 +882,144 @@ WS-Security X509 Certificate support.
   client.setSecurity(wsSecurity);
 ```
 
-the `options` object is optional and can contain the following properties:
-* `hasTimeStamp`: adds Timestamp element (default: `true`)
+The `options` object is optional and can contain the following properties:
+* `hasTimeStamp`: Includes Timestamp tags (default: `true`)
 * `signatureTransformations`: sets the Reference Transforms Algorithm (default ['http://www.w3.org/2000/09/xmldsig#enveloped-signature', 'http://www.w3.org/2001/10/xml-exc-c14n#']). Type is a string array
 * `signatureAlgorithm`: set to `http://www.w3.org/2001/04/xmldsig-more#rsa-sha256` to use sha256
-* `additionalReferences` : Array of Soap headers that need to be signed.  This need to be added using `client.addSoapHeader('header')`
-* `signerOptions`: passes options to the XML Signer package - from (https://github.com/yaronn/xml-crypto) 
-  * `existingPrefixes`: A hash of prefixes and namespaces prefix: namespace that shouldn't be in the signature because they already exist in the xml (default: `{ 'wsse': 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd' }`)
-  * `prefix`: Adds this value as a prefix for the generated signature tags.
-  * `attrs`: A hash of attributes and values attrName: value to add to the signature root node 
+* `additionalReferences` : (optional) Array of Soap headers that need to be signed.  This need to be added using `client.addSoapHeader('header')`
+* `signerOptions`: (optional) passes options to the XML Signer package - from (https://github.com/yaronn/xml-crypto) 
+  * `existingPrefixes`: (optional) A hash of prefixes and namespaces prefix: namespace that shouldn't be in the signature because they already exist in the xml (default: `{ 'wsse': 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd' }`)
+  * `prefix`: (optional) Adds this value as a prefix for the generated signature tags.
+  * `attrs`: (optional) A hash of attributes and values attrName: value to add to the signature root node 
   
+#### Option examples
+
+`hasTimeStamp:true` 
+  
+``` xml
+<soap:Header>
+    <wsse:Security soap:mustUnderstand="1">
+        <wsse:BinarySecurityToken>XXX</wsse:BinarySecurityToken>
+        <!-- The Timestamp group of tags are added and signed --> 
+        <Timestamp xmlns="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" Id="Timestamp">
+            <Created>2019-10-01T08:17:50Z</Created>
+            <Expires>2019-10-01T08:27:50Z</Expires>
+        </Timestamp>
+        <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+            <SignedInfo>
+                ...
+                <Reference URI="#Timestamp">
+                    <Transforms>
+                        <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+                        <Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+                    </Transforms>
+                    <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+                    <DigestValue>XyZ=</DigestValue>
+                </Reference>
+            </SignedInfo>
+        </Signature>
+    </wsse:Security>
+</soap:Header>
+```
+
+`additionalReferences: ['To']`
+``` XML
+<soap:Header>
+    <To Id="To">localhost.com</To>
+    <wsse:Security soap:mustUnderstand="1">
+        <wsse:BinarySecurityToken>XXX</wsse:BinarySecurityToken>
+        <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+            <SignedInfo>
+                <CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+                <SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+                <!-- The "To" tag is signed and added as a reference --> 
+                <Reference URI="#To">
+                    <Transforms>
+                        <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+                        <Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+                    </Transforms>
+                    <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+                    <DigestValue>XYZ</DigestValue>
+                </Reference>
+            </SignedInfo>
+            <SignatureValue>
+                Rf6M4F4puQuQHJIPtJz1CZIVvF3qOdpEEcuAiooWkX5ecnAHSf3RW3sOIzFUWW7VOOncJcts/3xr8DuN4+8Wm9hx1MoOcWJ6kyRIdVNbQWLseIcAhxYCntRY57T2TBXzpb0UPA56pry1+TEcnIQXhdIzG5YT+tTVTp+SZHHcnlP5Y+yqnIOH9wzgRvAovbydTYPCODF7Ana9K/7CSGDe7vpVT85CUYUcJE4DfTxaRa9gKkKrBdPN9vFVi0WfxtMF4kv23cZRCZzS5+CoLfPlx3mq65gVXsqH01RLbktNJq9VaQKcZUgapmUCMzrYhqyzUQJ8HrSHqe+ya2GsjlB0VQ==
+            </SignatureValue>
+            <KeyInfo>
+                <wsse:SecurityTokenReference
+                        xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+                    <wsse:Reference URI="#x509-c5c0d213676f4a6ba5e6fa58074eb57a"
+                                    ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3"/>
+                </wsse:SecurityTokenReference>
+            </KeyInfo>
+        </Signature>
+    </wsse:Security>
+</soap:Header>
+```
+
+`signerOptions.prefix:'ds'` 
+
+``` XML
+<soap:Header>
+    <To Id="To">localhost.com</To>
+    <wsse:Security soap:mustUnderstand="1">
+        <wsse:BinarySecurityToken>XXX</wsse:BinarySecurityToken>
+        <!-- Signature and children tags are given the prefix defined. -->
+        <ds:Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+            <ds:SignedInfo>
+                <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+                <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+                <ds:Reference URI="#To">
+                    <ds:Transforms>
+                        <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+                        <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+                    </ds:Transforms>
+                    <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+                    <ds:DigestValue>XYZ</DigestValue>
+                </ds:Reference>
+            </ds:SignedInfo>
+            <ds:SignatureValue>
+                Rf6M4F4puQuQHJIPtJz1CZIVvF3qOdpEEcuAiooWkX5ecnAHSf3RW3sOIzFUWW7VOOncJcts/3xr8DuN4+8Wm9hx1MoOcWJ6kyRIdVNbQWLseIcAhxYCntRY57T2TBXzpb0UPA56pry1+TEcnIQXhdIzG5YT+tTVTp+SZHHcnlP5Y+yqnIOH9wzgRvAovbydTYPCODF7Ana9K/7CSGDe7vpVT85CUYUcJE4DfTxaRa9gKkKrBdPN9vFVi0WfxtMF4kv23cZRCZzS5+CoLfPlx3mq65gVXsqH01RLbktNJq9VaQKcZUgapmUCMzrYhqyzUQJ8HrSHqe+ya2GsjlB0VQ==
+            </ds:SignatureValue>
+            <ds:KeyInfo>
+                <wsse:SecurityTokenReference
+                        xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+                    <wsse:Reference URI="#x509-c5c0d213676f4a6ba5e6fa58074eb57a"
+                                    ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3"/>
+                </wsse:SecurityTokenReference>
+            </ds:KeyInfo>
+        </ds:Signature>
+    </wsse:Security>
+</soap:Header>
+```
+
+`signerOptions.attrs:{ Id: 'signature-100', foo:'bar'}` 
+  
+``` xml
+<soap:Header>
+    <wsse:Security soap:mustUnderstand="1">
+        <wsse:BinarySecurityToken>XXX</wsse:BinarySecurityToken>
+        <!-- The Timestamp group of tags are added and signed --> 
+        <Timestamp xmlns="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" Id="Timestamp">
+            <Created>2019-10-01T08:17:50Z</Created>
+            <Expires>2019-10-01T08:27:50Z</Expires>
+        </Timestamp>
+        <Signature Id="signature-100" foo="bar" xmlns="http://www.w3.org/2000/09/xmldsig#">
+            <SignedInfo>
+                ...
+                <Reference URI="#Timestamp">
+                    <Transforms>
+                        <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+                        <Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+                    </Transforms>
+                    <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+                    <DigestValue>XyZ=</DigestValue>
+                </Reference>
+            </SignedInfo>
+        </Signature>
+    </wsse:Security>
+</soap:Header>
+```
 
 ### NTLMSecurity
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -398,7 +398,7 @@ export class Client extends EventEmitter {
         } else {
           return header;
         }
-      }).join('\n');
+      }).join(' ');
     }
 
     xml = '<?xml version="1.0" encoding="utf-8"?>' +

--- a/src/security/WSSecurityCert.ts
+++ b/src/security/WSSecurityCert.ts
@@ -103,7 +103,7 @@ export class WSSecurityCert implements ISecurity {
         `<wsse:Reference URI="#${this.x509Id}" ValueType="${oasisBaseUri}/oasis-200401-wss-x509-token-profile-1.0#X509v3"/>` +
         `</wsse:SecurityTokenReference>`;
     };
-  };
+  }
 
   public postProcess(xml, envelopeKey) {
     this.created = generateCreated();

--- a/test/security/WSSecurityCert.js
+++ b/test/security/WSSecurityCert.js
@@ -121,12 +121,12 @@ describe('WSSecurityCert', function () {
 
   it('should use default xmlns:wsse if no signerOptions.existingPrefixes is provided', function () {
     var instance = new WSSecurityCert(key, cert, '');
-    var xml = instance.postProcess('<soap:Header></soap:Header><soap:Body><Body></Body><Timestamp></Timestamp></soap:Body>', 'soap')
+    var xml = instance.postProcess('<soap:Header></soap:Header><soap:Body><Body></Body></soap:Body>', 'soap')
     xml.should.containEql('xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"');
   });
   it('should still add wsse if another signerOption attribute is passed through ', function(){
     var instance = new WSSecurityCert(key, cert, '', { signerOptions: { prefix: 'ds'} });
-    var xml = instance.postProcess('<soap:Header></soap:Header><soap:Body><Body></Body><Timestamp></Timestamp></soap:Body>', 'soap')
+    var xml = instance.postProcess('<soap:Header></soap:Header><soap:Body><Body></Body></soap:Body>', 'soap')
     xml.should.containEql('xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"');
     xml.should.containEql('<ds:SignedInfo>');
   });
@@ -137,7 +137,7 @@ describe('WSSecurityCert', function () {
         existingPrefixes: { wsse: 'https://localhost/node-soap.xsd' }
       }
     });
-    var xml = instance.postProcess('<soap:Header></soap:Header><soap:Body><Body></Body><Timestamp></Timestamp></soap:Body>', 'soap')
+    var xml = instance.postProcess('<soap:Header></soap:Header><soap:Body><Body></Body></soap:Body>', 'soap')
     xml.should.containEql('<wsse:SecurityTokenReference xmlns:wsse="https://localhost/node-soap.xsd">');
   });
   it('should contain the prefix to the generated Signature tags', function () {
@@ -146,7 +146,7 @@ describe('WSSecurityCert', function () {
         prefix: 'ds',
       }
     });
-    var xml = instance.postProcess('<soap:Header></soap:Header><soap:Body><Body></Body><Timestamp></Timestamp></soap:Body>', 'soap');
+    var xml = instance.postProcess('<soap:Header></soap:Header><soap:Body><Body></Body></soap:Body>', 'soap');
     xml.should.containEql('<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">');
     xml.should.containEql('<ds:SignedInfo>');
     xml.should.containEql('<ds:CanonicalizationMethod');
@@ -164,7 +164,7 @@ describe('WSSecurityCert', function () {
         attrs: { Id: 'security_123' },
       }
     });
-    var xml = instance.postProcess('<soap:Header></soap:Header><soap:Body><Body></Body><Timestamp></Timestamp></soap:Body>', 'soap');
+    var xml = instance.postProcess('<soap:Header></soap:Header><soap:Body><Body></Body></soap:Body>', 'soap');
     xml.should.containEql('<Signature Id="security_123" xmlns="http://www.w3.org/2000/09/xmldsig#">');
   });
   it('should sign additional headers that are added via additionalReferences', function () {
@@ -174,7 +174,7 @@ describe('WSSecurityCert', function () {
         'Action'
       ],
     });
-    var xml = instance.postProcess('<soap:Header><To Id="To">localhost.com</To><Action Id="action-1234">testing</Action></soap:Header><soap:Body><Body></Body><Timestamp></Timestamp></soap:Body>', 'soap');
+    var xml = instance.postProcess('<soap:Header><To Id="To">localhost.com</To><Action Id="action-1234">testing</Action></soap:Header><soap:Body><Body></Body></soap:Body>', 'soap');
     xml.should.containEql('<Reference URI="#To">');
     xml.should.containEql('<Reference URI="#action-1234">');
   });


### PR DESCRIPTION
Added new Signer Options to add a prefix to the signature tags added in WSSecurityCert
Added new Signer Options to add Attributes to the Signature tag added in WSSecurityCert
Updated the Readme file
Added tests
Change the join from `/n` to `' '` in client _invoke soapheaders.
The new line character stopped the XML from being decoded by a WSE SOAP server