### PR TITLE
Circular element references inside wsdl - assistance needed

### DIFF
--- a/src/wsdl/elements.ts
+++ b/src/wsdl/elements.ts
@@ -231,6 +231,7 @@ export class ElementElement extends Element {
           definitions.xmlns[type.prefix];
       const schema = definitions.schemas[ns];
       const typeElement = schema && ( this.$type ? schema.complexTypes[typeName] || schema.types[typeName] : schema.elements[typeName] );
+      const typeStorage = this.$type ? definitions.descriptions.types : definitions.descriptions.elements;
 
       if (ns && definitions.schemas[ns]) {
         xmlns = definitions.schemas[ns].xmlns;
@@ -238,12 +239,10 @@ export class ElementElement extends Element {
 
       if (typeElement && !(typeName in Primitives)) {
 
-        if (!(typeName in definitions.descriptions.types)) {
+        if (!(typeName in typeStorage)) {
 
           let elem: any = {};
-          if (!this.$ref) {
-            definitions.descriptions.types[typeName] = elem;
-          }
+          typeStorage[typeName] = elem;
 
           const description = typeElement.description(definitions, xmlns);
           if (typeof description === 'string') {
@@ -265,12 +264,12 @@ export class ElementElement extends Element {
             elem.targetNamespace = ns;
           }
 
-          definitions.descriptions.types[typeName] = elem;
+          typeStorage[typeName] = elem;
         } else {
           if (this.$ref) {
-            element = definitions.descriptions.types[typeName];
+            element = typeStorage[typeName];
           } else {
-            element[name] = definitions.descriptions.types[typeName];
+            element[name] = typeStorage[typeName];
           }
         }
 
@@ -1082,8 +1081,12 @@ export class DefinitionsElement extends Element {
     types: {
       [key: string]: Element;
     },
+    elements: {
+      [key: string]: Element;
+    },
   } = {
     types: {},
+    elements: {},
   };
 
   public init() {

--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -1291,6 +1291,7 @@ export class WSDL {
     this.definitions = this._parse(xml);
     this.definitions.descriptions = {
       types: {},
+      elements: {},
     };
     this.xml = xml;
   }

--- a/test/wsdl-parse-test.js
+++ b/test/wsdl-parse-test.js
@@ -54,4 +54,22 @@ describe(__filename, function () {
       done();
     });
   });
+
+  it('should parse recursive wsdls with element references', function (done) {
+    open_wsdl(path.resolve(__dirname, 'wsdl/recursive_with_ref.wsdl'), function (err, def) {
+        assert.ifError(err);
+        var desc = def.definitions.portTypes.CloudSignService.description(def.definitions);
+        assert.equal(desc.AddSignature.input.properties.property && desc.AddSignature.input.properties.property.value2, 'string');
+        done();
+    });
+  });
+
+  it('should parse recursive wsdls with element references and complex types named same as references', function (done) {
+    open_wsdl(path.resolve(__dirname, 'wsdl/recursive_with_ref2.wsdl'), function (err, def) {
+      assert.ifError(err);
+      var desc = def.definitions.portTypes.CloudSignService.description(def.definitions);
+      assert.equal(desc.AddSignature.input.properties.property && desc.AddSignature.input.properties.property.value2, 'xsd:string');
+      done();
+    });
+  });
 });

--- a/test/wsdl-parse-test.js
+++ b/test/wsdl-parse-test.js
@@ -68,7 +68,7 @@ describe(__filename, function () {
     open_wsdl(path.resolve(__dirname, 'wsdl/recursive_with_ref2.wsdl'), function (err, def) {
       assert.ifError(err);
       var desc = def.definitions.portTypes.CloudSignService.description(def.definitions);
-      assert.equal(desc.AddSignature.input.properties.property && desc.AddSignature.input.properties.property.value2, 'xsd:string');
+      assert.equal(desc.AddSignature.input.properties.property && desc.AddSignature.input.properties.property.value2, 'string');
       done();
     });
   });

--- a/test/wsdl/recursive_with_ref.wsdl
+++ b/test/wsdl/recursive_with_ref.wsdl
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+	xmlns:tns="http://www.comped.it/CloudSignService" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+	name="CloudSignService" targetNamespace="http://www.comped.it/CloudSignService"
+	xmlns:fault="http://www.comped.it/te/serviceFault" xmlns:p="http://www.w3.org/2001/XMLSchema">
+	<wsdl:types>
+		<schema xmlns="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.comped.it/CloudSignService">
+			<element name="property">
+				<complexType>
+					<sequence>
+						<element name="value2" type="string" minOccurs="0"/>
+						<element ref="tns:property" minOccurs="0" maxOccurs="unbounded"/>
+					</sequence>
+				</complexType>
+			</element>
+			
+			<complexType name="properties">
+				<sequence>
+					<element ref="tns:property" minOccurs="0" maxOccurs="unbounded"/>
+				</sequence>
+			</complexType>
+			
+			<element name="AddSignature">
+				<complexType>
+					<sequence>
+						<element name="properties" type="tns:properties"/>
+					</sequence>
+				</complexType>
+			</element>
+
+			<element name="AddSignatureResponse">
+				<complexType>
+					<sequence>
+					</sequence>
+				</complexType>
+			</element>
+		</schema>
+	</wsdl:types>
+	
+	<wsdl:message name="AddSignatureRequest">
+		<wsdl:part element="tns:AddSignature" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="AddSignatureResponse">
+		<wsdl:part element="tns:AddSignatureResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:portType name="CloudSignService">
+		<wsdl:operation name="AddSignature">
+			<wsdl:input message="tns:AddSignatureRequest" />
+			<wsdl:output message="tns:AddSignatureResponse" />
+		</wsdl:operation>
+	</wsdl:portType>
+	<wsdl:binding name="CloudSignServiceSOAP" type="tns:CloudSignService">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="AddSignature">
+			<soap:operation soapAction="http://www.comped.it/CloudSignService/AddSignature" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+			<wsdl:fault name="fault">
+				<soap:fault use="literal" name="fault" />
+			</wsdl:fault>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:service name="CloudSignService">
+		<wsdl:port binding="tns:CloudSignServiceSOAP" name="CloudSignServiceSOAP">
+			<soap:address location="http://www.example.org/" />
+		</wsdl:port>
+	</wsdl:service>
+</wsdl:definitions>

--- a/test/wsdl/recursive_with_ref2.wsdl
+++ b/test/wsdl/recursive_with_ref2.wsdl
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+	xmlns:tns="http://www.comped.it/CloudSignService" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+	name="CloudSignService" targetNamespace="http://www.comped.it/CloudSignService"
+	xmlns:fault="http://www.comped.it/te/serviceFault" xmlns:p="http://www.w3.org/2001/XMLSchema">
+	<wsdl:types>
+		<schema xmlns="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.comped.it/CloudSignService">
+			<element name="property">
+				<complexType>
+					<sequence>
+						<element name="value2" type="string" minOccurs="0"/>
+						<element ref="tns:property" minOccurs="0" maxOccurs="unbounded"/>
+					</sequence>
+				</complexType>
+			</element>
+			
+			<complexType name="property">
+				<sequence>
+					<element ref="tns:property" minOccurs="0" maxOccurs="unbounded"/>
+				</sequence>
+			</complexType>
+			
+			<element name="AddSignature">
+				<complexType>
+					<sequence>
+						<element name="properties" type="tns:property"/>
+					</sequence>
+				</complexType>
+			</element>
+
+			<element name="AddSignatureResponse">
+				<complexType>
+					<sequence>
+					</sequence>
+				</complexType>
+			</element>
+		</schema>
+	</wsdl:types>
+	
+	<wsdl:message name="AddSignatureRequest">
+		<wsdl:part element="tns:AddSignature" name="parameters" />
+	</wsdl:message>
+	<wsdl:message name="AddSignatureResponse">
+		<wsdl:part element="tns:AddSignatureResponse" name="parameters" />
+	</wsdl:message>
+	<wsdl:portType name="CloudSignService">
+		<wsdl:operation name="AddSignature">
+			<wsdl:input message="tns:AddSignatureRequest" />
+			<wsdl:output message="tns:AddSignatureResponse" />
+		</wsdl:operation>
+	</wsdl:portType>
+	<wsdl:binding name="CloudSignServiceSOAP" type="tns:CloudSignService">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="AddSignature">
+			<soap:operation soapAction="http://www.comped.it/CloudSignService/AddSignature" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+			<wsdl:fault name="fault">
+				<soap:fault use="literal" name="fault" />
+			</wsdl:fault>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:service name="CloudSignService">
+		<wsdl:port binding="tns:CloudSignServiceSOAP" name="CloudSignServiceSOAP">
+			<soap:address location="http://www.example.org/" />
+		</wsdl:port>
+	</wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
Hello.

This fix https://github.com/vpulim/node-soap/pull/1101 fixed one bug and introduced another. Now parsing wsdl with recursive ref elements will cause stack overflow. I created 2 test cases which demonstrate this bug, but I need advice of someone who knows this project better than me.

I can quick fix stack overflow with one kludge - just like https://github.com/vpulim/node-soap/pull/1101, something like this, or maybe a little more complex - because second test will fail with this:
```
          if (!this.$ref) {
            definitions.descriptions.types[typeName] = elem;
          } else {
            const refType = splitQName((typeElement as ElementElement).$type);
            if(refType.name != typeName)
              definitions.descriptions.types[typeName] = elem;
          }
```

As pedantic person, I think kludge is not the way to do. In my opinion main problem is more deep in internals: both element names (with references) and type names go to the same object `definitions.descriptions.types`, they are mixed, and this introduces all these bugs with elements and types, but I'm not sure in this, because I'm new to node-soap internals, I just use it as a regular user.

So I need advice from someone, I can try to fix this by splitting `definitions.descriptions.types` for elements and for types, but it seems this is core internal feature, I'm afraid to break something and waste my time making PR which will not be accepted.