### PR TITLE
soap-header-fix

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -439,7 +439,7 @@ export class Client extends EventEmitter {
       'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
       encoding +
       this.wsdl.xmlnsInEnvelope + '>' +
-      ((decodedHeaders || this.security) ?
+      ((decodedHeaders || this.security && this.security.toXML()) ?
         (
           '<' + envelopeKey + ':Header' + (this.wsdl.xmlnsInHeader ? (' ' + this.wsdl.xmlnsInHeader) : '') + '>' +
           (decodedHeaders ? decodedHeaders : '') +


### PR DESCRIPTION
There is an issue with appearing of empty soap:Header tag, although decodedHeaders are set to null it's being formed, because of this.security is defined, but this.security.toXML() returns empty string.