### PR TITLE
fix:ref attributes convert list

### DIFF
--- a/src/wsdl/elements.ts
+++ b/src/wsdl/elements.ts
@@ -244,6 +244,13 @@ export class ElementElement extends Element {
           let elem: any = {};
           typeStorage[typeName] = elem;
 
+          if (isMany) {
+            typeElement['maxOccurs'] = this.$maxOccurs
+          }
+          if (Boolean(this.$minOccurs)) {
+            typeElement['minOccurs'] = this.$minOccurs
+          }
+
           const description = typeElement.description(definitions, xmlns);
           if (typeof description === 'string') {
             elem = description;


### PR DESCRIPTION
Consider this XSD:

```
<xs:elements ref="tns:DummyList" minOccurs="1" maxOccurs="10" />
<xs:element name="DummyList">
  <xs:complexType> 
    <xs:sequence>
      <xs:element ref="DummyValues" minOccurs="1" maxOccurs="10" />
    </xs:sequence>
  </xs:complexType>
</xs:element>
```

I expected DummyList and DummyValues to be returned in List

sample response SOAP:

```
<Parent>
  <DummyList>
    <DummyValues>Hello</DummyValues>
  </DummyList>
</Parent>
```

The current value being returned.

```
{
  DummyList: {
    DummyValues: "Hello"
  }
}
```

When ref is used to set maxoccurs, if the returned value is a single value, it will not be converted to an array.

Response I'm expecting.

```
{
  DummyList[{
    DummyValues: ["Hello"]
  ]}
}
```

Similar to issues#1100
