### PR TITLE
Update express types to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       "devDependencies": {
         "@types/axios": "^0.14.0",
         "@types/debug": "^4.1.7",
-        "@types/express": "^4.17.13",
+        "@types/express": "^4.17.14",
         "@types/formidable": "^2.0.4",
         "@types/lodash": "^4.14.172",
         "@types/node": "^11.15.54",
@@ -242,9 +242,9 @@
       }
     },
     "node_modules/@types/express": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
-      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
+      "integrity": "sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==",
       "dev": true,
       "dependencies": {
         "@types/body-parser": "*",
@@ -5122,9 +5122,9 @@
       }
     },
     "@types/express": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
-      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
+      "integrity": "sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==",
       "dev": true,
       "requires": {
         "@types/body-parser": "*",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@types/axios": "^0.14.0",
     "@types/debug": "^4.1.7",
-    "@types/express": "^4.17.13",
+    "@types/express": "^4.17.14",
     "@types/formidable": "^2.0.4",
     "@types/lodash": "^4.14.172",
     "@types/node": "^11.15.54",


### PR DESCRIPTION
There is an issue with installing express types package without a lock file (via yarn) that gets resolved by updating to the latest version.

```
node_modules/@types/express-serve-static-core/index.d.ts:99:68 - error TS1110: Type expected.

99 type RemoveTail<S extends string, Tail extends string> = S extends `${infer P}${Tail}` ? P : S;
                                                                      ~~~

node_modules/@types/express-serve-static-core/index.d.ts:99:77 - error TS1005: '}' expected.

99 type RemoveTail<S extends string, Tail extends string> = S extends `${infer P}${Tail}` ? P : S;
                                                                               ~

```
