### PR TITLE
Allows SchemaElement instance to use import namespace as targetNamesp…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "soap",
-  "version": "0.29.0",
+  "version": "0.31.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/wsdl/elements.ts
+++ b/src/wsdl/elements.ts
@@ -802,8 +802,10 @@ export class TypesElement extends Element {
   // fix#325
   public addChild(child) {
     assert(child instanceof SchemaElement);
-
-    const targetNamespace = child.$targetNamespace;
+    const targetNamespace = child.$targetNamespace ||
+      child.includes.find(e => {
+        return e.hasOwnProperty("namespace");
+      }).namespace;
 
     if (!this.schemas.hasOwnProperty(targetNamespace)) {
       this.schemas[targetNamespace] = child;

--- a/src/wsdl/elements.ts
+++ b/src/wsdl/elements.ts
@@ -802,10 +802,11 @@ export class TypesElement extends Element {
   // fix#325
   public addChild(child) {
     assert(child instanceof SchemaElement);
+    const childInclude = child.includes.find((e) => {
+      return e.hasOwnProperty('namespace');
+    });
     const targetNamespace = child.$targetNamespace ||
-      child.includes.find(e => {
-        return e.hasOwnProperty("namespace");
-      }).namespace;
+      typeof childInclude !== 'undefined' ? childInclude.namespace : childInclude;
 
     if (!this.schemas.hasOwnProperty(targetNamespace)) {
       this.schemas[targetNamespace] = child;


### PR DESCRIPTION
### Allows SchemaElement instance to use import namespace as targetNamespace when the attribute is not set.

Prevents the following error message when schema elements do not include targetNamespace attribute:

> Target-Namespace "undefined" already in use by another Schema!