### PR TITLE
Bumped Axios version to ">=0.25.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "xml-crypto": "^2.1.3"
   },
   "peerDependencies": {
-    "axios": ">=0.21.1"
+    "axios": ">=0.25.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
If the response size for any SOAP API is greater than 0x1fffffe8 characters then getting the following uncaught error and node process is crashing.
```
Error: Cannot create a string longer than 0x1fffffe8 characters
    at Buffer.utf8Slice (<anonymous>)
    at Buffer.toString (buffer.js:799:17)
    at IncomingMessage.handleStreamEnd (/ws/node_modules/soap/node_modules/axios/lib/adapters/http.js:262:41)
    at IncomingMessage.emit (events.js:327:22)
    at IncomingMessage.EventEmitter.emit (domain.js:467:12)
    at endReadableNT (internal/streams/readable.js:1327:12)
    at processTicksAndRejections (internal/process/task_queues.js:80:21) {
  code: 'ERR_STRING_TOO_LONG'
}
```

The issue is due to older version of Axios (https://github.com/axios/axios/blob/v0.21.1/lib/adapters/http.js#L253) not properly handling this error.

But this is fixed in v0.25.0 of Axios (https://github.com/axios/axios/blob/v0.25.0/lib/adapters/http.js#L302).  So bumped the axios version to >=0.25.0 in the package.json
