### PR TITLE
Allow soap.createClient to create a new SOAP client from a WSDL string

### DIFF
--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -1399,7 +1399,12 @@ export function open_wsdl(uri: any, p2: WSDLCallback | IOptions, p3?: WSDLCallba
   const request_options = options.wsdl_options;
 
   let wsdl: WSDL;
-  if (!/^https?:/i.test(uri)) {
+  if (/^\<\?xml[^>]*?>/i.test(uri)) {
+    wsdl = new WSDL(uri, uri, options);
+    WSDL_CACHE[uri] = wsdl;
+    wsdl.WSDL_CACHE = WSDL_CACHE;
+    wsdl.onReady(callback);
+  } else if (!/^https?:/i.test(uri)) {
     debug('Reading file: %s', uri);
     fs.readFile(uri, 'utf8', (err, definition) => {
       if (err) {


### PR DESCRIPTION
Currently `soap.createClient` can create a new SOAP client from a WSDL url or local filesystem path. Creating a new SOAP client from a string containing the WSDL isn't supported.

This PR extends the `open_wsdl` function to detect a XML string being passed to it, and if so directly creates a `WSDL` based on it (instead of first loading the `definition` from file or uri)