### PR TITLE
Check if Schema has been defined

### DIFF
--- a/src/wsdl/elements.ts
+++ b/src/wsdl/elements.ts
@@ -589,7 +589,7 @@ export class MessageElement extends Element {
       const nsName = splitQName(part.$element);
       const ns = nsName.prefix;
       let schema = definitions.schemas[definitions.xmlns[ns]];
-      this.element = schema.elements[nsName.name];
+      if(schema) this.element = schema.elements[nsName.name];
       if (!this.element) {
         debug(nsName.name + ' is not present in wsdl and cannot be processed correctly.');
         return;


### PR DESCRIPTION
**The Problem:**
Some Magento XML gets an error in the line ``this.element = schema.elements[nsName.name];`` because schema is undefined.

**The Solution:**
Simple check if schema has been defined ``if(schema) this.element = schema.elements[nsName.name];``

**Tests:**
All existing tests passed. I didn't create a new test because all worked well and new tests would be the same.