### PR TITLE
Bug where no prototypical inheritence chain exists

### DIFF
--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -730,6 +730,10 @@ export class WSDL {
       }
     } else if (typeof obj === 'object') {
       for (name in obj) {
+        // Happens when Object.create(null) is used, it will not inherit the Object prototype
+        if (!obj.hasOwnProperty) {
+          obj = Object.assign({}, obj);
+        }
         if (!obj.hasOwnProperty(name)) { continue; }
         // don't process attributes as element
         if (name === this.options.attributesKey) {

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -240,32 +240,50 @@ describe('WSDL Parser (non-strict)', () => {
       });
     });
   });
-  
+
   it('should describe recursive wsdl with extended elements', (done) => {
     soap.createClient(__dirname+'/wsdl/extended_recursive.wsdl', function(err, client) {
       assert.ifError(err);
-      var desc = client.describe();		
+      var desc = client.describe();
       var personDescription = desc.Service1.BasicHttpBinding_IService1.GetPerson.output.GetPersonResult;
       assert.equal(personDescription, personDescription.Department.HeadOfDepartment);
       done();
     });
-  });  
+  });
 
   it('should describe referenced elements with type of the same name', (done) => {
     soap.createClient(__dirname+'/wsdl/ref_element_same_as_type.wsdl', function(err, client) {
       assert.ifError(err);
-      var desc = client.describe();		
+      var desc = client.describe();
       assert.equal(desc.MyService.MyPort.MyOperation.input.ExampleContent.MyID, 'xsd:string');
       done();
     });
-  });  
+  });
 
   it('should describe port type', (done) => {
     soap.createClient(__dirname+'/wsdl/ref_element_same_as_type.wsdl', function(err, client) {
       assert.ifError(err);
-      var desc = client.wsdl.definitions.portTypes.MyPortType.description(client.wsdl.definitions);		
+      var desc = client.wsdl.definitions.portTypes.MyPortType.description(client.wsdl.definitions);
       assert.equal(desc.MyOperation.input.ExampleContent.MyID, 'xsd:string');
       done();
     });
-  });  
+  });
+
+  it('Should convert objects without prototypical chains to objects with prototypical chains', function () {
+    var noPrototypeObj = Object.create(null);
+    assert.ok(typeof noPrototypeObj.hasOwnProperty === 'undefined');
+    noPrototypeObj.a = 'a';
+    noPrototypeObj.b = 'b';
+    const xml = fs.readFileSync(__dirname + '/wsdl/binding_document.wsdl', 'utf8');
+    var processed = new WSDL(xml, __dirname + '/wsdl/binding_document.wsdl', {});
+    processed.definitions = {
+      schemas: {
+        foo: {}
+      }
+    };
+    var parsed = processed.objectToXML(noPrototypeObj, 'a', 'xsd', 'foo');
+    assert.equal(parsed, '<a>a</a><b>b</b>');
+  });
+
+
 });


### PR DESCRIPTION
- Some transpilers will create objects using `Object.create(null)`.  This creates an object with no prototypical inheritance, so there is no `hasOwnProperty` method on it.

The fix is if that if such an object exists, use `Object.assign` to copy the prototype chain from an empty object into the null created obj.

Otherwise, you just get a TypeError that `obj.hasOwnProperty is not a function`.

Signed-off-by: NoMan2000 <webart.video@gmail.com>