### PR TITLE
Allow server path to be a regex

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -72,7 +72,7 @@ interface IExecuteMethodOptions {
 }
 
 export class Server extends EventEmitter {
-  public path: string;
+  public path: string | RegExp;
   public services: IServices;
   public log: (type: string, data: any) => any;
   public authorizeConnection: (req: Request, res?: Response) => boolean;
@@ -86,7 +86,7 @@ export class Server extends EventEmitter {
   private soapHeaders: any[];
   private callback?: (err: any, res: any) => void;
 
-  constructor(server: ServerType, path: string, services: IServices, wsdl: WSDL, options?: IServerOptions) {
+  constructor(server: ServerType, path: string | RegExp, services: IServices, wsdl: WSDL, options?: IServerOptions) {
     super();
 
     options = options || {
@@ -102,8 +102,10 @@ export class Server extends EventEmitter {
     this.enableChunkedEncoding =
       options.enableChunkedEncoding === undefined ? true : !!options.enableChunkedEncoding;
     this.callback = options.callback ? options.callback : () => { };
-    if (path[path.length - 1] !== '/') {
+    if (typeof path === 'string' && path[path.length - 1] !== '/') {
       path += '/';
+    } else if (path instanceof RegExp && path.source[path.source.length - 1] !== '/') {
+      path = new RegExp(path.source + '(?:\\/|)');
     }
     wsdl.onReady((err) => {
       if (isExpress(server)) {
@@ -132,7 +134,7 @@ export class Server extends EventEmitter {
           if (reqPath[reqPath.length - 1] !== '/') {
             reqPath += '/';
           }
-          if (path === reqPath) {
+          if (path === reqPath || (path instanceof RegExp && reqPath.match(path))) {
             this._requestListener(req, res);
           } else {
             for (let i = 0, len = listeners.length; i < len; i++) {

--- a/src/soap.ts
+++ b/src/soap.ts
@@ -98,14 +98,14 @@ export function createClientAsync(url: string, options?: IOptions, endpoint?: st
   });
 }
 
-export function listen(server: ServerType, path: string, services: IServices, wsdl: string, callback?: (err: any, res: any) => void): Server;
+export function listen(server: ServerType, path: string | RegExp, services: IServices, wsdl: string, callback?: (err: any, res: any) => void): Server;
 export function listen(server: ServerType, options: IServerOptions): Server;
-export function listen(server: ServerType, p2: string | IServerOptions, services?: IServices, xml?: string, callback?: (err: any, res: any) => void): Server {
+export function listen(server: ServerType, p2: string | RegExp | IServerOptions, services?: IServices, xml?: string, callback?: (err: any, res: any) => void): Server {
   let options: IServerOptions;
-  let path: string;
+  let path: string | RegExp;
   let uri = '';
 
-  if (typeof p2 === 'object') {
+  if (typeof p2 === 'object' && !(p2 instanceof RegExp)) {
     // p2 is options
     // server, options
     options = p2;

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,7 +140,7 @@ export interface IOneWayOptions {
 }
 
 export interface IServerOptions extends IWsdlBaseOptions {
-  path: string;
+  path: string | RegExp;
   services: IServices;
   xml?: string;
   uri?: string;

--- a/test/server-options-test.js
+++ b/test/server-options-test.js
@@ -586,4 +586,24 @@ describe('SOAP Server with Options', function() {
       });
     });
   });
+
+  it('should accept regex as path', function(done) {
+    test.server.listen(15099, null, null, function() {
+      test.soapServer = soap.listen(test.server, {
+        path: /test\/.*/,
+        services: test.service,
+        xml: test.wsdl
+      }, test.service, test.wsdl);
+
+      soap.createClient(test.baseUrl + '/test/te?wsdl', function(err, client) {
+        assert.ifError(err);
+      });
+
+      soap.createClient(test.baseUrl + '/teste/az?wsdl', function(err, client) {
+        assert.notStrictEqual(err, null);
+        done()
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
Hello,

Little changes that allow the path given to a server to be a regex.
No changes in case of Express server because regex are natively supported by route function.
Add a match to handle http server case.

To be equivalent to the add of the "/" at the end of the path if it doesn't exist, I used the regex `(?:\\/|)` to allow "/" to be facultative in the request. For HTTP server it is already handled by line 134 however in Express the "/" is facultative if the path is a string but isn't if it is a regex, so I added this regex to have the same effect than with a string path.

Don't mind to ask if you have questions or observations.