### PR TITLE
Allow WSSecurity and WSSecurityCert to be used together

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -929,6 +929,7 @@ The `options` object is optional and can contain the following properties:
   * `existingPrefixes`: (optional) A hash of prefixes and namespaces prefix: namespace that shouldn't be in the signature because they already exist in the xml (default: `{ 'wsse': 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd' }`)
   * `prefix`: (optional) Adds this value as a prefix for the generated signature tags.
   * `attrs`: (optional) A hash of attributes and values attrName: value to add to the signature root node
+  * `idMode`: (optional) either 'wssecurity' to generate wsse-scoped reference Id on <Body> or undefined for an unscoped reference Id
 
 ### WSSecurityPlusCert
 

--- a/Readme.md
+++ b/Readme.md
@@ -930,6 +930,17 @@ The `options` object is optional and can contain the following properties:
   * `prefix`: (optional) Adds this value as a prefix for the generated signature tags.
   * `attrs`: (optional) A hash of attributes and values attrName: value to add to the signature root node
 
+### WSSecurityPlusCert
+
+Use WSSecurity and WSSecurityCert together.
+
+``` javascript
+  var wsSecurity = new soap.WSSecurity(/* see WSSecurity above */);
+  var wsSecurityCert = new soap.WSSecurityCert(/* see WSSecurityCert above */);
+  var wsSecurityPlusCert = new soap.WSSecurityPlusCert(wsSecurity, wsSecurityCert);
+  client.setSecurity(wsSecurityPlusCert);
+```
+
 #### Option examples
 
 `hasTimeStamp:true`

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "xml-crypto": "^2.1.3"
       },
       "devDependencies": {
+        "@types/axios": "^0.14.0",
         "@types/debug": "^4.1.7",
         "@types/express": "^4.17.13",
         "@types/formidable": "^2.0.4",
@@ -194,6 +195,16 @@
         "structured-source": "^3.0.2",
         "traverse": "^0.6.6",
         "unified": "^6.1.6"
+      }
+    },
+    "node_modules/@types/axios": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz",
+      "integrity": "sha512-KqQnQbdYE54D7oa/UmYVMZKq7CO4l8DEENzOKc4aBRwxCXSlJXGz83flFx5L7AWrOQnmuN3kVsRdt+GZPPjiVQ==",
+      "deprecated": "This is a stub types definition for axios (https://github.com/mzabriskie/axios). axios provides its own type definitions, so you don't need @types/axios installed!",
+      "dev": true,
+      "dependencies": {
+        "axios": "*"
       }
     },
     "node_modules/@types/body-parser": {
@@ -534,7 +545,6 @@
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
       "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.10.0"
       }
@@ -5068,6 +5078,15 @@
         "unified": "^6.1.6"
       }
     },
+    "@types/axios": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz",
+      "integrity": "sha512-KqQnQbdYE54D7oa/UmYVMZKq7CO4l8DEENzOKc4aBRwxCXSlJXGz83flFx5L7AWrOQnmuN3kVsRdt+GZPPjiVQ==",
+      "dev": true,
+      "requires": {
+        "axios": "*"
+      }
+    },
     "@types/body-parser": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.1.tgz",
@@ -5369,7 +5388,6 @@
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
       "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
-      "peer": true,
       "requires": {
         "follow-redirects": "^1.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "@types/axios": "^0.14.0",
     "@types/debug": "^4.1.7",
     "@types/express": "^4.17.13",
     "@types/formidable": "^2.0.4",

--- a/src/client.ts
+++ b/src/client.ts
@@ -443,7 +443,6 @@ export class Client extends EventEmitter {
       ) +
       '<' + envelopeKey + ':Body' +
       (this.bodyAttributes ? this.bodyAttributes.join(' ') : '') +
-      (this.security && this.security.postProcess ? ' Id="_0"' : '') +
       '>' +
       message +
       '</' + envelopeKey + ':Body>' +

--- a/src/security/WSSecurityPlusCert.ts
+++ b/src/security/WSSecurityPlusCert.ts
@@ -1,0 +1,15 @@
+import {ISecurity} from '../types';
+import {WSSecurity} from './WSSecurity';
+import {WSSecurityCert} from './WSSecurityCert';
+
+export class WSSecurityPlusCert implements ISecurity {
+  constructor(private readonly wsSecurity: WSSecurity, private readonly wsSecurityCert: WSSecurityCert) {}
+
+  public postProcess(xml: string, envelopeKey: string) {
+    const securityXml = this.wsSecurity.toXML();
+    const endOfHeader = xml.indexOf(`</${envelopeKey}:Header>`);
+    xml = [xml.slice(0, endOfHeader), securityXml, xml.slice(endOfHeader)].join('');
+
+    return this.wsSecurityCert.postProcess(xml, envelopeKey);
+  }
+}

--- a/src/security/index.ts
+++ b/src/security/index.ts
@@ -6,3 +6,4 @@ export * from './ClientSSLSecurityPFX';
 export * from './NTLMSecurity';
 export * from './WSSecurity';
 export * from './WSSecurityCert';
+export * from './WSSecurityPlusCert';

--- a/src/soap.ts
+++ b/src/soap.ts
@@ -15,7 +15,7 @@ const debug = debugBuilder('node-soap:soap');
 export const security = _security;
 export { Client } from './client';
 export { HttpClient } from './http';
-export { BasicAuthSecurity, BearerSecurity, ClientSSLSecurity, ClientSSLSecurityPFX, NTLMSecurity, WSSecurity, WSSecurityCert } from './security';
+export { BasicAuthSecurity, BearerSecurity, ClientSSLSecurity, ClientSSLSecurityPFX, NTLMSecurity, WSSecurity, WSSecurityCert, WSSecurityPlusCert } from './security';
 export { Server } from './server';
 export { passwordDigest } from './utils';
 export * from './types';

--- a/test/security/WSSecurityCert.js
+++ b/test/security/WSSecurityCert.js
@@ -83,6 +83,25 @@ describe('WSSecurityCert', function () {
     xml.should.containEql(instance.signer.getSignatureXml());
   });
 
+  it('should extend an existing Security block', function () {
+    var instance = new WSSecurityCert(keyWithPassword, cert, 'soap');
+    var xml1 = instance.postProcess('<soap:Header><wsse:Security someAttribute="someValue"></wsse:Security></soap:Header><soap:Body></soap:Body>', 'soap');
+    var matches1 = xml1.match(/<wsse:Security [^>]*>/);
+    matches1[0].should.containEql('soap:mustUnderstand="1"');
+    matches1[0].should.containEql('someAttribute="someValue"');
+    matches1[0].should.containEql('http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd');
+    matches1[0].should.containEql('http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd');
+
+    var xml2 = instance.postProcess('<soap:Header><wsse:Security xmlns:wsu="wsu" xmlns:wsse="wsse" soap:mustUnderstand="true" someAttribute="someValue"></wsse:Security></soap:Header><soap:Body></soap:Body>', 'soap');
+    var matches2 = xml2.match(/<wsse:Security [^>]*>/);
+    matches2[0].should.not.containEql('soap:mustUnderstand="1"');
+    matches2[0].should.containEql('soap:mustUnderstand="true"');
+    matches2[0].should.not.containEql('http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd');
+    matches2[0].should.containEql('xmlns:wsse="wsse"');
+    matches2[0].should.not.containEql('http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd');
+    matches2[0].should.containEql('xmlns:wsu="wsu"');
+  });
+
   it('should only add two Reference elements, for Soap Body and Timestamp inside wsse:Security element', function () {
     var instance = new WSSecurityCert(key, cert, '');
     var xml = instance.postProcess('<soap:Header></soap:Header><soap:Body><Body></Body><Timestamp></Timestamp></soap:Body>', 'soap');


### PR DESCRIPTION
This PR changes/adds the following funtionality:

* a new ISecurity implementation (WSSecurityPlusCert) that takes WSSecurity and WSSecurityCert and combines their results into one SOAP request in case you need to use <UsernameToken> and <Signature> at the same time.
* changes to the WSSecurityCert implementation to enhance an existing <Security> header instead of adding another one.
* replace the static Id="_0" reference on the Body with reference Ids generated by xml-crypto.
* a new idMode option in WSSecurityCert to control the reference id generation of xml-crypto.

=====

I just realized that the functionality provided here is very close to PR  #1187. Just FYI.