### PR TITLE
feature to have the option to change the key of the wsdl 

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -188,6 +188,10 @@ export class Client extends EventEmitter {
         }
       }
     }
+
+    if(options.overrideElementKey !== undefined) {
+      this.wsdl.options.overrideElementKey = options.overrideElementKey;
+    }
     if (options.overrideRootElement !== undefined) {
       this.wsdl.options.overrideRootElement = options.overrideRootElement;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,7 +89,7 @@ export interface IWsdlBaseOptions {
   valueKey?: string;
   xmlKey?: string;
   overrideRootElement?: { namespace: string; xmlnsAttributes?: IXmlAttribute[]; };
-  overrideElementKey?: Array<string>
+  overrideElementKey?: Object
   ignoredNamespaces?: boolean | string[] | { namespaces?: string[]; override?: boolean; };
   ignoreBaseNameSpaces?: boolean;
   /** escape special XML characters in SOAP message (e.g. &, >, < etc), default: true. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,6 +89,7 @@ export interface IWsdlBaseOptions {
   valueKey?: string;
   xmlKey?: string;
   overrideRootElement?: { namespace: string; xmlnsAttributes?: IXmlAttribute[]; };
+  overrideElementKey?: Array<string>
   ignoredNamespaces?: boolean | string[] | { namespaces?: string[]; override?: boolean; };
   ignoreBaseNameSpaces?: boolean;
   /** escape special XML characters in SOAP message (e.g. &, >, < etc), default: true. */

--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -637,7 +637,7 @@ export class WSDL {
   public objectToXML(obj, name: string, nsPrefix: any, nsURI: string, isFirst?: boolean, xmlnsAttr?, schemaObject?, nsContext?: NamespaceContext) {
     const schema = this.definitions.schemas[nsURI];
 
-    if(this.options.overrideElementKey.length > 0) {
+    if(Object.keys(this.options.overrideElementKey).length > 0) {
       for (let key in this.options.overrideElementKey) {
         const overrideKey = this.options.overrideElementKey[key];
         if (obj && obj[key]) {

--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -637,7 +637,7 @@ export class WSDL {
   public objectToXML(obj, name: string, nsPrefix: any, nsURI: string, isFirst?: boolean, xmlnsAttr?, schemaObject?, nsContext?: NamespaceContext) {
     const schema = this.definitions.schemas[nsURI];
 
-    if(Object.keys(this.options.overrideElementKey).length > 0) {
+    if(this.options.overrideElementKey && Object.keys(this.options.overrideElementKey).length > 0) {
       for (let key in this.options.overrideElementKey) {
         const overrideKey = this.options.overrideElementKey[key];
         if (obj && obj[key]) {

--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -1186,6 +1186,9 @@ export class WSDL {
     this.options.forceSoap12Headers = options.forceSoap12Headers;
     this.options.customDeserializer = options.customDeserializer;
 
+    if(options.overrideElementKey !== undefined) {
+      this.options.overrideElementKey = options.overrideElementKey;
+    }
     if (options.overrideRootElement !== undefined) {
       this.options.overrideRootElement = options.overrideRootElement;
     }

--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -637,6 +637,17 @@ export class WSDL {
   public objectToXML(obj, name: string, nsPrefix: any, nsURI: string, isFirst?: boolean, xmlnsAttr?, schemaObject?, nsContext?: NamespaceContext) {
     const schema = this.definitions.schemas[nsURI];
 
+    if(this.options.overrideElementKey.length > 0) {
+      for (let key in this.options.overrideElementKey) {
+        const overrideKey = this.options.overrideElementKey[key];
+        if (obj && obj[key]) {
+          Object.defineProperty(obj, overrideKey,
+              Object.getOwnPropertyDescriptor(obj, key));
+          delete obj[key];
+        }
+      }
+    }
+
     let parentNsPrefix = nsPrefix ? nsPrefix.parent : undefined;
     if (typeof parentNsPrefix !== 'undefined') {
       // we got the parentNsPrefix for our array. setting the namespace-variable back to the current namespace string


### PR DESCRIPTION
I was having a problem with a company, that the wsdl was returning the wrong data to the soapclient; but despite i knew the expected data, I can't change by the code.
So I made a small change that allow me to change the XML key before send to the server
I just have to pass an object with the key value that I want to change, and the value that I want that this key have
```
        const options = { 
            overrideElementKey: {
                oldKeyOnTheXML: "NewKeyOnTheXML"
            }
        }
```

