### PR TITLE
Fix axios peer dependency version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "node": ">=12.0.0"
       },
       "peerDependencies": {
-        "axios": "^0.21.1"
+        "axios": ">=0.21.1"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "xml-crypto": "^2.1.3"
   },
   "peerDependencies": {
-    "axios": "^0.21.1"
+    "axios": ">=0.21.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This fixes the issue mentioned in #1180. It should remain a peer dependency since its types are exposed by this library, but the version restriction should be loosened. Hopefully this can be released soon as the current version of the library cannot be installed if a user has a direct dependency on a newer version of axios.