### PR TITLE
Fixed namespace resolution in case of complexType extension.

### DIFF
--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -1087,7 +1087,7 @@ export class WSDL {
         if (child.$base) {
           const baseQName = splitQName(child.$base);
           const childNameSpace = baseQName.prefix === TNS_PREFIX ? '' : baseQName.prefix;
-          childNsURI = child.xmlns[baseQName.prefix] || this.definitions.xmlns[baseQName.prefix];
+          childNsURI = child.xmlns[baseQName.prefix] || child.schemaXmlns[baseQName.prefix];
 
           const foundBase = this.findSchemaType(baseQName.name, childNsURI);
 

--- a/test/wsdl-parse-test.js
+++ b/test/wsdl-parse-test.js
@@ -56,7 +56,7 @@ describe(__filename, function () {
   });
 
   it('should parse complex wsdls', function (done) {
-    open_wsdl(path.resolve(__dirname, 'wsdl/complex/registration.wsdl'), function (err, def) {
+    open_wsdl(path.resolve(__dirname, 'wsdl/complex/registration-common.wsdl'), function (err, def) {
       if (err) {
         return done( err );
       }
@@ -75,7 +75,7 @@ describe(__filename, function () {
       }
 
       var requestBody = {
-        id: 'FI_ID_VALUE',
+        id: 'ID00000000000000000000000000000000',
         lastName: 'Doe',
         firstName: 'John',
         dateOfBirth: '1970-01-01',
@@ -98,15 +98,13 @@ describe(__filename, function () {
         requestBody, 
         'msg',
         'http://test-soap.com/api/registration/messages',
-        'registerUserRequest'
+        'registerUserRequest' 
       );
 
-      console.log(requestAsXML);
-
       /*
-      Expected XML
+      Expected XML:
       <msg:registerUserRequest xmlns:msg="http://test-soap.com/api/registration/messages" xmlns="http://test-soap.com/api/registration/messages">
-        <msg:id>FI_ID_VALUE</msg:id>
+        <msg:id>ID00000000000000000000000000000000</msg:id>
         <msg:lastName>Doe</msg:lastName>
         <msg:firstName>John</msg:firstName>
         <msg:dateOfBirth>1970-01-01</msg:dateOfBirth>
@@ -120,11 +118,11 @@ describe(__filename, function () {
             <ct:city>City</ct:city>
             <ct:countryCode>US</ct:countryCode>
           </ct:address>
-          <ct:companyName>ACME</ct:companyName>
+          <ct:companyName xmlns:ct="http://test-soap.com/api/common/types">ACME</ct:companyName>
         </msg:companyAddress>
       </msg:registerUserRequest>
       */
-      assert.strictEqual(requestAsXML, '<msg:registerUserRequest xmlns:msg="http://test-soap.com/api/registration/messages" xmlns="http://test-soap.com/api/registration/messages"><msg:id>FI_ID_VALUE</msg:id><msg:lastName>Doe</msg:lastName><msg:firstName>John</msg:firstName><msg:dateOfBirth>1970-01-01</msg:dateOfBirth><msg:correspondenceLanguage>ENG</msg:correspondenceLanguage><msg:emailAddress>jdoe@doe.com</msg:emailAddress><msg:lookupPermission>ALLOWED</msg:lookupPermission><msg:companyAddress><ct:address xmlns:ct="http://test-soap.com/api/common/types"><ct:streetName>Street</ct:streetName><ct:postalCode>Code</ct:postalCode><ct:city>City</ct:city><ct:countryCode>US</ct:countryCode></ct:address><ct:companyName>ACME</ct:companyName></msg:companyAddress></msg:registerUserRequest>');
+      assert.strictEqual(requestAsXML, '<msg:registerUserRequest xmlns:msg="http://test-soap.com/api/registration/messages" xmlns="http://test-soap.com/api/registration/messages"><msg:id>ID00000000000000000000000000000000</msg:id><msg:lastName>Doe</msg:lastName><msg:firstName>John</msg:firstName><msg:dateOfBirth>1970-01-01</msg:dateOfBirth><msg:correspondenceLanguage>ENG</msg:correspondenceLanguage><msg:emailAddress>jdoe@doe.com</msg:emailAddress><msg:lookupPermission>ALLOWED</msg:lookupPermission><msg:companyAddress><ct:address xmlns:ct="http://test-soap.com/api/common/types"><ct:streetName>Street</ct:streetName><ct:postalCode>Code</ct:postalCode><ct:city>City</ct:city><ct:countryCode>US</ct:countryCode></ct:address><ct:companyName xmlns:ct="http://test-soap.com/api/common/types">ACME</ct:companyName></msg:companyAddress></msg:registerUserRequest>');
 
       done();
     });

--- a/test/wsdl-parse-test.js
+++ b/test/wsdl-parse-test.js
@@ -54,4 +54,80 @@ describe(__filename, function () {
       done();
     });
   });
+
+  it('should parse complex wsdls', function (done) {
+    open_wsdl(path.resolve(__dirname, 'wsdl/complex/registration.wsdl'), function (err, def) {
+      if (err) {
+        return done( err );
+      }
+
+      if (null === def.findSchemaType('recipientAddress', 'http://test-soap.com/api/common/types')) {
+        return done( 'Unable to find "recipientAddress" complex type' );
+      }
+      if (null === def.findSchemaType('commonAddress', 'http://test-soap.com/api/common/types')) {
+        return done( 'Unable to find "commonAddress" complex type' );
+      }
+      if (null === def.findSchemaType('companyAddress', 'http://test-soap.com/api/common/types')) {
+        return done( 'Unable to find "companyAddress" complex type' );
+      }
+      if (null === def.findSchemaObject('http://test-soap.com/api/registration/messages', 'registerUserRequest')) {
+        return done( 'Unable to find "registerUserRequest" schema object' );
+      }
+
+      var requestBody = {
+        id: 'FI_ID_VALUE',
+        lastName: 'Doe',
+        firstName: 'John',
+        dateOfBirth: '1970-01-01',
+        correspondenceLanguage: 'ENG',
+        emailAddress: 'jdoe@doe.com',
+        lookupPermission: 'ALLOWED',
+        companyAddress: {
+          address: {
+            streetName: 'Street',
+            postalCode: 'Code',
+            city: 'City',
+            countryCode: 'US'
+          },
+          companyName: 'ACME'
+        }
+      }
+
+      var requestAsXML = def.objectToDocumentXML(
+        'registerUserRequest', 
+        requestBody, 
+        'msg',
+        'http://test-soap.com/api/registration/messages',
+        'registerUserRequest'
+      );
+
+      console.log(requestAsXML);
+
+      /*
+      Expected XML
+      <msg:registerUserRequest xmlns:msg="http://test-soap.com/api/registration/messages" xmlns="http://test-soap.com/api/registration/messages">
+        <msg:id>FI_ID_VALUE</msg:id>
+        <msg:lastName>Doe</msg:lastName>
+        <msg:firstName>John</msg:firstName>
+        <msg:dateOfBirth>1970-01-01</msg:dateOfBirth>
+        <msg:correspondenceLanguage>ENG</msg:correspondenceLanguage>
+        <msg:emailAddress>jdoe@doe.com</msg:emailAddress>
+        <msg:lookupPermission>ALLOWED</msg:lookupPermission>
+        <msg:companyAddress>
+          <ct:address xmlns:ct="http://test-soap.com/api/common/types">
+            <ct:streetName>Street</ct:streetName>
+            <ct:postalCode>Code</ct:postalCode>
+            <ct:city>City</ct:city>
+            <ct:countryCode>US</ct:countryCode>
+          </ct:address>
+          <ct:companyName>ACME</ct:companyName>
+        </msg:companyAddress>
+      </msg:registerUserRequest>
+      */
+      assert.strictEqual(requestAsXML, '<msg:registerUserRequest xmlns:msg="http://test-soap.com/api/registration/messages" xmlns="http://test-soap.com/api/registration/messages"><msg:id>FI_ID_VALUE</msg:id><msg:lastName>Doe</msg:lastName><msg:firstName>John</msg:firstName><msg:dateOfBirth>1970-01-01</msg:dateOfBirth><msg:correspondenceLanguage>ENG</msg:correspondenceLanguage><msg:emailAddress>jdoe@doe.com</msg:emailAddress><msg:lookupPermission>ALLOWED</msg:lookupPermission><msg:companyAddress><ct:address xmlns:ct="http://test-soap.com/api/common/types"><ct:streetName>Street</ct:streetName><ct:postalCode>Code</ct:postalCode><ct:city>City</ct:city><ct:countryCode>US</ct:countryCode></ct:address><ct:companyName>ACME</ct:companyName></msg:companyAddress></msg:registerUserRequest>');
+
+      done();
+    });
+  });
+
 });

--- a/test/wsdl/complex/common-messages.xsd
+++ b/test/wsdl/complex/common-messages.xsd
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="http://test-soap.com/api/common/messages"
+            xmlns:tns="http://test-soap.com/api/common/messages"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            version="5.0">
+
+  <xsd:annotation>
+    <xsd:documentation>Common Messages</xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:complexType name="errorDetailParameter">
+    <xsd:sequence>
+      <xsd:element name="key" type="xsd:string"/>
+      <xsd:element name="value" type="xsd:string"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="errorDetailParameters">
+    <xsd:sequence>
+      <xsd:element name="parameter" type="tns:errorDetailParameter" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:element name="errorDetail">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="code" type="xsd:string"/>
+        <xsd:element name="message" type="xsd:string"/>
+        <xsd:element name="parameters" type="tns:errorDetailParameters" minOccurs="0"/>
+        <xsd:element name="staleData" type="xsd:boolean" default="false"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+</xsd:schema>

--- a/test/wsdl/complex/common-types.xsd
+++ b/test/wsdl/complex/common-types.xsd
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="http://test-soap.com/api/common/types"
+            xmlns:tns="http://test-soap.com/api/common/types"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            version="5.0">
+
+  <xsd:annotation>
+    <xsd:documentation>Common Types</xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:simpleType name="mandatoryStringType">
+    <xsd:restriction base="xsd:string">
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="mandatoryStringWithMaxLength35Type">
+    <xsd:restriction base="tns:mandatoryStringType">
+      <xsd:maxLength value="35"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="mandatoryStringWithMaxLength70Type">
+    <xsd:restriction base="tns:mandatoryStringType">
+      <xsd:maxLength value="70"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="emailAddressType">
+    <xsd:restriction base="tns:mandatoryStringType">
+      <xsd:maxLength value="256"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="correspondenceLanguageType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="GER"/>
+      <xsd:enumeration value="ITA"/>
+      <xsd:enumeration value="FRE"/>
+      <xsd:enumeration value="ENG"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="idType">
+    <xsd:restriction base="tns:mandatoryStringType">
+      <xsd:pattern value="ID[A-Z0-9]{32}"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="lookupType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="ALLOWED"/>
+      <xsd:enumeration value="NOT_ALLOWED"/>
+      <xsd:enumeration value="UNDECIDED"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="postalCodeType">
+    <xsd:restriction base="tns:mandatoryStringType">
+      <xsd:maxLength value="9"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="countryCodeType">
+    <xsd:annotation>
+      <xsd:documentation>ISO-3166</xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="[A-Z]{2}"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:complexType name="recipientAddress">
+    <xsd:sequence>
+      <xsd:element name="streetName" type="tns:mandatoryStringWithMaxLength70Type"/>
+      <xsd:element name="postalCode" type="tns:postalCodeType"/>
+      <xsd:element name="city" type="tns:mandatoryStringWithMaxLength35Type"/>
+      <xsd:element name="countryCode" type="tns:countryCodeType"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="commonAddress" abstract="true">
+    <xsd:sequence>
+      <xsd:element name="address" type="tns:recipientAddress"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="privateAddress">
+    <xsd:complexContent>
+      <xsd:extension base="tns:commonAddress"/>
+    </xsd:complexContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="companyAddress">
+    <xsd:complexContent>
+      <xsd:extension base="tns:commonAddress">
+        <xsd:sequence>
+          <xsd:element name="companyName" type="tns:mandatoryStringWithMaxLength70Type"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+
+  <xsd:simpleType name="userIdType">
+    <xsd:restriction base="tns:mandatoryStringType">
+      <xsd:pattern value="EBID[A-Z0-9]{32}"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+</xsd:schema>

--- a/test/wsdl/complex/registration-common.wsdl
+++ b/test/wsdl/complex/registration-common.wsdl
@@ -40,7 +40,7 @@
     <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
 
     <wsdl:operation name="registerUser">
-      <soap:operation soapAction="http://test-soap.com/api/registration/registerCUser"/>
+      <soap:operation soapAction="http://test-soap.com/api/registration/registerUser"/>
       <wsdl:input>
         <soap:body parts="registerUserRequest" use="literal"/>
       </wsdl:input>

--- a/test/wsdl/complex/registration-common.wsdl
+++ b/test/wsdl/complex/registration-common.wsdl
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="RegistrationCommonApi"
+                  targetNamespace="http://test-soap.com/api/registration"
+                  xmlns:tns="http://test-soap.com/api/registration"
+                  xmlns:registrationMessages="http://test-soap.com/api/registration/messages"
+                  xmlns:commonMessages="http://test-soap.com/api/common/messages"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+>
+
+  <wsdl:documentation>Registration Web Service Definition</wsdl:documentation>
+
+  <wsdl:types>
+    <xsd:schema targetNamespace="http://test-soap.com/api/registration" elementFormDefault="qualified">
+      <xsd:import namespace="http://test-soap.com/api/registration/messages" schemaLocation="registration-messages-common.xsd"/>
+      <xsd:import namespace="http://test-soap.com/api/common/messages" schemaLocation="common-messages.xsd"/>
+      <xsd:import namespace="http://test-soap.com/api/common/types" schemaLocation="common-types.xsd"/>
+    </xsd:schema>
+  </wsdl:types>
+
+  <wsdl:message name="registerUserRequestMessage">
+    <wsdl:part name="registerUserRequest" element="registrationMessages:registerUserRequest"/>
+  </wsdl:message>
+  <wsdl:message name="registerUserResponseMessage">
+    <wsdl:part name="registerUserResponse" element="registrationMessages:registerUserResponse"/>
+  </wsdl:message>
+
+  <wsdl:portType name="registrationCommonPortType">
+
+    <wsdl:operation name="registerUser">
+      <wsdl:input name="registerUserRequestMessage" message="tns:registerUserRequestMessage"/>
+      <wsdl:output name="registerUserResponseMessage" message="tns:registerUserResponseMessage"/>
+      <wsdl:fault name="errorDetail" message="tns:errorDetailMessage"/>
+    </wsdl:operation>
+
+  </wsdl:portType>
+
+  <wsdl:binding name="registrationCommonHttpSoapBinding" type="tns:registrationCommonPortType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+
+    <wsdl:operation name="registerUser">
+      <soap:operation soapAction="http://test-soap.com/api/registration/registerCUser"/>
+      <wsdl:input>
+        <soap:body parts="registerUserRequest" use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body parts="registerUserResponse" use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="errorDetail">
+        <soap:fault name="errorDetail" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+
+  </wsdl:binding>
+
+  <wsdl:service name="registrationCommon">
+    <wsdl:port name="registrationCommonHttpSoapPort" binding="tns:registrationCommonHttpSoapBinding">
+      <soap:address location="https://{{SERVER}}/api/api/v5/registration"/>
+    </wsdl:port>
+  </wsdl:service>
+
+</wsdl:definitions>

--- a/test/wsdl/complex/registration-messages-common.xsd
+++ b/test/wsdl/complex/registration-messages-common.xsd
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="http://test-soap.com/api/registration/messages"
+            xmlns:ct="http://test-soap.com/api/common/types"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            version="5.0">
+
+  <xsd:annotation>
+    <xsd:documentation>Registration Messages</xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:import namespace="http://test-soap.com/api/common/types" schemaLocation="common-types.xsd"/>
+
+  <xsd:element name="registerUserRequest">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="id" type="ct:idType"/>
+        <xsd:element name="lastName" type="ct:mandatoryStringWithMaxLength35Type"/>
+        <xsd:element name="firstName" type="ct:mandatoryStringWithMaxLength35Type"/>
+        <xsd:element name="dateOfBirth" type="xsd:date"/>
+        <xsd:element name="correspondenceLanguage" type="ct:correspondenceLanguageType"/>
+        <xsd:element name="emailAddress" type="ct:emailAddressType"/>
+        <xsd:element name="lookupPermission" type="ct:lookupType"/>
+        <xsd:choice>
+          <xsd:element name="privateAddress" type="ct:privateAddress"/>
+          <xsd:element name="companyAddress" type="ct:companyAddress"/>
+        </xsd:choice>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="registerUserResponse">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="userId" type="ct:userIdType"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+</xsd:schema>

--- a/test/wsdl/complex/registration-messages.xsd
+++ b/test/wsdl/complex/registration-messages.xsd
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="http://test-soap.com/api/registration/messages"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            version="5.0">
+
+  <xsd:annotation>
+    <xsd:documentation>Registration Messages</xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="registration-messages-common.xsd"/>
+
+</xsd:schema>

--- a/test/wsdl/complex/registration.wsdl
+++ b/test/wsdl/complex/registration.wsdl
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="RegistrationnApi"
+                  targetNamespace="http://test-soap.com/api/registration"
+                  xmlns:tns="http://test-soap.com/api/registration"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+>
+
+  <wsdl:documentation>Registration Web Service Definition</wsdl:documentation>
+
+  <wsdl:import namespace="http://test-soap.com/api/registration" location="registration-common.wsdl"/>
+
+  <wsdl:types>
+    <xsd:schema targetNamespace="http://test-soap.com/api/registration" elementFormDefault="qualified">
+      <xsd:import namespace="http://test-soap.com/api/registration/messages" schemaLocation="registration-messages.xsd"/>
+    </xsd:schema>
+  </wsdl:types>
+
+  <wsdl:binding name="registrationPortalHttpSoapBinding" type="tns:registrationPortalPortType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+  </wsdl:binding>
+
+  <wsdl:portType name="registrationPortalPortType">
+  </wsdl:portType>
+
+  <wsdl:service name="registrationPortal">
+    <wsdl:port name="registrationPortalHttpSoapPort" binding="tns:registrationPortalHttpSoapBinding">
+      <soap:address location="https://{{SERVER}}/api/api/v5/registration"/>
+    </wsdl:port>
+  </wsdl:service>
+
+</wsdl:definitions>


### PR DESCRIPTION
Hello,

I added a complex WSLD and its related XSDs to test the case of XSD complexType that extends another complexType + new elements.
Check `common-types.xsd`.
```
<xsd:schema targetNamespace="http://test-soap.com/api/common/types"
              xmlns:tns="http://test-soap.com/api/common/types"
            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
            elementFormDefault="qualified"
            version="5.0">
  
  <xsd:complexType name="recipientAddress">
    <xsd:sequence>
      <xsd:element name="streetName" type="tns:mandatoryStringWithMaxLength70Type"/>
      <xsd:element name="postalCode" type="tns:postalCodeType"/>
      <xsd:element name="city" type="tns:mandatoryStringWithMaxLength35Type"/>
      <xsd:element name="countryCode" type="tns:countryCodeType"/>
    </xsd:sequence>
  </xsd:complexType>

  <xsd:complexType name="commonAddress" abstract="true">
    <xsd:sequence>
      <xsd:element name="address" type="tns:recipientAddress"/>
    </xsd:sequence>
  </xsd:complexType>

  <xsd:complexType name="privateAddress">
    <xsd:complexContent>
      <xsd:extension base="tns:commonAddress"/>
    </xsd:complexContent>
  </xsd:complexType>

  <xsd:complexType name="companyAddress">
    <xsd:complexContent>
      <xsd:extension base="tns:commonAddress">
        <xsd:sequence>
          <xsd:element name="companyName" type="tns:mandatoryStringWithMaxLength70Type"/>
        </xsd:sequence>
      </xsd:extension>
    </xsd:complexContent>
  </xsd:complexType>
...
```

The modified code looks up for the matching namespace into the child's schema definitions instead of the definitions of WSLD.
If the prefix is "tns", the previous code fetched the namespace from the WSDL definition. But the prefix "tns" (and any prefix) can be defined in any schema.
Example in the schema above: xmlns:tns="http://test-soap.com/api/common/types".

What do you think ?

Thank you,
Stephane