### PR TITLE
handle base attribute on WSDL.prototype.findChildSchemaObject

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "soap",
-  "version": "0.33.0",
+  "version": "0.35.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -469,9 +469,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
-      "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "bail": {
       "version": "1.0.5",
@@ -862,9 +862,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -3482,9 +3482,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
-      "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -170,9 +170,9 @@
       "dev": true
     },
     "@types/connect": {
-      "version": "3.4.33",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
-      "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
+      "version": "3.4.34",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.34.tgz",
+      "integrity": "sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -185,9 +185,9 @@
       "dev": true
     },
     "@types/express": {
-      "version": "4.17.8",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.8.tgz",
-      "integrity": "sha512-wLhcKh3PMlyA2cNAB9sjM1BntnhPMiM0JOBwPBqttjHev2428MLEB4AYVN+d8s2iyCVZac+o41Pflm/ZH5vLXQ==",
+      "version": "4.17.9",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.9.tgz",
+      "integrity": "sha512-SDzEIZInC4sivGIFY4Sz1GG6J9UObPwCInYJjko2jzOf/Imx/dlpume6Xxwj1ORL82tBbmN4cPDIDkLbWHk9hw==",
       "dev": true,
       "requires": {
         "@types/body-parser": "*",
@@ -197,9 +197,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.13.tgz",
-      "integrity": "sha512-RgDi5a4nuzam073lRGKTUIaL3eF2+H7LJvJ8eUnCI0wA6SNjXc44DCmWNiTLs/AZ7QlsFWZiw/gTG3nSQGL0fA==",
+      "version": "4.17.17",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.17.tgz",
+      "integrity": "sha512-YYlVaCni5dnHc+bLZfY908IG1+x5xuibKZMGv8srKkvtul3wUuanYvpIj9GXXoWkQbaAdR+kgX46IETKUALWNQ==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -242,9 +242,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.162",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.162.tgz",
-      "integrity": "sha512-alvcho1kRUnnD1Gcl4J+hK0eencvzq9rmzvFPRmP5rPHx9VVsJj6bKLTATPVf9ktgv4ujzh7T+XWKp+jhuODig==",
+      "version": "4.14.166",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.166.tgz",
+      "integrity": "sha512-A3YT/c1oTlyvvW/GQqG86EyqWNrT/tisOIh2mW3YCgcx71TNjiTZA3zYZWA5BCmtsOTXjhliy4c4yEkErw6njA==",
       "dev": true
     },
     "@types/marked": {
@@ -266,9 +266,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "11.15.34",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.34.tgz",
-      "integrity": "sha512-mT918tcEWkw9SYzpKzDdrYzjMDh68wmLfiVo6PDPEt1k71qcuPQumGcLlxB2AW/pLdTDNO+Nxj2fvsClDrtkqg==",
+      "version": "11.15.42",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.42.tgz",
+      "integrity": "sha512-CUwq20cDEavWvtzSQVcBKjG6bj/JiBMGJqar7uNPQR+JUbpPg6Pvjk/piV1YTJzCck8yD2SZQOmnJ3ZvOkq4Mg==",
       "dev": true
     },
     "@types/qs": {
@@ -318,9 +318,9 @@
       }
     },
     "@types/serve-static": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.6.tgz",
