### PR TITLE
Allows SchemaElement instance to use import namespace as targetNamesp…

### DIFF
--- a/src/wsdl/elements.ts
+++ b/src/wsdl/elements.ts
@@ -803,12 +803,25 @@ export class TypesElement extends Element {
   public addChild(child) {
     assert(child instanceof SchemaElement);
 
-    const targetNamespace = child.$targetNamespace;
+    const childInclude = child.includes.find((e: object) => {
+      return e.hasOwnProperty('namespace');
+    });
+    const childIncludeNs: string = (
+      (typeof childInclude !== 'undefined' &&
+        childInclude.hasOwnProperty('namespace') &&
+        child instanceof SchemaElement) ?
+        childInclude.namespace :
+        undefined);
+    const targetNamespace = child.$targetNamespace || childIncludeNs;
 
     if (!this.schemas.hasOwnProperty(targetNamespace)) {
       this.schemas[targetNamespace] = child;
     } else {
-      console.error('Target-Namespace "' + targetNamespace + '" already in use by another Schema!');
+      if (targetNamespace === child.$targetNamespace) {
+        this.schemas[targetNamespace] = child;
+      } else {
+        console.error('Target-Namespace "' + targetNamespace + '" already in use by another Schema!');
+      }
     }
   }
 }

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -252,5 +252,16 @@ describe('WSDL Parser (non-strict)', () => {
       )
       done();
     });
+  });
+
+  it('should not return both schemas when targetNamespace is undefined (no imports)', (done) => {
+    soap.createClient(
+      __dirname + "/wsdl/schemas_without_targetnamespace.wsdl",
+      function(err, client) {
+        assert.ifError(err);
+        assert.equal(Object.keys(client.wsdl.definitions.schemas).length, 1);
+        done();
+      }
+    );
   })
 });

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -240,5 +240,17 @@ describe('WSDL Parser (non-strict)', () => {
       assert.equal(personDescription, personDescription.Department.HeadOfDepartment);
       done();
     });
-  });  
+  });
+
+  it('should return the right amount of schemas with no targetNamespace', (done) => {
+    soap.createClient(__dirname+'/wsdl/schema_with_no_targetnamespace.wsdl', function(err, client) {
+      assert.ifError(err);
+      assert.equal(Object.keys(client.wsdl.definitions.schemas).length, 2);
+      assert.ok(
+        client.wsdl.definitions.schemas.hasOwnProperty('http://www.Dummy.com/Common/Types') &&
+        client.wsdl.definitions.schemas.hasOwnProperty('http://www.Dummy.com/Name/Types')
+      )
+      done();
+    });
+  })
 });

--- a/test/wsdl/schema_with_no_targetnamespace.wsdl
+++ b/test/wsdl/schema_with_no_targetnamespace.wsdl
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+xmlns:xs="http://www.w3.org/2001/XMLSchema"
+xmlns:tns="http://www.Dummy.com"  xmlns:n="http://www.Dummy.com/Name/Types"  xmlns:ns="http://schemas.xmlsoap.org/soap/encoding/" targetNamespace="http://www.Dummy.com">
+	<wsdl:types>
+		<xs:schema>
+			<xs:import namespace="http://www.Dummy.com/Common/Types" schemaLocation="./Common.xsd"/>
+        </xs:schema>
+        <xs:schema>
+			<xs:import namespace="http://www.Dummy.com/Name/Types" schemaLocation="./Name.xsd"/>
+		</xs:schema>
+	</wsdl:types>
+	<wsdl:message name="DummyRequest">
+		<wsdl:part name="DummyRequest" element="n:DummyRequest"/>
+	</wsdl:message>
+	<wsdl:message name="DummyResponse">
+		<wsdl:part name="DummyResponse" element="n:DummyResponse"/>
+	</wsdl:message>
+	<wsdl:portType name="DummyPortType">
+		<wsdl:operation name="Dummy">
+			<wsdl:input message="tns:DummyRequest"/>
+			<wsdl:output message="tns:DummyResponse"/>
+		</wsdl:operation>
+	</wsdl:portType>
+	<wsdl:binding name="DummyBinding" type="tns:DummyPortType">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+		<wsdl:operation name="Dummy">
+			<soap:operation soapAction="http://www.Dummy.com#Dummy" style="document"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+		<wsdl:operation name="DummySave">
+			<soap:operation soapAction="http://www.Dummy.com#DummySave" style="document"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:service name="DummyService">
+		<wsdl:port name="DummyPortType" binding="tns:DummyBinding">
+			<soap:address location="http://www.Dummy.com/"/>
+		</wsdl:port>
+	</wsdl:service>
+</wsdl:definitions>
+

--- a/test/wsdl/schemas_without_targetnamespace.wsdl
+++ b/test/wsdl/schemas_without_targetnamespace.wsdl
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://www.BuiltinTypes.com/" xmlns:ns="http://schemas.xmlsoap.org/soap/encoding/" targetNamespace="http://www.BuiltinTypes.com/">
+    <wsdl:types>
+        <xs:schema>
+            <xs:element name="dummyId" type="xs:duration" />
+            <xs:element name="dummyDescription" type="xs:dateTime" />
+        </xs:schema>
+        <xs:schema>
+            <xs:element name="anotherId" type="xs:duration" />
+            <xs:element name="anotherDescription" type="xs:dateTime" />
+        </xs:schema>
+    </wsdl:types>
+    <wsdl:message name="DummyRequest">
+        <wsdl:part name="DummyRequest" element="n:DummyRequest" />
+    </wsdl:message>
+    <wsdl:message name="DummyResponse">
+        <wsdl:part name="DummyResponse" element="n:DummyResponse" />
+    </wsdl:message>
+    <wsdl:portType name="DummyPortType">
+        <wsdl:operation name="Dummy">
+            <wsdl:input message="tns:DummyRequest" />
+            <wsdl:output message="tns:DummyResponse" />
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="DummyBinding" type="tns:DummyPortType">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="Dummy">
+            <soap:operation soapAction="http://www.Dummy.com#Dummy" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="DummySave">
+            <soap:operation soapAction="http://www.Dummy.com#DummySave" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="DummyService">
+        <wsdl:port name="DummyPortType" binding="tns:DummyBinding">
+            <soap:address location="http://www.Dummy.com/" />
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
### Allows SchemaElement instance to use import namespace as targetNamespace when the attribute is not set.

Prevents the following error message when schema elements do not include `targetNamespace` attribute:

> Target-Namespace "undefined" already in use by another Schema!

If `targetNamespace` is declared by an import is used in a different schema, it overrides the value for the targetNamespace key.