### PR TITLE
Fix typo in ISoapFault12

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -416,7 +416,7 @@ export class Server extends EventEmitter {
           return this._sendError({
             Code: {
               Value: 'SOAP-ENV:Server',
-              Subcode: { value: 'InternalServerError' },
+              Subcode: { Value: 'InternalServerError' },
             },
             Reason: { Text: authResult.toString() },
             statusCode: 500,
@@ -435,7 +435,7 @@ export class Server extends EventEmitter {
               return this._sendError({
                 Code: {
                   Value: 'SOAP-ENV:Server',
-                  Subcode: { value: 'InternalServerError' },
+                  Subcode: { Value: 'InternalServerError' },
                 },
                 Reason: { Text: error.toString() },
                 statusCode: 500,
@@ -445,7 +445,7 @@ export class Server extends EventEmitter {
             return this._sendError({
               Code: {
                 Value: 'SOAP-ENV:Client',
-                Subcode: { value: 'AuthenticationFailure' },
+                Subcode: { Value: 'AuthenticationFailure' },
               },
               Reason: { Text: 'Invalid username or password' },
               statusCode: 401,
@@ -527,7 +527,7 @@ export class Server extends EventEmitter {
           return this._sendError({
             Code: {
               Value: 'SOAP-ENV:Server',
-              Subcode: { value: 'InternalServerError' },
+              Subcode: { Value: 'InternalServerError' },
             },
             Reason: { Text: error.toString() },
             statusCode: 500,

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,7 +53,7 @@ export interface ISoapFault11 {
 // Role, Node, Detail. Should be added when soap module implements them
 // https://www.w3.org/TR/soap12/#soapfault
 export interface ISoapFault12 {
-  Code: { Value: string; Subcode?: { value: string; }; };
+  Code: { Value: string; Subcode?: { Value: string; }; };
   Reason: { Text: string; };
   statusCode?: number;
 }

--- a/test/server-authentication-test.js
+++ b/test/server-authentication-test.js
@@ -134,8 +134,8 @@ describe('SOAP Server', function () {
         assert.ok(err);
         assert.ok(err.root.Envelope.Body.Fault.Code.Value);
         assert.equal(err.root.Envelope.Body.Fault.Code.Value, 'SOAP-ENV:Client');
-        assert.ok(err.root.Envelope.Body.Fault.Code.Subcode.value);
-        assert.equal(err.root.Envelope.Body.Fault.Code.Subcode.value, 'AuthenticationFailure');
+        assert.ok(err.root.Envelope.Body.Fault.Code.Subcode.Value);
+        assert.equal(err.root.Envelope.Body.Fault.Code.Subcode.Value, 'AuthenticationFailure');
         done();
       });
     });
@@ -155,8 +155,8 @@ describe('SOAP Server', function () {
         assert.ok(err);
         assert.ok(err.root.Envelope.Body.Fault.Code.Value);
         assert.equal(err.root.Envelope.Body.Fault.Code.Value, 'SOAP-ENV:Client');
-        assert.ok(err.root.Envelope.Body.Fault.Code.Subcode.value);
-        assert.equal(err.root.Envelope.Body.Fault.Code.Subcode.value, 'AuthenticationFailure');
+        assert.ok(err.root.Envelope.Body.Fault.Code.Subcode.Value);
+        assert.equal(err.root.Envelope.Body.Fault.Code.Subcode.Value, 'AuthenticationFailure');
         done();
       });
     });
@@ -178,8 +178,8 @@ describe('SOAP Server', function () {
         assert.ok(err);
         assert.ok(err.root.Envelope.Body.Fault.Code.Value);
         assert.equal(err.root.Envelope.Body.Fault.Code.Value, 'SOAP-ENV:Client');
-        assert.ok(err.root.Envelope.Body.Fault.Code.Subcode.value);
-        assert.equal(err.root.Envelope.Body.Fault.Code.Subcode.value, 'AuthenticationFailure');
+        assert.ok(err.root.Envelope.Body.Fault.Code.Subcode.Value);
+        assert.equal(err.root.Envelope.Body.Fault.Code.Subcode.Value, 'AuthenticationFailure');
         done();
       });
     });
@@ -199,8 +199,8 @@ describe('SOAP Server', function () {
         assert.ok(err);
         assert.ok(err.root.Envelope.Body.Fault.Code.Value);
         assert.equal(err.root.Envelope.Body.Fault.Code.Value, 'SOAP-ENV:Server');
-        assert.ok(err.root.Envelope.Body.Fault.Code.Subcode.value);
-        assert.equal(err.root.Envelope.Body.Fault.Code.Subcode.value, 'InternalServerError');
+        assert.ok(err.root.Envelope.Body.Fault.Code.Subcode.Value);
+        assert.equal(err.root.Envelope.Body.Fault.Code.Subcode.Value, 'InternalServerError');
         done();
       });
     });
@@ -220,8 +220,8 @@ describe('SOAP Server', function () {
         assert.ok(err);
         assert.ok(err.root.Envelope.Body.Fault.Code.Value);
         assert.equal(err.root.Envelope.Body.Fault.Code.Value, 'SOAP-ENV:Server');
-        assert.ok(err.root.Envelope.Body.Fault.Code.Subcode.value);
-        assert.equal(err.root.Envelope.Body.Fault.Code.Subcode.value, 'InternalServerError');
+        assert.ok(err.root.Envelope.Body.Fault.Code.Subcode.Value);
+        assert.equal(err.root.Envelope.Body.Fault.Code.Subcode.Value, 'InternalServerError');
         done();
       });
     });


### PR DESCRIPTION
`value` within `Subcode` object should be capitalized to `Value` according to SOAP Fault 1.2 spec.
See https://www.w3.org/TR/soap12-part1/#faultsubvalueelem

Originally I think it was my mistake since I contributed the previous types  to DefinitelyTyped.
