### PR TITLE
Clear http client header

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -370,9 +370,9 @@ export class Client extends EventEmitter {
 
     // Add extra headers
     if (this.httpHeaders === null) {
-      headers = {}
+      headers = {};
     } else {
-      for (const header in this.httpHeaders ) { headers[header] = this.httpHeaders[header];  }
+      for (const header in this.httpHeaders) { headers[header] = this.httpHeaders[header];  }
       for (const attr in extraHeaders) { headers[attr] = extraHeaders[attr]; }
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -120,7 +120,7 @@ export class Client extends EventEmitter {
   }
 
   public clearHttpHeaders(): void {
-    this.httpHeaders = {};
+    this.httpHeaders = null;
   }
 
   public addBodyAttribute(bodyAttribute: any, name?: string, namespace?: string, xmlns?: string): void {
@@ -278,7 +278,7 @@ export class Client extends EventEmitter {
     let req: Request;
     let soapAction: string;
     const alias = findPrefix(defs.xmlns, ns);
-    const headers: any = {
+    let headers: any = {
       'Content-Type': 'text/xml; charset=utf-8',
     };
     let xmlnsSoap = 'xmlns:' + envelopeKey + '="http://schemas.xmlsoap.org/soap/envelope/"';
@@ -369,8 +369,12 @@ export class Client extends EventEmitter {
     options = options || {};
 
     // Add extra headers
-    for (const header in this.httpHeaders ) { headers[header] = this.httpHeaders[header];  }
-    for (const attr in extraHeaders) { headers[attr] = extraHeaders[attr]; }
+    if (this.httpHeaders === null) {
+      headers = {}
+    } else {
+      for (const header in this.httpHeaders ) { headers[header] = this.httpHeaders[header];  }
+      for (const attr in extraHeaders) { headers[attr] = extraHeaders[attr]; }
+    }
 
     // Allow the security object to add headers
     if (this.security && this.security.addHeaders) {

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -455,6 +455,26 @@ var fs = require('fs'),
         }, baseUrl);
       });
 
+      it ('should remove add httpHeaders after the call', function (done) {
+        soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {
+          assert.ok(client);
+          assert.ifError(err);
+
+          client.addHttpHeader('foo', 'bar');
+          assert.equal(client.getHttpHeaders().foo, 'bar');
+  
+          client.clearHttpHeaders();
+          assert.equal(client.getHttpHeaders(), null);
+
+          client.MyOperation({}, function (err, result) {
+            assert.ok(result);
+            assert.equal(client.lastRequestHeaders.foo, undefined);
+
+            done();
+          });
+        }, baseUrl);
+      });
+
       it('should have rawRequest available in the callback', function (done) {
         soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', meta.options, function (err, client) {
           assert.ok(client);
@@ -674,7 +694,7 @@ var fs = require('fs'),
         assert.equal(client.getHttpHeaders().foo, 'bar');
 
         client.clearHttpHeaders();
-        assert.equal(Object.keys(client.getHttpHeaders()).length, 0);
+        assert.equal(client.getHttpHeaders(), null);
         done();
       });
     });
@@ -1453,7 +1473,7 @@ var fs = require('fs'),
           assert.equal(client.getHttpHeaders().foo, 'bar');
 
           client.clearHttpHeaders();
-          assert.equal(Object.keys(client.getHttpHeaders()).length, 0);
+          assert.equal(client.getHttpHeaders(), null);
           done();
         });
       });


### PR DESCRIPTION
The `public clearHttpHeaders (): void` method in the` client.ts` file does not really remove the Http headers. 
In the `_invoke` method, another variable was created to manage the headers. This variable doesn't even care if the variable `this.httpHeaders` was cleaned by user