### PR TITLE
Add WSDL xmlns header attribute

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -409,7 +409,7 @@ export class Client extends EventEmitter {
       this.wsdl.xmlnsInEnvelope + '>' +
       ((decodedHeaders || this.security) ?
         (
-          '<' + envelopeKey + ':Header>' +
+          '<' + envelopeKey + ':Header ' + this.wsdl.xmlnsInHeader +'>' +
           (decodedHeaders ? decodedHeaders : '') +
           (this.security && !this.security.postProcess ? this.security.toXML() : '') +
           '</' + envelopeKey + ':Header>'

--- a/src/client.ts
+++ b/src/client.ts
@@ -409,7 +409,7 @@ export class Client extends EventEmitter {
       this.wsdl.xmlnsInEnvelope + '>' +
       ((decodedHeaders || this.security) ?
         (
-          '<' + envelopeKey + ':Header ' + this.wsdl.xmlnsInHeader +'>' +
+          '<' + envelopeKey + ':Header ' + (this.wsdl.xmlnsInHeader || '') +'>' +
           (decodedHeaders ? decodedHeaders : '') +
           (this.security && !this.security.postProcess ? this.security.toXML() : '') +
           '</' + envelopeKey + ':Header>'


### PR DESCRIPTION
I've encounter a case where the SOAP Header value needs to have an xmlns:value attribute. 
In Bing Ads SOAP requests (maybe for every Microsoft Service SOAP api) the xmlns attribute in the header element is required. 

Example request here: https://docs.microsoft.com/en-us/advertising/campaign-management-service/getaccountmigrationstatuses?view=bingads-13#request-header 

This provides a way of adding it through ```client.wsdl.xmlnsInHeader```. 

For above example, ```client.wsdl.xmlnsInHeader = 'xmlns="https://bingads.microsoft.com/CampaignManagement/v13"'```; should work just fine.