### PR TITLE
Prefix was not correct when using arrays

### DIFF
--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -767,7 +767,7 @@ export class WSDL {
         }
 
         if (isFirst) {
-          value = this.objectToXML(child, name, nsPrefix, nsURI, false, null, schemaObject, nsContext);
+          value = this.objectToXML(child, name, nsPrefix, nsURI, Array.isArray(child), null, schemaObject, nsContext);
         } else {
 
           if (this.definitions.schemas) {


### PR DESCRIPTION
If using array as parameters then you cannot have a way to prefix the method with namespace using overrideRootElement