### PR TITLE
Added MTOM support for multipart/related responses with attachments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "soap",
-  "version": "0.29.0",
+  "version": "0.32.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -170,7 +170,8 @@
     "@types/caseless": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
-      "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A=="
+      "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A==",
+      "dev": true
     },
     "@types/connect": {
       "version": "3.4.32",
@@ -218,6 +219,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
       "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -281,7 +283,8 @@
     "@types/node": {
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.0.tgz",
-      "integrity": "sha512-D5Rt+HXgEywr3RQJcGlZUCTCx1qVbCZpVk3/tOOA6spLNZdGm8BU+zRgdRYDoF1pO3RuXLxADzMrF903JlQXqg=="
+      "integrity": "sha512-D5Rt+HXgEywr3RQJcGlZUCTCx1qVbCZpVk3/tOOA6spLNZdGm8BU+zRgdRYDoF1pO3RuXLxADzMrF903JlQXqg==",
+      "dev": true
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -293,6 +296,7 @@
       "version": "2.48.1",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.1.tgz",
       "integrity": "sha512-ZgEZ1TiD+KGA9LiAAPPJL68Id2UWfeSO62ijSXZjFJArVV+2pKcsVHmrcu+1oiE3q6eDGiFiSolRc4JHoerBBg==",
+      "dev": true,
       "requires": {
         "@types/caseless": "*",
         "@types/form-data": "*",
@@ -332,7 +336,8 @@
     "@types/tough-cookie": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
-      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg=="
+      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==",
+      "dev": true
     },
     "@types/uuid": {
       "version": "3.4.4",
@@ -1257,6 +1262,11 @@
       "requires": {
         "samsam": "~1.1"
       }
+    },
+    "formidable": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
     },
     "forwarded": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "serve-static": "^1.11.1",
     "strip-bom": "^3.0.0",
     "uuid": "^3.1.0",
-    "xml-crypto": "^1.4.0"
+    "xml-crypto": "^1.4.0",
+    "formidable": "^1.2.2"
   },
   "repository": {
     "type": "git",

--- a/src/client.ts
+++ b/src/client.ts
@@ -284,6 +284,10 @@ export class Client extends EventEmitter {
     let xmlnsSoap = 'xmlns:' + envelopeKey + '="http://schemas.xmlsoap.org/soap/envelope/"';
 
     const finish = (obj, body, response) => {
+      if(response.attachments){
+        obj.Body.getContentResponse.return.attachments = response.attachments;
+      }
+        
       let result;
 
       if (!output) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -284,10 +284,10 @@ export class Client extends EventEmitter {
     let xmlnsSoap = 'xmlns:' + envelopeKey + '="http://schemas.xmlsoap.org/soap/envelope/"';
 
     const finish = (obj, body, response) => {
-      if(response.attachments){
+      if (response.attachments) {
         obj.Body.getContentResponse.return.attachments = response.attachments;
       }
-        
+
       let result;
 
       if (!output) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -284,8 +284,9 @@ export class Client extends EventEmitter {
     let xmlnsSoap = 'xmlns:' + envelopeKey + '="http://schemas.xmlsoap.org/soap/envelope/"';
 
     const finish = (obj, body, response) => {
-      if (response.attachments) {
-        obj.Body.getContentResponse.return.attachments = response.attachments;
+      var arr = response.attachments;
+      if (Array.isArray(arr) && arr.length) {
+        obj.Body[name + 'Response'].return.attachments = response.attachments;
       }
 
       let result;

--- a/src/http.ts
+++ b/src/http.ts
@@ -6,7 +6,6 @@
 import * as debugBuilder from 'debug';
 import * as httpNtlm from 'httpntlm';
 import * as _ from 'lodash';
-import * as mimeReader from './mime-reader';
 import * as req from 'request';
 import * as url from 'url';
 import * as uuid from 'uuid/v4';
@@ -14,6 +13,7 @@ import { IHeaders, IOptions } from './types';
 
 const debug = debugBuilder('node-soap');
 const VERSION = require('../package.json').version;
+const mimeReader = require('./mime-reader');
 
 export interface IExOptions {
   [key: string]: any;
@@ -199,7 +199,7 @@ export class HttpClient {
             // use slice() since in http multipart response the first chars are #13#10 which the parser does not expect
             const parts = mimeReader.parse_multipart(res.body.slice(2), boundary);
 
-            //first element.data is xml message of multipart response as a buffer
+            // first element.data is xml message of multipart response as a buffer
             body = parts.shift()['data'].toString('utf8');
 
             // rest of parts are attachments

--- a/src/http.ts
+++ b/src/http.ts
@@ -13,7 +13,7 @@ import { IHeaders, IOptions } from './types';
 
 const debug = debugBuilder('node-soap');
 const VERSION = require('../package.json').version;
-const mimeReader = require('./mime-reader');
+const mimeReader = require('./lib/mime-reader');
 
 export interface IExOptions {
   [key: string]: any;

--- a/src/http.ts
+++ b/src/http.ts
@@ -6,7 +6,7 @@
 import * as debugBuilder from 'debug';
 import * as httpNtlm from 'httpntlm';
 import * as _ from 'lodash';
-import * as mimeReader from './mime-reader.js';
+import * as mimeReader from './mime-reader';
 import * as req from 'request';
 import * as url from 'url';
 import * as uuid from 'uuid/v4';

--- a/src/http.ts
+++ b/src/http.ts
@@ -200,7 +200,8 @@ export class HttpClient {
             const parts = mimeReader.parse_multipart(res.body.slice(2), boundary);
 
             // first element.data is xml message of multipart response as a buffer
-            body = parts.shift()['data'].toString('utf8');
+            let msg = parts.shift().data
+            body = msg.toString('utf8');
 
             // rest of parts are attachments
             res.attachments = parts;

--- a/src/http.ts
+++ b/src/http.ts
@@ -6,6 +6,7 @@
 import * as debugBuilder from 'debug';
 import * as httpNtlm from 'httpntlm';
 import * as _ from 'lodash';
+import * as mimeReader from './mime-reader';
 import * as req from 'request';
 import * as url from 'url';
 import * as uuid from 'uuid/v4';
@@ -13,7 +14,6 @@ import { IHeaders, IOptions } from './types';
 
 const debug = debugBuilder('node-soap');
 const VERSION = require('../package.json').version;
-const mimeReader = require('./lib/mime-reader');
 
 export interface IExOptions {
   [key: string]: any;

--- a/src/http.ts
+++ b/src/http.ts
@@ -197,7 +197,7 @@ export class HttpClient {
             const boundary = b && b.length && b[1];
 
             //use slice() since in http multipart response the first chars are #13#10 which the parser does not expect
-            var parts = mimeReader.parse_multipart(res.body.slice(2), boundary);
+            const parts = mimeReader.parse_multipart(res.body.slice(2), boundary);
 
             //first element.data is xml message of multipart response as a buffer
             body = parts.shift()['data'].toString('utf8');

--- a/src/http.ts
+++ b/src/http.ts
@@ -6,11 +6,11 @@
 import * as debugBuilder from 'debug';
 import * as httpNtlm from 'httpntlm';
 import * as _ from 'lodash';
+import * as mimeReader from './mime-reader.js';
 import * as req from 'request';
 import * as url from 'url';
 import * as uuid from 'uuid/v4';
 import { IHeaders, IOptions } from './types';
-import * as mimeReader from './mime-reader.js';
 
 const debug = debugBuilder('node-soap');
 const VERSION = require('../package.json').version;
@@ -183,29 +183,29 @@ export class HttpClient {
         callback(null, res, res.body);
       });
     } else {
-      //add to options for request to get raw bindary response
+      // add to options for request to get raw bindary response
       options.encoding = null;
       req = this._request(options, (err, res, body) => {
         if (err) {
           return callback(err);
         }
 
-        //look for boundary in headers to see if this is a multipart response
+        // look for boundary in headers to see if this is a multipart response
         const b = res.headers['content-type'].match('boundary=\"(.*?)\"');
-        if(b){
-            //get the value of the boundary
+        if (b) {
+            // get the value of the boundary
             const boundary = b && b.length && b[1];
 
-            //use slice() since in http multipart response the first chars are #13#10 which the parser does not expect
+            // use slice() since in http multipart response the first chars are #13#10 which the parser does not expect
             const parts = mimeReader.parse_multipart(res.body.slice(2), boundary);
 
             //first element.data is xml message of multipart response as a buffer
             body = parts.shift()['data'].toString('utf8');
 
-            //rest of parts are attachments
+            // rest of parts are attachments
             res.attachments = parts;
-        } else { //no boundary found not a multipart response
-            body = body.toString('utf8'); //convert body to utf8 string for node-soap to work
+        } else { // no boundary found not a multipart response
+            body = body.toString('utf8'); // convert body to utf8 string for node-soap to work
         }
 
         body = this.handleResponse(req, res, body);

--- a/src/http.ts
+++ b/src/http.ts
@@ -200,7 +200,7 @@ export class HttpClient {
             const parts = mimeReader.parse_multipart(res.body.slice(2), boundary);
 
             // first element.data is xml message of multipart response as a buffer
-            let msg = parts.shift().data
+            const msg = parts.shift().data
             body = msg.toString('utf8');
 
             // rest of parts are attachments

--- a/src/http.ts
+++ b/src/http.ts
@@ -200,7 +200,7 @@ export class HttpClient {
             const parts = mimeReader.parse_multipart(res.body.slice(2), boundary);
 
             // first element.data is xml message of multipart response as a buffer
-            const msg = parts.shift().data
+            const msg = parts.shift().data;
             body = msg.toString('utf8');
 
             // rest of parts are attachments

--- a/src/mime-reader.js
+++ b/src/mime-reader.js
@@ -30,7 +30,7 @@ const MimeReader = {
       if(parts.length == 0){
           data = new Buffer('');
       } else {
-          tempId = Math.floor(new Date()).toString() + ".bin";
+          tempId = new Date().getTime() + ".bin";
           fd = fs.openSync(tempId, 'a+');
       }
     }

--- a/src/mime-reader.js
+++ b/src/mime-reader.js
@@ -2,22 +2,22 @@
 //https://github.com/yaronn/ws.js/
 //modified to support large files using a temp local file
 
-var MultipartParser = require('formidable/lib/multipart_parser.js').MultipartParser
+const MultipartParser = require('formidable/lib/multipart_parser.js').MultipartParser
   , fs = require('fs')
 
-var MimeReader = {
+const MimeReader = {
 
   parse_multipart: function(payload, boundary) {
-    var parts = []
-    var part
-    var data
-    var headers = []
-    var curr_header_name
-    var curr_header_value
-    var fd
-    var tempId
+    const parts = []
+    const part
+    const data
+    const headers = []
+    const curr_header_name
+    const curr_header_value
+    const fd
+    const tempId
 
-    var parser = new MultipartParser()
+    const parser = new MultipartParser()
     parser.initWithBoundary(boundary)
 
     parser.onPartBegin = function() {

--- a/src/mime-reader.js
+++ b/src/mime-reader.js
@@ -63,13 +63,9 @@ var MimeReader = {
         //treat first part as xml message
         if(parts.length == 0){
             part.data = data;
-            //part.msg = data.toString();
         } else {
             part.localTmpFile = tempId;
-            fs.closeSync(fd, (err => {
-              if(err)
-                  console.log('Failed to close file', err);
-            }));
+            fs.closeSync(fd);
         }
 
       part.headers = headers

--- a/src/mime-reader.js
+++ b/src/mime-reader.js
@@ -63,9 +63,13 @@ var MimeReader = {
         //treat first part as xml message
         if(parts.length == 0){
             part.data = data;
+            //part.msg = data.toString();
         } else {
             part.localTmpFile = tempId;
-            fs.closeSync(fd);
+            fs.closeSync(fd, (err => {
+              if(err)
+                  console.log('Failed to close file', err);
+            }));
         }
 
       part.headers = headers

--- a/src/mime-reader.js
+++ b/src/mime-reader.js
@@ -1,0 +1,88 @@
+//Original code from Yaron Naveh, 
+//https://github.com/yaronn/ws.js/
+//modified to support large files using a temp local file
+
+var MultipartParser = require('formidable/lib/multipart_parser.js').MultipartParser
+  , fs = require('fs')
+
+var MimeReader = {
+
+  parse_multipart: function(payload, boundary) {
+    var parts = []
+    var part
+    var data
+    var headers = []
+    var curr_header_name
+    var curr_header_value
+    var fd
+    var tempId
+
+    var parser = new MultipartParser()
+    parser.initWithBoundary(boundary)
+
+    parser.onPartBegin = function() {
+      part = {}
+      headers = []
+      curr_header_name = ""
+      curr_header_value = ""
+        
+      //only open a file for writing if we are after the first part ie the message otherwise use a buffer
+      if(parts.length == 0){
+          data = new Buffer('');
+      } else {
+          tempId = Math.floor(new Date()).toString() + ".bin";
+          fd = fs.openSync(tempId, 'a+');
+      }
+    }
+
+    parser.onHeaderField = function(b, start, end) {
+      curr_header_name = b.slice(start, end).toString()
+    };
+
+    parser.onHeaderValue = function(b, start, end) {
+      curr_header_value = b.slice(start, end).toString()
+    }
+
+    parser.onHeaderEnd = function() {
+      headers[curr_header_name.toLowerCase()] = curr_header_value
+    }
+    
+    parser.onHeadersEnd = function() { }
+    
+    parser.onPartData = function(b, start, end) {
+        //treat first part as xml message
+        if(parts.length == 0){
+            data = Buffer.concat([data, b.slice(start, end)]);
+        } else {
+            //write parts directly to file instead of a buffer, to be able to work with large attachments
+            fs.appendFileSync(fd, b.slice(start, end));
+        }
+    }
+
+    parser.onPartEnd = function() {
+        //treat first part as xml message
+        if(parts.length == 0){
+            part.data = data;
+            //part.msg = data.toString();
+        } else {
+            part.localTmpFile = tempId;
+            fs.closeSync(fd, (err => {
+              if(err)
+                  console.log('Failed to close file', err);
+            }));
+        }
+
+      part.headers = headers
+      parts.push(part)
+    }
+    
+    parser.onEnd = function() {}
+    parser.write(payload)
+    return parts
+  },
+}
+
+exports.parse_multipart = function(payload, boundary)
+{
+  return MimeReader.parse_multipart(payload, boundary)
+}


### PR DESCRIPTION
Pretty new to soap and typescript so please check over the code.  

I've got this working in my environment but have not tested outside of that.  

Basically what is going on is I have added the option to have the request module return binary and not utf8.  I then check the headers and see if their is a boundary in the header that would indicate a multipart response.  if no boundary I use toString(utf8) to convert back to utf8 so node-soap runs as it used to.  

If we have a boundary I get the boundary id with some regex and pass the res.body and the boundary to the mime-reader.js (feel free to convert this to type-script I do not know how to do that)

In mime-reader.js we create a buffer to hold the first part of the multipart response which is the soap xml response.  then I use a temp file to write the binary data for each of the parts to a file.  I had this using a buffer but on large files I would get slow performance and sometimes out of memory errors.  I package all the headers and the buffer in a parts array and return it.  

then I use the first element in the parts array and convert the buffer to a utf8 string and assign it to the body variable

the other parts get assigned to res.attachments

client.ts then looks to see if response.attachments exists and if it does we assign it to obj.Body.getContentResponse.return.attachments

I use the multipart parser from formidable v1.2.2 and I code written by:

//Original code from Yaron Naveh, 
//https://github.com/yaronn/ws.js/

for the mime-reader.  

Again this has only been tested in one environment and I'm new to soap and typescript so please check it over for issues.  It's currently working in my environment and fulfilling my needs

Also all my edits were done in the javascript files and I tried to convert them to the type-script but may have errors.  I've only been running my javascript files not the type-script ones.  