### PR TITLE
update xml-crypto version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "sax": ">=0.6",
     "strip-bom": "^3.0.0",
     "uuid": "^8.3.0",
-    "xml-crypto": "^2.0.0"
+    "xml-crypto": "^2.1.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I have the `node-soap` in my dependency tree and I've got a security alert from `dependabot`, it says: update `xmldom` to `0.5.0`. `xmldom` is a dependency of `xml-crypto`, which is a dependency of the `node-soap`, and they have already updated the `xmldom` to 0.5.0, so it's your turn :)
[The alert](https://github.com/advisories/GHSA-h6q6-9hqw-rwfv)
