### PR TITLE
Change axios to be a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.43.0",
       "license": "MIT",
       "dependencies": {
-        "axios": "^0.21.1",
         "axios-ntlm": "^1.2.0",
         "debug": "^4.3.2",
         "formidable": "^1.2.2",
@@ -55,6 +54,9 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "axios": "^0.21.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -517,6 +519,7 @@
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
       "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.10.0"
       }
@@ -5306,6 +5309,7 @@
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
       "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "peer": true,
       "requires": {
         "follow-redirects": "^1.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   },
   "author": "Vinay Pulim <v@pulim.com>",
   "dependencies": {
-    "axios": "^0.21.1",
     "axios-ntlm": "^1.2.0",
     "debug": "^4.3.2",
     "formidable": "^1.2.2",
@@ -18,6 +17,9 @@
     "uuid": "^8.3.2",
     "whatwg-mimetype": "3.0.0",
     "xml-crypto": "^2.1.3"
+  },
+  "peerDependencies": {
+    "axios": "^0.21.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The usage of axios in this repository is very basic, but its versioning
is defined very tightly. This causes problems, because the interface
IOptions uses AxiosInstance as its property, preventing the clients of
this library from updating their axios version beyond the limits set in
this library. Typescript compiler gives type error when giving higher
version AxiosInstance for IOptions.

By setting axios as a peer dependency, we would allow the clients of
this library to install other versions of axios if they so choose.