### PR TITLE
Fix for circular descriptions

### DIFF
--- a/src/wsdl/elements.ts
+++ b/src/wsdl/elements.ts
@@ -224,7 +224,10 @@ export class ElementElement extends Element {
         if (!(typeName in definitions.descriptions.types)) {
 
           let elem: any = {};
-          definitions.descriptions.types[typeName] = elem;
+          if (!this.$ref) {
+            definitions.descriptions.types[typeName] = elem;
+          }
+
           const description = typeElement.description(definitions, xmlns);
           if (typeof description === 'string') {
             elem = description;

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -241,4 +241,22 @@ describe('WSDL Parser (non-strict)', () => {
       done();
     });
   });  
+
+  it('should describe referenced elements with type of the same name', (done) => {
+    soap.createClient(__dirname+'/wsdl/ref_element_same_as_type.wsdl', function(err, client) {
+      assert.ifError(err);
+      var desc = client.describe();		
+      assert.equal(desc.MyService.MyPort.MyOperation.input.ExampleContent.MyID, 'xsd:string');
+      done();
+    });
+  });  
+
+  it('should describe port type', (done) => {
+    soap.createClient(__dirname+'/wsdl/ref_element_same_as_type.wsdl', function(err, client) {
+      assert.ifError(err);
+      var desc = client.wsdl.definitions.portTypes.MyPortType.description(client.wsdl.definitions);		
+      assert.equal(desc.MyOperation.input.ExampleContent.MyID, 'xsd:string');
+      done();
+    });
+  });  
 });

--- a/test/wsdl/ref_element_same_as_type.wsdl
+++ b/test/wsdl/ref_element_same_as_type.wsdl
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:v1="http://www.example.com/v1" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.example.com/v1">
+  <wsdl:types>
+    <xsd:schema targetNamespace="http://www.example.com/v1">
+
+      <xsd:element name="ExampleContent" type="v1:ExampleContent"/>
+      <xsd:element name="ExampleRequest" type="v1:ExampleRequestType"/>
+
+      <xsd:complexType name="ExampleContent">
+        <xsd:sequence>
+          <xsd:element name="MyID" type="xsd:string" />
+        </xsd:sequence>
+      </xsd:complexType>
+
+      <xsd:complexType name="ExampleRequestType">
+        <xsd:sequence>
+          <xsd:element ref="v1:ExampleContent"/>
+        </xsd:sequence>
+      </xsd:complexType>
+
+    </xsd:schema>
+  </wsdl:types>
+
+  <wsdl:message name="InMessage">
+    <wsdl:part element="v1:ExampleRequest" name="parameters"/>
+  </wsdl:message>
+  <wsdl:message name="OutMessage" />
+
+  <wsdl:portType name="MyPortType">
+    <xsd:annotation>Sample Port</xsd:annotation>
+    <wsdl:operation name="MyOperation">
+      <wsdl:input message="v1:InMessage"/>
+      <wsdl:output message="v1:OutMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+
+  <wsdl:binding name="MyBinding" type="v1:MyPortType">
+    <xsd:annotation>Sample Binding</xsd:annotation>
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="MyOperation">
+      <soap:operation soapAction="MyAction" style="document"/>
+      <wsdl:input>
+        <soap:body parts="parameters" use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body parts="parameters" use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+
+  <wsdl:service name="MyService">
+    <wsdl:port binding="v1:MyBinding" name="MyPort">
+      <soap:address location="https://examplelocation.com/myservice"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
There seems to be an edge case when using refs in wsdls like this:
```xml
      <xsd:element name="ExampleContent" type="v1:ExampleContent"/>
      <xsd:element name="ExampleRequest" type="v1:ExampleRequestType"/>

      <xsd:complexType name="ExampleContent">
        <xsd:sequence>
          <xsd:element name="MyID" type="xsd:string" />
        </xsd:sequence>
      </xsd:complexType>

      <xsd:complexType name="ExampleRequestType">
        <xsd:sequence>
          <xsd:element ref="v1:ExampleContent"/>
        </xsd:sequence>
      </xsd:complexType>
```

The reference to `ExampleContent` would cause a circular description because there is an element and type of the same name. 