### PR TITLE
Add WSDL xmlns header attribute

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -409,7 +409,7 @@ export class Client extends EventEmitter {
       this.wsdl.xmlnsInEnvelope + '>' +
       ((decodedHeaders || this.security) ?
         (
-          '<' + envelopeKey + ':Header>' +
+          '<' + envelopeKey + ':Header ' + (this.wsdl.xmlnsInHeader || '') +'>' +
           (decodedHeaders ? decodedHeaders : '') +
           (this.security && !this.security.postProcess ? this.security.toXML() : '') +
           '</' + envelopeKey + ':Header>'

--- a/src/client.ts
+++ b/src/client.ts
@@ -409,7 +409,7 @@ export class Client extends EventEmitter {
       this.wsdl.xmlnsInEnvelope + '>' +
       ((decodedHeaders || this.security) ?
         (
-          '<' + envelopeKey + ':Header ' + (this.wsdl.xmlnsInHeader || '') +'>' +
+          '<' + envelopeKey + ':Header ' + (this.wsdl.xmlnsInHeader || '') + '>' +
           (decodedHeaders ? decodedHeaders : '') +
           (this.security && !this.security.postProcess ? this.security.toXML() : '') +
           '</' + envelopeKey + ':Header>'

--- a/src/client.ts
+++ b/src/client.ts
@@ -409,7 +409,7 @@ export class Client extends EventEmitter {
       this.wsdl.xmlnsInEnvelope + '>' +
       ((decodedHeaders || this.security) ?
         (
-          '<' + envelopeKey + ':Header ' + (this.wsdl.xmlnsInHeader || '') + '>' +
+          '<' + envelopeKey + ':Header' + (this.wsdl.xmlnsInHeader ? (' ' + this.wsdl.xmlnsInHeader) : '') + '>' +
           (decodedHeaders ? decodedHeaders : '') +
           (this.security && !this.security.postProcess ? this.security.toXML() : '') +
           '</' + envelopeKey + ':Header>'

--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -70,6 +70,7 @@ export class WSDL {
   public valueKey = '$value';
   public xmlKey = '$xml';
   public xmlnsInEnvelope: string;
+  public xmlnsInHeader: string;
   public uri: string;
   public definitions: elements.DefinitionsElement;
   public options: IInitializedOptions;

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -1544,8 +1544,8 @@ it('shall generate correct header for custom defined header arguments', function
     var expectedDefinedHeader = '<soap:Header xmlns="https://example.com/v1">';
 
     client.MyOperation(function(err, result, rawResponse, soapHeader, rawRequest) {
-      var soapHeader = client.lastRequest.match(/<soap:Header xmlns=("(.*?)">)/)[0];
-      assert.ok(soapHeader === expectedDefinedHeader);
+      var definedSoapHeader = client.lastRequest.match(/<soap:Header xmlns=("(.*?)">)/)[0];
+      assert.ok(definedSoapHeader === expectedDefinedHeader);
       done();
     });
   });

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -1537,6 +1537,20 @@ var fs = require('fs'),
   });
 });
 
+it('shall generate correct header for custom defined header arguments', function(done) {
+  soap.createClientAsync(__dirname + '/wsdl/default_namespace.wsdl').then(function (client) {
+    client.addSoapHeader('test-header-namespace')
+    client.wsdl.xmlnsInHeader = 'xmlns="https://example.com/v1"';
+    var expectedDefinedHeader = '<soap:Header xmlns="https://example.com/v1">';
+
+    client.MyOperation(function(err, result, rawResponse, soapHeader, rawRequest) {
+      var soapHeader = client.lastRequest.match(/<soap:Header xmlns=("(.*?)">)/)[0];
+      assert.ok(soapHeader === expectedDefinedHeader);
+      done();
+    });
+  });
+});
+
 it('should create async client without options', function (done) {
   soap.createClientAsync(__dirname + '/wsdl/default_namespace.wsdl').then(function (client) {
     assert.ok(client);


### PR DESCRIPTION
I've encounter a case where the SOAP Header value needs to have an xmlns:value attribute. 
In Bing Ads SOAP requests (maybe for every Microsoft Service SOAP api) the xmlns attribute in the header element is required. 

Example request here: https://docs.microsoft.com/en-us/advertising/campaign-management-service/getaccountmigrationstatuses?view=bingads-13#request-header 

This provides a way of adding it through ```client.wsdl.xmlnsInHeader```. 

For above example, ```client.wsdl.xmlnsInHeader = 'xmlns="https://bingads.microsoft.com/CampaignManagement/v13"'```; should work just fine.