### PR TITLE
fix: serverless-http compatibility

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -239,7 +239,8 @@ export class Server extends EventEmitter {
     }
 
     if (req.method === 'GET') {
-      if (reqQuery && reqQuery.toLowerCase() === '?wsdl') {
+
+      if (reqQuery && reqQuery.startsWith('?wsdl')) {
         if (typeof this.log === 'function') {
           this.log('info', 'Wants the WSDL');
         }


### PR DESCRIPTION
if you use serverless-http to serve soap server the url lib is compiled http://example.com/?wsdl to ?wsdl=.