### PR TITLE
Fixes bug when envelopeKey is changed and WSSecurityCert is set

### DIFF
--- a/src/security/WSSecurityCert.ts
+++ b/src/security/WSSecurityCert.ts
@@ -129,7 +129,7 @@ export class WSSecurityCert implements ISecurity {
       timestampStr +
       `</wsse:Security>`;
 
-    const xmlWithSec = insertStr(secHeader, xml, xml.indexOf('</soap:Header>'));
+    const xmlWithSec = insertStr(secHeader, xml, xml.indexOf(`</${envelopeKey}:Header>`));
 
     const references = this.signatureTransformations;
 

--- a/test/security/WSSecurityCert.js
+++ b/test/security/WSSecurityCert.js
@@ -178,4 +178,19 @@ describe('WSSecurityCert', function () {
     xml.should.containEql('<Reference URI="#To">');
     xml.should.containEql('<Reference URI="#action-1234">');
   });
+  it('should add a WSSecurity signing block when valid envelopeKey is passed', function () {
+    var instance = new WSSecurityCert(key, cert, '');
+    var xml = instance.postProcess('<soapenv:Header></soapenv:Header><soapenv:Body></soapenv:Body>', 'soapenv');
+    xml.should.containEql('<wsse:Security');
+  });
+  it('should not accept envelopeKey not set in envelope', function () {
+    var xml;
+    try {
+      var instance = new WSSecurityCert(key, cert, '');
+      xml = instance.postProcess('<soapenv:Header></soapenv:Header><soapenv:Body></soapenv:Body>', 'soap');
+    } catch (e) {
+      // do nothing
+    }
+    should(xml).not.be.ok();
+  });
 });


### PR DESCRIPTION
Heyo,

There is a hard coded envelopeKey in WSSecurityCert.postProcess method, and it throws when the envelopeKey for the envelope is not 'soap'.

Thanks!