### PR TITLE
refactor: use of 'Buffer.from' instead of a deprecated 'new Buffer()'

### DIFF
--- a/src/security/BasicAuthSecurity.ts
+++ b/src/security/BasicAuthSecurity.ts
@@ -15,7 +15,7 @@ export class BasicAuthSecurity implements ISecurity {
   }
 
   public addHeaders(headers: IHeaders): void {
-    headers.Authorization = 'Basic ' + new Buffer((this._username + ':' + this._password) || '').toString('base64');
+    headers.Authorization = 'Basic ' + Buffer.from((this._username + ':' + this._password) || '').toString('base64');
   }
 
   public toXML(): string {


### PR DESCRIPTION
When setting a `BasicAuthSecurity` I was getting this warning:

> DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

Changing `new Buffer()` to `Buffer.from` in order to get rid of this warning.