### PR TITLE
promisifyMethod return object instead of array to allow for destructuring

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -236,7 +236,7 @@ export class Client extends EventEmitter {
           if (err) {
             reject(err);
           } else {
-            resolve([result, rawResponse, soapHeader, rawRequest, mtomAttachments]);
+            resolve({result, rawResponse, soapHeader, rawRequest, mtomAttachments});
           }
         };
         method(


### PR DESCRIPTION
Currently, if users do this:
> const result =  await client.MyFunction(args) 
The result will be equal to an array containing result, rawResponse, soapHeader, rawRequest, mtomAttachments. And if they want just the parsed JSON response they have to do result[0].

This is fine. But if we make promisify return an object instead of an array, they could do this:
> const { result } =  await client.MyFunction(args)

