### PR TITLE
Replace concat-stream with get-stream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: node_js
 notifications:
   email: false
 node_js:
+  - "10"
+  - "12"
+  - "14"
   - "lts/*"
 env:
   - CXX=g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ language: node_js
 notifications:
   email: false
 node_js:
-  - "9"
-  - "8"
-  - "7"
-  - "6"
   - "lts/*"
 env:
   - CXX=g++-4.8

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "soap",
-  "version": "0.29.0",
+  "version": "0.33.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -170,7 +170,8 @@
     "@types/caseless": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
-      "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A=="
+      "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A==",
+      "dev": true
     },
     "@types/connect": {
       "version": "3.4.32",
@@ -218,6 +219,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
       "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -281,7 +283,8 @@
     "@types/node": {
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.0.tgz",
-      "integrity": "sha512-D5Rt+HXgEywr3RQJcGlZUCTCx1qVbCZpVk3/tOOA6spLNZdGm8BU+zRgdRYDoF1pO3RuXLxADzMrF903JlQXqg=="
+      "integrity": "sha512-D5Rt+HXgEywr3RQJcGlZUCTCx1qVbCZpVk3/tOOA6spLNZdGm8BU+zRgdRYDoF1pO3RuXLxADzMrF903JlQXqg==",
+      "dev": true
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -293,6 +296,7 @@
       "version": "2.48.1",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.1.tgz",
       "integrity": "sha512-ZgEZ1TiD+KGA9LiAAPPJL68Id2UWfeSO62ijSXZjFJArVV+2pKcsVHmrcu+1oiE3q6eDGiFiSolRc4JHoerBBg==",
+      "dev": true,
       "requires": {
         "@types/caseless": "*",
         "@types/form-data": "*",
@@ -332,7 +336,8 @@
     "@types/tough-cookie": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
-      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg=="
+      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==",
+      "dev": true
     },
     "@types/uuid": {
       "version": "3.4.4",
@@ -531,7 +536,8 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -687,29 +693,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
-    },
-    "concat-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.0.2",
-        "typedarray": "^0.0.6"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
-          "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
     },
     "console-browserify": {
       "version": "1.1.0",
@@ -961,9 +944,9 @@
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"
@@ -1056,6 +1039,17 @@
         "p-finally": "^1.0.0",
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
       }
     },
     "exit": {
@@ -1299,13 +1293,9 @@
       "dev": true
     },
     "get-stream": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-      "dev": true,
-      "requires": {
-        "pump": "^3.0.0"
-      }
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
+      "integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg=="
     },
     "getpass": {
       "version": "0.1.7",
@@ -3045,14 +3035,6 @@
         "strip-ansi": "^4.0.0"
       }
     },
-    "string_decoder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
-      "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "strip-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -3233,11 +3215,6 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.18"
       }
-    },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typedoc": {
       "version": "0.14.2",
@@ -3444,7 +3421,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "author": "Vinay Pulim <v@pulim.com>",
   "dependencies": {
     "bluebird": "^3.5.0",
-    "concat-stream": "^2.0.0",
     "debug": "^4.1.1",
+    "get-stream": "^6.0.0",
     "httpntlm": "^1.5.2",
     "lodash": "^4.17.19",
     "request": ">=2.9.0",

--- a/src/client.ts
+++ b/src/client.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert';
 import * as BluebirdPromise from 'bluebird';
-import * as concatStream from 'concat-stream';
+import getStream = require('get-stream');
 import * as debugBuilder from 'debug';
 import { EventEmitter } from 'events';
 import { IncomingHttpHeaders } from 'http';
@@ -476,15 +476,14 @@ export class Client extends EventEmitter {
         // When the output element cannot be looked up in the wsdl, play it safe and
         // don't stream
         if (response.statusCode !== 200 || !output || !output.$lookupTypes) {
-          response.pipe(concatStream({encoding: 'string'}, (body) => {
+          getStream(response).then(body => {
             this.lastResponse = body;
             this.lastResponseHeaders = response && response.headers;
             this.lastElapsedTime = Date.now() - startTime;
             this.emit('response', body, response, eid);
 
             return parseSync(body, response);
-
-          }));
+          })
           return;
         }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -5,9 +5,9 @@
 
 import * as assert from 'assert';
 import * as BluebirdPromise from 'bluebird';
-import getStream = require('get-stream');
 import * as debugBuilder from 'debug';
 import { EventEmitter } from 'events';
+import getStream = require('get-stream');
 import { IncomingHttpHeaders } from 'http';
 import * as _ from 'lodash';
 import * as request from 'request';
@@ -476,14 +476,14 @@ export class Client extends EventEmitter {
         // When the output element cannot be looked up in the wsdl, play it safe and
         // don't stream
         if (response.statusCode !== 200 || !output || !output.$lookupTypes) {
-          getStream(response).then(body => {
+          getStream(response).then((body) => {
             this.lastResponse = body;
             this.lastResponseHeaders = response && response.headers;
             this.lastElapsedTime = Date.now() - startTime;
             this.emit('response', body, response, eid);
 
             return parseSync(body, response);
-          })
+          });
           return;
         }
 


### PR DESCRIPTION
Ref https://packagephobia.com/result?p=concat-stream https://packagephobia.com/result?p=get-stream

Concat-stream is a big package with not relevant in node 10 dependencies.
In this diff I replaced it with dependency-free get-stream with promise
based api.