### PR TITLE
Upgrade XML Crypto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "strip-bom": "^3.0.0",
         "uuid": "^8.3.2",
         "whatwg-mimetype": "3.0.0",
-        "xml-crypto": "^2.1.3"
+        "xml-crypto": "^3.0.0"
       },
       "devDependencies": {
         "@types/axios": "^0.14.0",
@@ -375,9 +375,9 @@
       "dev": true
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.2.tgz",
-      "integrity": "sha512-t/Zqo0ewes3iq6zGqEqJNUWI27Acr3jkmSUNp6E3nl0Z2XbtqAG5XYqPNLdYonILmhcxANsIidh69tHzjXtuRg==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.3.tgz",
+      "integrity": "sha512-Lv2vySXypg4nfa51LY1nU8yDAGo/5YwF+EY/rUZgIbfvwVARcd67ttCM8SMsTeJy51YhHYavEq+FS6R0hW9PFQ==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -4891,11 +4891,11 @@
       }
     },
     "node_modules/xml-crypto": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.3.tgz",
-      "integrity": "sha512-MpXZwnn9JK0mNPZ5mnFIbNnQa+8lMGK4NtnX2FlJMfMWR60sJdFO9X72yO6ji068pxixzk53O7x0/iSKh6IhyQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-3.0.0.tgz",
+      "integrity": "sha512-vdmZOsWgjnFxYGY7OwCgxs+HLWzwvLgX2n0NSYWh3gudckQyNOmtJTT6ooOWEvDZSpC9qRjRs2bEXqKFi1oCHw==",
       "dependencies": {
-        "@xmldom/xmldom": "^0.7.0",
+        "@xmldom/xmldom": "^0.8.3",
         "xpath": "0.0.32"
       },
       "engines": {
@@ -5324,9 +5324,9 @@
       "dev": true
     },
     "@xmldom/xmldom": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.2.tgz",
-      "integrity": "sha512-t/Zqo0ewes3iq6zGqEqJNUWI27Acr3jkmSUNp6E3nl0Z2XbtqAG5XYqPNLdYonILmhcxANsIidh69tHzjXtuRg=="
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.3.tgz",
+      "integrity": "sha512-Lv2vySXypg4nfa51LY1nU8yDAGo/5YwF+EY/rUZgIbfvwVARcd67ttCM8SMsTeJy51YhHYavEq+FS6R0hW9PFQ=="
     },
     "accepts": {
       "version": "1.3.7",
@@ -8856,11 +8856,11 @@
       }
     },
     "xml-crypto": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.3.tgz",
-      "integrity": "sha512-MpXZwnn9JK0mNPZ5mnFIbNnQa+8lMGK4NtnX2FlJMfMWR60sJdFO9X72yO6ji068pxixzk53O7x0/iSKh6IhyQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-3.0.0.tgz",
+      "integrity": "sha512-vdmZOsWgjnFxYGY7OwCgxs+HLWzwvLgX2n0NSYWh3gudckQyNOmtJTT6ooOWEvDZSpC9qRjRs2bEXqKFi1oCHw==",
       "requires": {
-        "@xmldom/xmldom": "^0.7.0",
+        "@xmldom/xmldom": "^0.8.3",
         "xpath": "0.0.32"
       }
     },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "strip-bom": "^3.0.0",
     "uuid": "^8.3.2",
     "whatwg-mimetype": "3.0.0",
-    "xml-crypto": "^2.1.3"
+    "xml-crypto": "^3.0.0"
   },
   "peerDependencies": {
     "axios": "^0.27.2"


### PR DESCRIPTION
This fixes the following issue in a nested dependency https://github.com/advisories/GHSA-9pgh-qqpf-7wqj
The fix in xml/crypto has only been pushed in a major version release based on a breaking change; see https://github.com/yaronn/xml-crypto/releases