### PR TITLE
+ pass *res* and *server* object into header() and method()

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export type SoapMethodAsync = (
   extraHeaders?: any,
 ) => Promise<[any, any, any, any]>;
 
-export type ISoapServiceMethod = (args: any, callback?: (data: any) => void, headers?: any, req?: any) => any;
+export type ISoapServiceMethod = (args: any, callback?: (data: any) => void, headers?: any, req?: any, res?: any, sender?: any) => any;
 
 // SOAP Fault 1.1 & 1.2
 export interface ISoapFaultError {


### PR DESCRIPTION
In some cases you need a communication way between header and method. E.g. in header you should create wsa:MessageId which may be needed in the method. Using res object you can create this communication.

Same with soap server object. You can have some settings which may be useful both in header and method and having server object inside these functions gives a way to read settings from the server object.