### PR TITLE
[audit] fix dependency vuln in xmldom via xml-crypto/xmldom update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -293,6 +293,11 @@
       "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
       "dev": true
     },
+    "@xmldom/xmldom": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.2.tgz",
+      "integrity": "sha512-t/Zqo0ewes3iq6zGqEqJNUWI27Acr3jkmSUNp6E3nl0Z2XbtqAG5XYqPNLdYonILmhcxANsIidh69tHzjXtuRg=="
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -3893,18 +3898,13 @@
       "dev": true
     },
     "xml-crypto": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.2.tgz",
-      "integrity": "sha512-DBhZXtBjENtLwJmeJhLUBwUm9YWNjCRvAx6ESP4VJyM9PDuKqZu2Fp5Y5HKqcdJT7vV7eI25Z4UBMezji6QloQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.3.tgz",
+      "integrity": "sha512-MpXZwnn9JK0mNPZ5mnFIbNnQa+8lMGK4NtnX2FlJMfMWR60sJdFO9X72yO6ji068pxixzk53O7x0/iSKh6IhyQ==",
       "requires": {
-        "xmldom": "^0.6.0",
+        "@xmldom/xmldom": "^0.7.0",
         "xpath": "0.0.32"
       }
-    },
-    "xmldom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
     },
     "xpath": {
       "version": "0.0.32",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "sax": ">=0.6",
     "strip-bom": "^3.0.0",
     "uuid": "^8.3.2",
-    "xml-crypto": "^2.1.0"
+    "xml-crypto": "^2.1.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`xmldom` is depended on by `xml-crypto`. The former's version 0.6.0 and below is vulnerable to "Misinterpretation of malicious XML input". The xmldom project has moved to a scoped release `@xmldom/xmldom` and the update to `xml-crypto` reflects that.
Please apply ASAP. Thank you!