### PR TITLE
Fixed preserveWhitespace not taken in account if text contains only spaces

### DIFF
--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -418,7 +418,7 @@ export class WSDL {
     p.ontext = (text) => {
       const originalText = text;
       text = trim(text);
-      if (!text.length) {
+      if (!text.length && !this.options.preserveWhitespace) {
         return;
       }
 


### PR DESCRIPTION
The preserveWhitespace option is not taken in account if the text only contains spaces. This leads to cases where the returned text should be ' ' but leads to ''.