### PR TITLE
Fixing Too many properties to enumerate on big XML documents

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -257,7 +257,7 @@ export class Server extends EventEmitter {
 
       // request body is already provided by an express middleware
       // in this case unzipping should also be done by the express middleware itself
-      if (req.body && Object.keys(req.body).length > 0) {
+      if (req.body && req.body.length > 0) {
         return this._processRequestXml(req, res, req.body.toString());
       }
 


### PR DESCRIPTION
This PR fixes an error when receiving a large XML document. When checking for the body length Object.keys is used causing the "Too many properties to enumerate" error for large XML documents.

When checking a length of buffer (when using raw body parser) you get the same results of

```javascript
const buffer = Buffer.from('abc')
console.log(buffer.length) // 3
```

```javascript
const buffer = Buffer.from('abc')
const keys = Object.keys(buffer)
console.log(keys.length) //3
```

When checking a length of a text (when using text body parser) you get the same results of

```javascript
const txt = 'abc'
console.log(text.length) // 3
```

```javascript
const text = 'abc'
const keys = Object.keys(buffer)
console.log(keys.length) //3
```

Except you won't reach the property limit of 65535](https://stackoverflow.com/a/9283945/5189472) for large documents. This PR solves that issue.