### PR TITLE
Drop bluebird

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -151,12 +151,6 @@
         }
       }
     },
-    "@types/bluebird": {
-      "version": "3.5.26",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.26.tgz",
-      "integrity": "sha512-aj2mrBLn5ky0GmAg6IPXrQjnN0iB/ulozuJ+oZdrHRAzRbXjGmu4UXsNCjFvPbSaaPZmniocdOzsM392qLOlmQ==",
-      "dev": true
-    },
     "@types/body-parser": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
@@ -476,11 +470,6 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
-    },
-    "bluebird": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
     },
     "body-parser": {
       "version": "1.18.3",
@@ -1519,7 +1508,8 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "interpret": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   },
   "author": "Vinay Pulim <v@pulim.com>",
   "dependencies": {
-    "bluebird": "^3.5.0",
     "debug": "^4.1.1",
     "get-stream": "^6.0.0",
     "httpntlm": "^1.5.2",
@@ -45,7 +44,6 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@types/bluebird": "^3.5.26",
     "@types/debug": "^4.1.2",
     "@types/express": "^4.16.1",
     "@types/lodash": "^4.14.122",

--- a/src/client.ts
+++ b/src/client.ts
@@ -70,10 +70,10 @@ export class Client extends EventEmitter {
   constructor(wsdl: WSDL, endpoint?: string, options?: IOptions) {
     super();
     options = options || {};
+    this._overridePromiseSuffix = options.overridePromiseSuffix || 'Async';
     this.wsdl = wsdl;
     this._initializeOptions(options);
     this._initializeServices(endpoint);
-    this._overridePromiseSuffix = options.overridePromiseSuffix || 'Async';
     this.httpClient = options.httpClient || new HttpClient(options);
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -66,7 +66,7 @@ export class Client extends EventEmitter {
   private streamAllowed: boolean;
   private returnSaxStream: boolean;
   private normalizeNames: boolean;
-  private overridePromiseSuffix: string
+  private overridePromiseSuffix: string;
 
   constructor(wsdl: WSDL, endpoint?: string, options?: IOptions) {
     super();
@@ -245,7 +245,7 @@ export class Client extends EventEmitter {
           extraHeaders,
         );
       });
-    }
+    };
   }
 
   private _defineMethod(method: OperationElement, location: string): SoapMethod {

--- a/src/client.ts
+++ b/src/client.ts
@@ -66,11 +66,11 @@ export class Client extends EventEmitter {
   private streamAllowed: boolean;
   private returnSaxStream: boolean;
   private normalizeNames: boolean;
+  private overridePromiseSuffix: string
 
   constructor(wsdl: WSDL, endpoint?: string, options?: IOptions) {
     super();
     options = options || {};
-    this._overridePromiseSuffix = options.overridePromiseSuffix || 'Async';
     this.wsdl = wsdl;
     this._initializeOptions(options);
     this._initializeServices(endpoint);
@@ -174,6 +174,7 @@ export class Client extends EventEmitter {
     this.streamAllowed = options.stream;
     this.returnSaxStream = options.returnSaxStream;
     this.normalizeNames = options.normalizeNames;
+    this.overridePromiseSuffix = options.overridePromiseSuffix || 'Async';
     this.wsdl.options.attributesKey = options.attributesKey || 'attributes';
     this.wsdl.options.envelopeKey = options.envelopeKey || 'soap';
     this.wsdl.options.preserveWhitespace = !!options.preserveWhitespace;
@@ -213,8 +214,10 @@ export class Client extends EventEmitter {
       def[name] = this._defineMethod(methods[name], location);
       const methodName = this.normalizeNames ? name.replace(nonIdentifierChars, '_') : name;
       this[methodName] = def[name];
-      const suffix = this._overridePromiseSuffix;
-      this[methodName + suffix] = this._promisifyMethod(def[name]);
+      if (!nonIdentifierChars.test(methodName)) {
+        const suffix = this.overridePromiseSuffix;
+        this[methodName + suffix] = this._promisifyMethod(def[name]);
+      }
     }
     return def;
   }

--- a/src/soap.ts
+++ b/src/soap.ts
@@ -3,7 +3,6 @@
  * MIT Licensed
  */
 
-import * as BluebirdPromise from 'bluebird';
 import * as debugBuilder from 'debug';
 import { Client } from './client';
 import * as _security from './security';
@@ -85,11 +84,11 @@ export function createClient(url: string, p2: CreateClientCallback | IOptions, p
   });
 }
 
-export function createClientAsync(url: string, options?: IOptions, endpoint?: string): BluebirdPromise<Client> {
+export function createClientAsync(url: string, options?: IOptions, endpoint?: string): Promise<Client> {
   if (typeof options === 'undefined') {
     options = {};
   }
-  return new BluebirdPromise((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     createClient(url, options, (err, client) => {
       if (err) {
         reject(err);

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,12 @@ export type SoapMethod = (
   extraHeaders?: any,
 ) => void;
 
+export type SoapMethodAsync = (
+  args: any,
+  options?: any,
+  extraHeaders?: any,
+) => Promise<[any, any, any, any]>;
+
 export type ISoapServiceMethod = (args: any, callback?: (data: any) => void, headers?: any, req?: any) => any;
 
 // SOAP Fault 1.1 & 1.2

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -1401,7 +1401,7 @@ var fs = require('fs'),
             var xmlStr = '<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n\t<head>\n\t\t<title>404 - Not Found</title>\n\t</head>\n\t<body>\n\t\t<h1>404 - Not Found</h1>\n\t\t<script type="text/javascript" src="http://gp1.wpc.edgecastcdn.net/00222B/beluga/pilot_rtm/beluga_beacon.js"></script>\n\t</body>\n</html>';
             return client.MyOperationAsync({_xml: xmlStr});
           })
-          .spread(function (result, raw, soapHeader) {})
+          .then(function ([result, raw, soapHeader]) {})
           .catch(function (err) {
             done();
           });


### PR DESCRIPTION
Using bluebird for promisifying is a bit overhead. Especially since the
package is quite massive. https://packagephobia.com/result?p=bluebird

In this diff I replaced Bluebird.promisifyAll with custom promisifying
specifically for services methods instead of all class methods.