### PR TITLE
Add an option to for an envelopeKey for WSSecurity

### DIFF
--- a/src/security/WSSecurity.ts
+++ b/src/security/WSSecurity.ts
@@ -12,6 +12,7 @@ export interface IWSSecurityOptions {
   hasTokenCreated?: boolean;
   actor?: string;
   mustUnderstand?;
+  envelopeKey?: string;
 }
 
 export class WSSecurity implements ISecurity {
@@ -23,11 +24,13 @@ export class WSSecurity implements ISecurity {
   private _hasTokenCreated: boolean;
   private _actor: string;
   private _mustUnderstand: boolean;
+  private _envelopeKey: string;
 
   constructor(username: string, password: string, options?: string | IWSSecurityOptions) {
     options = options || {};
     this._username = username;
     this._password = password;
+    this._envelopeKey = 'soap';
     // must account for backward compatibility for passwordType String param as well as object options defaults: passwordType = 'PasswordText', hasTimeStamp = true
     if (typeof options === 'string') {
       this._passwordType = options ? options : 'PasswordText';
@@ -51,6 +54,9 @@ export class WSSecurity implements ISecurity {
     }
     if (options.mustUnderstand != null) {
       this._mustUnderstand = !!options.mustUnderstand;
+    }
+    if (options.envelopeKey) {
+      this._envelopeKey = options.envelopeKey;
     }
   }
 
@@ -98,8 +104,8 @@ export class WSSecurity implements ISecurity {
         '<wsse:Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">' + nonce + '</wsse:Nonce>';
     }
 
-    return '<wsse:Security ' + (this._actor ? 'soap:actor="' + this._actor + '" ' : '') +
-      (this._mustUnderstand ? 'soap:mustUnderstand="1" ' : '') +
+    return '<wsse:Security ' + (this._actor ? `${this._envelopeKey}:actor="${this._actor}" ` : '') +
+      (this._mustUnderstand ? `${this._envelopeKey}:mustUnderstand="1" ` : '') +
       'xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">' +
       timeStampXml +
       '<wsse:UsernameToken xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="SecurityToken-' + created + '">' +

--- a/src/security/WSSecurityCert.ts
+++ b/src/security/WSSecurityCert.ts
@@ -130,7 +130,7 @@ export class WSSecurityCert implements ISecurity {
     const secHeader =
       `<wsse:Security xmlns:wsse="${oasisBaseUri}/oasis-200401-wss-wssecurity-secext-1.0.xsd" ` +
       `xmlns:wsu="${oasisBaseUri}/oasis-200401-wss-wssecurity-utility-1.0.xsd" ` +
-      `soap:mustUnderstand="1">` +
+      `${envelopeKey}:mustUnderstand="1">` +
       `<wsse:BinarySecurityToken ` +
       `EncodingType="${oasisBaseUri}/oasis-200401-wss-soap-message-security-1.0#Base64Binary" ` +
       `ValueType="${oasisBaseUri}/oasis-200401-wss-x509-token-profile-1.0#X509v3" ` +

--- a/test/security/WSSecurity.js
+++ b/test/security/WSSecurity.js
@@ -69,4 +69,18 @@ describe('WSSecurity', function() {
     xml.should.containEql('</wsse:UsernameToken></wsse:Security>');
 
   });
+  it('should add envelopeKey to properties in Security block', function () {
+    var username = 'myUser';
+    var password = 'myPass';
+    var options = {
+      hasTimeStamp: false,
+      mustUnderstand: true,
+      actor: 'urn:sample',
+      envelopeKey: 'soapenv',
+    };
+    var instance = new WSSecurity(username, password, options);
+    var xml = instance.toXML();
+    xml.should.containEql('<wsse:Security soapenv:actor="urn:sample" ');
+    xml.should.containEql('soapenv:mustUnderstand="1"');
+  });
 });

--- a/test/security/WSSecurityCert.js
+++ b/test/security/WSSecurityCert.js
@@ -190,6 +190,13 @@ describe('WSSecurityCert', function () {
     var xml = instance.postProcess('<soapenv:Header></soapenv:Header><soapenv:Body></soapenv:Body>', 'soapenv');
     xml.should.containEql('<wsse:Security');
   });
+  it('should add envelopeKey to properties in Security block', function () {
+    var instance = new WSSecurityCert(key, cert, '', {
+      mustUnderstand: true,
+    });
+    var xml = instance.postProcess('<soapenv:Header></soapenv:Header><soapenv:Body></soapenv:Body>', 'soapenv');
+    xml.should.containEql('soapenv:mustUnderstand="1"');
+  });
   it('should not accept envelopeKey not set in envelope', function () {
     var xml;
     try {


### PR DESCRIPTION
 - When including an `envelopeKey` in client creation the `mustUnderstand` and `actor` attributes 
   will not have the correct prefix.
 - Passing this value to as an option to creating the security instance is not an ideal solution
 - ~~This change does not fix the same issue that exists in WSSecurityCert~~