### PR TITLE
Removed double await in async and fixed response

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -161,7 +161,7 @@ Construct a `Promise<Client>` with the given WSDL file.
   // async/await
   var client = await soap.createClientAsync(url);
   var result = await client.MyFunctionAsync(args);
-  console.log(await result);
+  console.log(result);
 ```
 
 Note: for versions of node >0.10.X, you may need to specify `{connection: 'keep-alive'}` in SOAP headers to avoid truncation of longer chunked responses.

--- a/Readme.md
+++ b/Readme.md
@@ -161,7 +161,7 @@ Construct a `Promise<Client>` with the given WSDL file.
   // async/await
   var client = await soap.createClientAsync(url);
   var result = await client.MyFunctionAsync(args);
-  console.log(result);
+  console.log(result[0]);
 ```
 
 Note: for versions of node >0.10.X, you may need to specify `{connection: 'keep-alive'}` in SOAP headers to avoid truncation of longer chunked responses.


### PR DESCRIPTION
There's no need to call await again on the result object since result is already resolved.