-      "integrity": "sha512-nuRJmv7jW7VmCVTn+IgYDkkbbDGyIINOeu/G0d74X3lm6E5KfMeQPJhxIt1ayQeQB3cSxvYs1RA/wipYoFB4EA==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.8.tgz",
+      "integrity": "sha512-MoJhSQreaVoL+/hurAZzIm8wafFR6ajiTM1m4A0kv6AGeVBl4r4pOV8bGFrjjq1sGxDTnCoF8i22o0/aE5XCyA==",
       "dev": true,
       "requires": {
         "@types/mime": "*",
@@ -1078,8 +1078,30 @@
           "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
           "requires": {
             "define-properties": "^1.1.3",
+            "es-abstract": "^1.18.0-next.0",
             "has-symbols": "^1.0.1",
             "object-keys": "^1.1.1"
+          },
+          "dependencies": {
+            "es-abstract": {
+              "version": "1.18.0-next.1",
+              "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+              "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+              "requires": {
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1",
+                "is-callable": "^1.2.2",
+                "is-negative-zero": "^2.0.0",
+                "is-regex": "^1.1.1",
+                "object-inspect": "^1.8.0",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.1",
+                "string.prototype.trimend": "^1.0.1",
+                "string.prototype.trimstart": "^1.0.1"
+              }
+            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
   "license": "MIT",
   "devDependencies": {
     "@types/debug": "^4.1.2",
-    "@types/express": "^4.16.1",
-    "@types/lodash": "^4.14.122",
-    "@types/node": "^11.11.0",
+    "@types/express": "^4.17.9",
+    "@types/lodash": "^4.14.166",
+    "@types/node": "^11.15.42",
     "@types/request": "^2.48.1",
     "@types/sax": "^1.0.1",
     "@types/uuid": "^8.3.0",

--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -1058,6 +1058,20 @@ export class WSDL {
         return this.findChildSchemaObject(typeDef, childName, backtrace);
       }
     }
+    
+    // handle $base (e.g. for ExtensionElement) like $type
+    if (object.$base) {
+      const typeInfo = splitQName(object.$base);
+      if (typeInfo.prefix === TNS_PREFIX) {
+        childNsURI = parameterTypeObj.$targetNamespace;
+      } else {
+        childNsURI = this.definitions.xmlns[typeInfo.prefix];
+      }
+      const typeDef = this.findSchemaType(typeInfo.name, childNsURI);
+      if (typeDef) {
+        return this.findChildSchemaObject(typeDef, childName, backtrace);
+      }
+    }
 
     if (object.children) {
       for (i = 0, child; child = object.children[i]; i++) {

--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -1062,11 +1062,10 @@ export class WSDL {
     // handle $base (e.g. for ExtensionElement) like $type
     if (object.$base && (!Array.isArray(object.children) || !object.children.length)) {
       const baseInfo = splitQName(object.$base);
+      childNsURI = this.definitions.xmlns[baseInfo.prefix];
       if (baseInfo.prefix === TNS_PREFIX) {
         childNsURI = parameterTypeObj.$targetNamespace;
-      } else {
-        childNsURI = this.definitions.xmlns[baseInfo.prefix];
-      }
+      } 
       const baseDef = this.findSchemaType(baseInfo.name, childNsURI);
       if (baseDef) {
         return this.findChildSchemaObject(baseDef, childName, backtrace);

--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -1058,7 +1058,7 @@ export class WSDL {
         return this.findChildSchemaObject(typeDef, childName, backtrace);
       }
     }
-    
+
     // handle $base (e.g. for ExtensionElement) like $type
     if (object.$base) {
       const typeInfo = splitQName(object.$base);

--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -1060,20 +1060,20 @@ export class WSDL {
     }
 
     // handle $base (e.g. for ExtensionElement) like $type
-    if (object.$base) {
-      const typeInfo = splitQName(object.$base);
-      if (typeInfo.prefix === TNS_PREFIX) {
+    if (object.$base && (!Array.isArray(object.children) || !object.children.length)) {
+      const baseInfo = splitQName(object.$base);
+      if (baseInfo.prefix === TNS_PREFIX) {
         childNsURI = parameterTypeObj.$targetNamespace;
       } else {
-        childNsURI = this.definitions.xmlns[typeInfo.prefix];
+        childNsURI = this.definitions.xmlns[baseInfo.prefix];
       }
-      const typeDef = this.findSchemaType(typeInfo.name, childNsURI);
-      if (typeDef) {
-        return this.findChildSchemaObject(typeDef, childName, backtrace);
+      const baseDef = this.findSchemaType(baseInfo.name, childNsURI);
+      if (baseDef) {
+        return this.findChildSchemaObject(baseDef, childName, backtrace);
       }
     }
 
-    if (object.children) {
+    if (Array.isArray(object.children) && object.children.length > 0) {
       for (i = 0, child; child = object.children[i]; i++) {
         found = this.findChildSchemaObject(child, childName, backtrace);
         if (found) {

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -120,6 +120,20 @@ describe('WSDL Parser (strict)', () => {
       });
     });
   });
+  
+  it('should handle extension base', (done) => {
+    var expectedMsg = '<bar:Shipper xmlns:bar="http://example.com/bar/xsd"' +
+      ' xmlns="http://example.com/bar/xsd"><bar:Name>' + 
+      '<bar1:name1 xmlns:bar1="http://example.com/bar1/xsd">ABC</bar1:name1></bar:Name>' + 
+      '</bar:Shipper>';
+    soap.createClient(__dirname + '/wsdl/extensionBase/foo.wsdl', {strict: true}, function(err, client) {
+      assert.ifError(err);
+      client.fooOp({Name: {name1: 'ABC'}}, function(err, result) {
+        assert.equal(client.lastMessage, expectedMsg);
+        done();
+      });
+    });
+  });
 
   it('should parse POJO into xml without making unnecessary recursion', (done) => {
     var expectedMsg = require('./wsdl/perf/request.xml.js');

--- a/test/wsdl/extensionBase/bar.xsd
+++ b/test/wsdl/extensionBase/bar.xsd
@@ -1,0 +1,19 @@
+<xsd:schema targetNamespace="http://example.com/bar/xsd"
+            elementFormDefault="qualified"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:bar1="http://example.com/bar1/xsd"
+            xmlns:bar="http://example.com/bar/xsd">
+    <xsd:import namespace="http://example.com/bar1/xsd"
+                schemaLocation="bar1.xsd"/>
+    <xsd:element name="Shipper" type="bar:ShipperType"/>
+    <xsd:complexType name="ShipperTypeType">
+        <xsd:sequence>
+            <xsd:element name="Name" type="bar1:NameType" />
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="ShipperType">
+        <xsd:complexContent>
+            <xsd:extension base="bar:ShipperTypeType" />
+        </xsd:complexContent>
+    </xsd:complexType>
+</xsd:schema>

--- a/test/wsdl/extensionBase/bar1.xsd
+++ b/test/wsdl/extensionBase/bar1.xsd
@@ -1,0 +1,17 @@
+<xsd:schema targetNamespace="http://example.com/bar1/xsd"
+            elementFormDefault="qualified" version="2.1.4"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:bar1="http://example.com/bar1/xsd">
+  <xsd:complexType name="NameType">
+      <xsd:sequence>
+          <xsd:element ref="bar1:name1" minOccurs="1"/>
+      </xsd:sequence>
+  </xsd:complexType>
+  <xsd:element name="name1">
+    <xsd:simpleType>
+      <xsd:restriction base="xsd:string">
+        <xsd:maxLength value="50"/>
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:element>
+</xsd:schema>

--- a/test/wsdl/extensionBase/foo.wsdl
+++ b/test/wsdl/extensionBase/foo.wsdl
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="foo"
+                  targetNamespace="http://example.com/foo/wsdl"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:bar="http://example.com/bar/xsd"
+                  xmlns:tns="http://example.com/foo/wsdl"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/">
+    <wsdl:types>
+        <xsd:schema>
+            <xsd:import
+                    namespace="http://example.com/bar/xsd"
+                    schemaLocation="bar.xsd"/>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="fooRs">
+        <wsdl:part name="fooRs" element="bar:Shipper">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="fooRq">
+        <wsdl:part name="fooRq" element="bar:Shipper">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:portType name="foo_PortType">
+        <wsdl:operation name="fooOp">
+            <wsdl:input message="tns:fooRq">
+            </wsdl:input>
+            <wsdl:output message="tns:fooRs">
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="foo_Binding" type="tns:foo_PortType">
+        <soap:binding style="document"
+                      transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="fooOp">
+            <soap:operation soapAction="fooPayment"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="foo">
+        <wsdl:port name="payment_Port"
+                   binding="tns:foo_Binding">
+            <soap:address
+                    location="http://localhost:8888/mockfoo_Binding"/>
+        </wsdl:port>
+    </wsdl:service>
+    <xsd:attriute fixed="2.1.4" name="version"/>
+</wsdl:definitions>


### PR DESCRIPTION
When parsing the wsdl, the trace don't recognize the reference in the base attribute of an ExtensionElement, when it comes to findChildSchemaObject. It should be handled like the type attribute on ElementElements, but don't know what it's about with the "backtrace.length === 1".

It's my first pull request - I think, this minor changes don't need an extra test - but please let me know, if something is missing. 

Additionally i don't know how to handle the diffs in package-lock.json.... 