### PR TITLE
Extract required HttpClient functions to dedicated interface

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -12,7 +12,7 @@ import * as _ from 'lodash';
 import * as request from 'request';
 import { v4 as uuidv4 } from 'uuid';
 import { HttpClient, Request } from './http';
-import { IHeaders, IOptions, ISecurity, SoapMethod, SoapMethodAsync } from './types';
+import { IHeaders, IHttpClient, IOptions, ISecurity, SoapMethod, SoapMethodAsync } from './types';
 import { findPrefix } from './utils';
 import { WSDL } from './wsdl';
 import { IPort, OperationElement, ServiceElement } from './wsdl/elements';
@@ -56,7 +56,7 @@ export class Client extends EventEmitter {
   public lastElapsedTime?: number;
 
   private wsdl: WSDL;
-  private httpClient: HttpClient;
+  private httpClient: IHttpClient;
   private soapHeaders: any[];
   private httpHeaders: IHeaders;
   private bodyAttributes: string[];

--- a/src/http.ts
+++ b/src/http.ts
@@ -8,14 +8,10 @@ import * as httpNtlm from 'httpntlm';
 import * as req from 'request';
 import * as url from 'url';
 import {v4 as uuidv4} from 'uuid';
-import { IHeaders, IOptions } from './types';
+import { IExOptions, IHeaders, IHttpClient, IOptions } from './types';
 
 const debug = debugBuilder('node-soap');
 const VERSION = require('../package.json').version;
-
-export interface IExOptions {
-  [key: string]: any;
-}
 
 export interface IAttachment {
   name: string;
@@ -33,7 +29,7 @@ export type Request = req.Request;
  *
  * @constructor
  */
-export class HttpClient {
+export class HttpClient implements IHttpClient {
   private _request: req.RequestAPI<req.Request, req.CoreOptions, req.Options>;
 
   constructor(options?: IOptions) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,17 @@
 
 import * as req from 'request';
-import { HttpClient } from './http';
 
 export interface IHeaders {
   [k: string]: any;
+}
+
+export interface IExOptions {
+  [key: string]: any;
+}
+
+export interface IHttpClient {
+  request(rurl: string, data: any, callback: (error: any, res?: any, body?: any) => any, exheaders?: IHeaders, exoptions?: IExOptions, caller?);
+  requestStream?(rurl: string, data: any, exheaders?: IHeaders, exoptions?: IExOptions, caller?): req.Request;
 }
 
 /** @deprecated use SoapMethod */
@@ -112,7 +120,7 @@ export interface IOptions extends IWsdlBaseOptions {
   /** set specific key instead of <pre><soap:Body></soap:Body></pre>. */
   envelopeKey?: string;
   /** provide your own http client that implements request(rurl, data, callback, exheaders, exoptions) */
-  httpClient?: HttpClient;
+  httpClient?: IHttpClient;
   /** override the request module. */
   request?: req.RequestAPI<req.Request, req.CoreOptions, req.RequiredUriUrl>;
   stream?: boolean;


### PR DESCRIPTION
Per the documentation, one of the options that can be defined when creating a SOAP client is `httpClient`:

> httpClient: to provide your own http client that implements request(rurl, data, callback, exheaders, exoptions).

However, the Typescript declaration is generated from the concrete class. As a result, the Typescript declaration includes additional functions and attributes that are specific to the concrete implementation, but aren't necessarily required when called from an instance of the client.

This change extracts the absolute minimum required function (`request`) to a dedicated interface defined along with other exported types.

A couple of notes:
1. Since there is enhanced support for streaming (via a `requestStream` implementation), that function is also included in the interface but marked as optional since its existence is preemptively checked before being called by the client.
1. I also moved the `IExOptions` interface up to the `types` since it is a related part of the `IHttpClient` interface.
