### PR TITLE
feat(Server): method called with apply

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "soap",
-  "version": "0.29.0",
+  "version": "0.31.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,7 @@
 import { EventEmitter } from 'events';
 import * as http from 'http';
 import * as url from 'url';
-import { IOneWayOptions, ISecurity, IServerOptions, IServices, ISoapFault, ISoapServiceMethod } from './types';
+import { IOneWayOptions, IServerOptions, IServicePort, IServices, ISoapFault, ISoapServiceMethod } from './types';
 import { findPrefix } from './utils';
 import { WSDL } from './wsdl';
 import { BindingElement, IPort } from './wsdl/elements';
@@ -173,29 +173,29 @@ export class Server extends EventEmitter {
 
   private _processSoapHeader(soapHeader, name, namespace, xmlns) {
     switch (typeof soapHeader) {
-    case 'object':
-      return this.wsdl.objectToXML(soapHeader, name, namespace, xmlns, true);
-    case 'function':
-      const _this = this;
-      // arrow function does not support arguments variable
-      // tslint:disable-next-line
-      return function() {
-        const result = soapHeader.apply(null, arguments);
+      case 'object':
+        return this.wsdl.objectToXML(soapHeader, name, namespace, xmlns, true);
+      case 'function':
+        const _this = this;
+        // arrow function does not support arguments variable
+        // tslint:disable-next-line
+        return function () {
+          const result = soapHeader.apply(null, arguments);
 
-        if (typeof result === 'object') {
-          return _this.wsdl.objectToXML(result, name, namespace, xmlns, true);
-        } else {
-          return result;
-        }
-      };
-    default:
-      return soapHeader;
+          if (typeof result === 'object') {
+            return _this.wsdl.objectToXML(result, name, namespace, xmlns, true);
+          } else {
+            return result;
+          }
+        };
+      default:
+        return soapHeader;
     }
   }
 
   private _initializeOptions(options: IServerOptions) {
     this.wsdl.options.attributesKey = options.attributesKey || 'attributes';
-    this.onewayOptions.statusCode = this.onewayOptions.responseCode || 200;
+    this.onewayOptions.statusCode = this.onewayOptions.responseCode || 200;
     this.onewayOptions.emptyBody = !!this.onewayOptions.emptyBody;
   }
 
@@ -468,6 +468,7 @@ export class Server extends EventEmitter {
     includeTimestamp?,
   ) {
     options = options || {};
+    let port: IServicePort;
     let method: ISoapServiceMethod;
     let body;
     let headers;
@@ -490,6 +491,7 @@ export class Server extends EventEmitter {
 
     try {
       method = this.services[serviceName][portName][methodName];
+      port = this.services[serviceName][portName];
     } catch (error) {
       return callback(this._envelope('', headers, includeTimestamp));
     }
@@ -546,7 +548,7 @@ export class Server extends EventEmitter {
       handleResult(error, result);
     };
 
-    const result = method(args, methodCallback, options.headers, req);
+    const result = method.apply(this, [args, methodCallback, options.headers, req]);
     if (typeof result !== 'undefined') {
       if (isPromiseLike<any>(result)) {
         result.then((value) => {


### PR DESCRIPTION
When using node-soap to create a soap server, one could prefer to declare and instantiate a class and pass that as the service object (_although the current documentation does instruct developers to use anonymous objects_). This would allow us to create more complex service implementations by using methods, properties, etc.

However, right now, doing so results in little gain since methods are being called directly, without correctly setting the "this" variable.

The correction is very simple, though: the owning object for `method` is `port`; it's just a question of instead of invoking it directly, just call `apply` and pass the `port` as it's `this` variable.
