### PR TITLE
Add overrideImportLocation option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1191,6 +1191,23 @@ soap.createClient(__dirname+'/wsdl/fixedPath/netsuite.wsdl', options, function(e
 });
 ```
 
+### Overriding imports URIs
+
+You can override the URIs of imports in the WSDL by specifying a `overrideImportLocation` function in the WSDL options. This works for both local files where `location` will be a path and for remote sources where `location` will be a URI.
+
+```javascript
+const options ={
+    wsdl_options = {
+        overrideImportLocation: (location) => {
+          return 'https://127.0.0.1/imported-service.wsdl';
+        }
+    }
+};
+soap.createClient('https://127.0.0.1/service.wsdl', options, function(err, client) {
+    // your code
+});
+```
+
 ### Specifying the exact namespace definition of the root element
 In rare cases, you may want to precisely control the namespace definition that is included in the root element.
 

--- a/Readme.md
+++ b/Readme.md
@@ -1191,9 +1191,9 @@ soap.createClient(__dirname+'/wsdl/fixedPath/netsuite.wsdl', options, function(e
 });
 ```
 
-### Overriding imports URIs
+### Overriding import locations
 
-You can override the URIs of imports in the WSDL by specifying a `overrideImportLocation` function in the WSDL options. This works for both local files where `location` will be a path and for remote sources where `location` will be a URI.
+You can override the URIs or paths of imports in the WSDL by specifying a `overrideImportLocation` function in the WSDL options.
 
 ```javascript
 const options ={

--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -1169,6 +1169,10 @@ export class WSDL {
       includePath = url.resolve(this.uri || '', include.location);
     }
 
+    if (this.options.wsdl_options !== undefined && typeof this.options.wsdl_options.overrideImportLocation === 'function') {
+      includePath = this.options.wsdl_options.overrideImportLocation(includePath);
+    }
+
     const options = _.assign({}, this.options);
     // follow supplied ignoredNamespaces option
     options.ignoredNamespaces = this._originalIgnoredNamespaces || this.options.ignoredNamespaces;

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -51,7 +51,7 @@ describe('WSDL Parser (strict)', () => {
     });
   });
 
-  it('should support the overrideImportUri option', (done) => {
+  it('should support the overrideImportLocation option', (done) => {
     const options = {
       strict: true,
       wsdl_options: {

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -51,6 +51,26 @@ describe('WSDL Parser (strict)', () => {
     });
   });
 
+  it('should support the overrideImportUri option', (done) => {
+    const options = {
+      strict: true,
+      wsdl_options: {
+        overrideImportLocation: (location) => {
+          return location.replace('sub.wsdl', 'overridden.wsdl');
+        }
+      },
+      disableCache: true,
+    };
+
+    soap.createClient(__dirname+'/wsdl/wsdlImport/main.wsdl', options, function(err, client){
+      assert.ifError(err);
+      assert.deepEqual(Object.keys(client.wsdl.definitions.schemas),
+        ['http://example.com/', 'http://schemas.microsoft.com/2003/10/Serialization/Arrays']);
+      assert.equal(typeof client.getLatestVersionOverridden, 'function');
+      done();
+    });
+  });
+
   it('should get the parent namespace when parent namespace is empty string', (done) => {
     soap.createClient(__dirname+'/wsdl/marketo.wsdl', {strict: true}, function(err, client){
       assert.ifError(err);

--- a/test/wsdl/wsdlImport/overridden.wsdl
+++ b/test/wsdl/wsdlImport/overridden.wsdl
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions name="IUserRemoteService" targetNamespace="http://example.com/" xmlns:ns1="http://example.com/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <wsdl:types>
+<xs:schema elementFormDefault="unqualified" targetNamespace="http://example.com/" version="1.0" xmlns:tns="http://example.com/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:import schemaLocation="./xsd.xsd" namespace="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+
+<xs:element name="getLatestVersionOverridden" type="tns:getLatestVersionOverridden" />
+<xs:element name="getLatestVersionOverriddenResponse" type="tns:getLatestVersionOverriddenResponse" />
+
+<xs:complexType name="getLatestVersionOverridden">
+<xs:sequence />
+</xs:complexType>
+<xs:complexType name="getLatestVersionOverriddenResponse">
+<xs:sequence>
+<xs:element minOccurs="0" name="return" type="xs:long" />
+</xs:sequence>
+</xs:complexType>
+
+</xs:schema>
+  </wsdl:types>
+  <wsdl:message name="getLatestVersionOverridden">
+    <wsdl:part element="ns1:getLatestVersionOverridden" name="parameters">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getLatestVersionOverriddenResponse">
+<wsdl:part element="ns1:getLatestVersionOverriddenResponse" name="parameters"></wsdl:part>
+</wsdl:message>
+  <wsdl:portType name="IUserRemoteService">
+    <wsdl:operation name="getLatestVersionOverridden">
+      <wsdl:input message="ns1:getLatestVersionOverridden" name="getLatestVersionOverridden">
+    </wsdl:input>
+      <wsdl:output message="ns1:getLatestVersionOverriddenResponse" name="getLatestVersionOverriddenResponse">
+    </wsdl:output>
+    </wsdl:operation>
+
+  </wsdl:portType>
+</wsdl:definitions>


### PR DESCRIPTION
To mock a remote server for tests, I need a way to override both the endpoint used for the SOAP services as well as the URI used in `import` statements inside the WSDL.

The existing `Client.setEndpoint` works for the first case and this adds a new `overrideImportLocation` wsdl option to override the import statements.

I think this option is generally useful, for example if a remotely obtained WSDL imports another unreachable WSDL, it allows users to supply the imported WSDL locally.