### PR TITLE
Avoid lodash where possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.33.0",
   "description": "A minimal node SOAP client",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": "Vinay Pulim <v@pulim.com>",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.33.0",
   "description": "A minimal node SOAP client",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=8.0.0"
   },
   "author": "Vinay Pulim <v@pulim.com>",
   "dependencies": {

--- a/soap-stub.js
+++ b/soap-stub.js
@@ -1,5 +1,3 @@
-var _ = require('lodash');
-
 var aliasedClientStubs = {};
 var clientStubs = {};
 
@@ -124,7 +122,7 @@ function registerClient(alias, urlToWsdl, clientStub) {
  * Resets state associated with clientStubs.
  */
 function reset() {
-  _.forEach(clientStubs, resetStubbedMethods);
+  Object.values(clientStubs).forEach(resetStubbedMethods);
   this.errOnCreateClient = false;
 }
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -66,7 +66,7 @@ export class HttpClient {
     };
     const mergeOptions = ['headers'];
 
-    const {attachments: _attachments, ...newExoptions } = exoptions
+    const {attachments: _attachments, ...newExoptions } = exoptions;
     const attachments: IAttachment[] = _attachments || [];
 
     if (typeof data === 'string' && attachments.length === 0 && !exoptions.forceMTOM) {

--- a/src/http.ts
+++ b/src/http.ts
@@ -5,7 +5,6 @@
 
 import * as debugBuilder from 'debug';
 import * as httpNtlm from 'httpntlm';
-import * as _ from 'lodash';
 import * as req from 'request';
 import * as url from 'url';
 import * as uuid from 'uuid/v4';
@@ -66,7 +65,9 @@ export class HttpClient {
       'Host': host + (isNaN(port) ? '' : ':' + port),
     };
     const mergeOptions = ['headers'];
-    const attachments: IAttachment[] = exoptions.attachments || [];
+
+    const {attachments: _attachments, ...newExoptions } = exoptions
+    const attachments: IAttachment[] = _attachments || [];
 
     if (typeof data === 'string' && attachments.length === 0 && !exoptions.forceMTOM) {
       headers['Content-Length'] = Buffer.byteLength(data, 'utf8');
@@ -120,7 +121,7 @@ export class HttpClient {
       options.body = data;
     }
 
-    for (const attr in _.omit(exoptions, ['attachments'])) {
+    for (const attr in newExoptions) {
       if (mergeOptions.indexOf(attr) !== -1) {
         for (const header in exoptions[attr]) {
           options[attr][header] = exoptions[attr][header];

--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -32,7 +32,7 @@ function trim(text) {
 
 function deepMerge<A, B>(destination: A, source: B): A & B {
   return _.mergeWith(destination, source, (a, b) => {
-    return _.isArray(a) ? a.concat(b) : undefined;
+    return Array.isArray(a) ? a.concat(b) : undefined;
   });
 }
 
@@ -495,7 +495,7 @@ export class WSDL {
       for (const n in refs) {
         const ref = refs[n];
         for (const href of ref.hrefs) {
-          _.assign(href.obj, ref.obj);
+          Object.assign(href.obj, ref.obj);
         }
       }
 
@@ -1184,7 +1184,7 @@ export class WSDL {
       includePath = this.options.wsdl_options.overrideImportLocation(includePath);
     }
 
-    const options = _.assign({}, this.options);
+    const options = Object.assign({}, this.options);
     // follow supplied ignoredNamespaces option
     options.ignoredNamespaces = this._originalIgnoredNamespaces || this.options.ignoredNamespaces;
     options.WSDL_CACHE = this.WSDL_CACHE;

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -72,7 +72,7 @@ var fs = require('fs'),
         request: function () { }
       };
       soap.createClient(__dirname + '/wsdl/default_namespace.wsdl',
-        _.assign({ httpClient: myHttpClient }, meta.options),
+        Object.assign({ httpClient: myHttpClient }, meta.options),
         function (err, client) {
           assert.ok(client);
           assert.ifError(err);
@@ -85,7 +85,7 @@ var fs = require('fs'),
       var myRequest = function () {
       };
       soap.createClient(__dirname + '/wsdl/default_namespace.wsdl',
-        _.assign({ request: myRequest }, meta.options),
+        Object.assign({ request: myRequest }, meta.options),
         function (err, client) {
           assert.ok(client);
           assert.ifError(err);
@@ -96,7 +96,7 @@ var fs = require('fs'),
 
 
     it('should allow customization of envelope', function (done) {
-      soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', _.assign({ envelopeKey: 'soapenv' }, meta.options), function (err, client) {
+      soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', Object.assign({ envelopeKey: 'soapenv' }, meta.options), function (err, client) {
         assert.ok(client);
         assert.ifError(err);
 
@@ -109,7 +109,7 @@ var fs = require('fs'),
 
 
     it('should allow passing in XML strings', function (done) {
-      soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', _.assign({ envelopeKey: 'soapenv' }, meta.options), function (err, client) {
+      soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', Object.assign({ envelopeKey: 'soapenv' }, meta.options), function (err, client) {
         assert.ok(client);
         assert.ifError(err);
 
@@ -135,7 +135,7 @@ var fs = require('fs'),
 
     it('should allow disabling the wsdl cache', function (done) {
       var spy = sinon.spy(wsdl, 'open_wsdl');
-      var options = _.assign({ disableCache: true }, meta.options);
+      var options = Object.assign({ disableCache: true }, meta.options);
       soap.createClient(__dirname + '/wsdl/binding_document.wsdl', options, function (err1, client1) {
         assert.ok(client1);
         assert.ok(!err1);
@@ -279,7 +279,7 @@ var fs = require('fs'),
       });
 
       it('Should preserve SOAP 1.2 "action" header when sending MTOM request', function (done) {
-        soap.createClient(__dirname + '/wsdl/attachments.wsdl', _.assign({ forceSoap12Headers: true }, meta.options), function (initError, client) {
+        soap.createClient(__dirname + '/wsdl/attachments.wsdl', Object.assign({ forceSoap12Headers: true }, meta.options), function (initError, client) {
           assert.ifError(initError);
 
           client.MyOperation({}, function (error, response, body, soapHeader, rawRequest) {
@@ -291,7 +291,7 @@ var fs = require('fs'),
       })
 
       it('Should send MTOM request even without attachment', function (done) {
-        soap.createClient(__dirname + '/wsdl/attachments.wsdl', _.assign({ forceSoap12Headers: true }, meta.options), function (initError, client) {
+        soap.createClient(__dirname + '/wsdl/attachments.wsdl', Object.assign({ forceSoap12Headers: true }, meta.options), function (initError, client) {
           assert.ifError(initError);
 
           client.MyOperation({}, function (error, response, body, soapHeader, rawRequest) {
@@ -536,7 +536,7 @@ var fs = require('fs'),
       });
 
       it('should add proper headers for soap12', function (done) {
-        soap.createClient(__dirname + '/wsdl/default_namespace_soap12.wsdl', _.assign({ forceSoap12Headers: true }, meta.options), function (err, client) {
+        soap.createClient(__dirname + '/wsdl/default_namespace_soap12.wsdl', Object.assign({ forceSoap12Headers: true }, meta.options), function (err, client) {
           assert.ok(client);
           assert.ifError(err);
 
@@ -1143,7 +1143,7 @@ var fs = require('fs'),
             on: function () { }
           };
         };
-        var options = _.assign({
+        var options = Object.assign({
           request: mockRequestHandler,
         }, meta.options);
         soap.createClient(__dirname + '/wsdl/builtin_types.wsdl', options, function (err, client) {
@@ -1365,7 +1365,7 @@ var fs = require('fs'),
           request: function () { }
         };
         soap.createClientAsync(__dirname + '/wsdl/default_namespace.wsdl',
-          _.assign({ httpClient: myHttpClient }, meta.options))
+          Object.assign({ httpClient: myHttpClient }, meta.options))
           .then(function (client) {
             assert.ok(client);
             assert.equal(client.httpClient, myHttpClient);
@@ -1377,7 +1377,7 @@ var fs = require('fs'),
         var myRequest = function () {
         };
         soap.createClientAsync(__dirname + '/wsdl/default_namespace.wsdl',
-          _.assign({ request: myRequest }, meta.options))
+          Object.assign({ request: myRequest }, meta.options))
           .then(function (client) {
             assert.ok(client);
             assert.equal(client.httpClient._request, myRequest);
@@ -1395,7 +1395,7 @@ var fs = require('fs'),
       });
 
       it('should allow passing in XML strings', function (done) {
-        soap.createClientAsync(__dirname + '/wsdl/default_namespace.wsdl', _.assign({envelopeKey: 'soapenv'}, meta.options))
+        soap.createClientAsync(__dirname + '/wsdl/default_namespace.wsdl', Object.assign({envelopeKey: 'soapenv'}, meta.options))
           .then(function (client) {
             assert.ok(client);
             var xmlStr = '<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n\t<head>\n\t\t<title>404 - Not Found</title>\n\t</head>\n\t<body>\n\t\t<h1>404 - Not Found</h1>\n\t\t<script type="text/javascript" src="http://gp1.wpc.edgecastcdn.net/00222B/beluga/pilot_rtm/beluga_beacon.js"></script>\n\t</body>\n</html>';
@@ -1409,7 +1409,7 @@ var fs = require('fs'),
 
       it('should allow customization of envelope', function (done) {
         var client;
-        soap.createClientAsync(__dirname + '/wsdl/default_namespace.wsdl', _.assign({ envelopeKey: 'soapenv' }, meta.options))
+        soap.createClientAsync(__dirname + '/wsdl/default_namespace.wsdl', Object.assign({ envelopeKey: 'soapenv' }, meta.options))
         .then(function (createdClient) {
           assert.ok(createdClient);
           client = createdClient;
@@ -1448,7 +1448,7 @@ var fs = require('fs'),
 
       it('should allow disabling the wsdl cache', function (done) {
         var spy = sinon.spy(wsdl, 'open_wsdl');
-        var options = _.assign({ disableCache: true }, meta.options);
+        var options = Object.assign({ disableCache: true }, meta.options);
         soap.createClientAsync(__dirname + '/wsdl/binding_document.wsdl', options)
         .then(function (client) {
           assert.ok(client);
@@ -1484,7 +1484,7 @@ var fs = require('fs'),
     describe('Client created with option normalizeNames', function(){
 
       it('should create node-style method with normalized name (a valid Javascript identifier)', function (done) {
-        soap.createClient(__dirname + '/wsdl/non_identifier_chars_in_operation.wsdl', _.assign({ normalizeNames: true }, meta.options), function (err, client) {
+        soap.createClient(__dirname + '/wsdl/non_identifier_chars_in_operation.wsdl', Object.assign({ normalizeNames: true }, meta.options), function (err, client) {
           assert.ok(client);
           assert.ifError(err);
           client.prefixed_MyOperation({},function(err, result){
@@ -1511,7 +1511,7 @@ var fs = require('fs'),
       });
 
       it('should create promise-style method with normalized name (a valid Javascript identifier)', function (done) {
-        soap.createClient(__dirname + '/wsdl/non_identifier_chars_in_operation.wsdl', _.assign({ normalizeNames: true }, meta.options), function (err, client) {
+        soap.createClient(__dirname + '/wsdl/non_identifier_chars_in_operation.wsdl', Object.assign({ normalizeNames: true }, meta.options), function (err, client) {
           assert.ok(client);
           assert.ifError(err);
           client.prefixed_MyOperationAsync({})
@@ -1525,7 +1525,7 @@ var fs = require('fs'),
       });
 
       it('should not create methods with invalid Javascript identifier', function (done) {
-        soap.createClient(__dirname + '/wsdl/non_identifier_chars_in_operation.wsdl', _.assign({ normalizeNames: true }, meta.options), function (err, client) {
+        soap.createClient(__dirname + '/wsdl/non_identifier_chars_in_operation.wsdl', Object.assign({ normalizeNames: true }, meta.options), function (err, client) {
           assert.ok(client);
           assert.ifError(err);
           assert.throws(function() {client['prefixed-MyOperationAsync']({});}, TypeError);


### PR DESCRIPTION
Lodash is quote big project and it's required less with a time in modern
environments. In this diff I bumped node support to 8+ and used native
methods where possible instead of lodash. Later we can go further and
completely remove it from the project.

This can make the project much smaller.
https://packagephobia.com/result?p=soap