### PR TITLE
Publicly expose wsdl in Client

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -55,7 +55,7 @@ export class Client extends EventEmitter {
   public lastElapsedTime?: number;
   public lastResponseAttachments: IMTOMAttachments;
 
-  private wsdl: WSDL;
+  public wsdl: WSDL;
   private httpClient: IHttpClient;
   private soapHeaders: any[];
   private httpHeaders: IHeaders;


### PR DESCRIPTION
The `wsdl` property in `Client` is currently private. And while it's possible to manually construct it using `new WSDL(...)`, the actual implementation as done in `createClient(...)` is more complicated and does caching/fetching from file or url/etc.