### PR TITLE
fix: updated xml-crypto package to 2.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "strip-bom": "^3.0.0",
         "uuid": "^8.3.2",
         "whatwg-mimetype": "3.0.0",
-        "xml-crypto": "^2.1.3"
+        "xml-crypto": "^2.1.5"
       },
       "devDependencies": {
         "@types/axios": "^0.14.0",
@@ -375,9 +375,9 @@
       "dev": true
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.2.tgz",
-      "integrity": "sha512-t/Zqo0ewes3iq6zGqEqJNUWI27Acr3jkmSUNp6E3nl0Z2XbtqAG5XYqPNLdYonILmhcxANsIidh69tHzjXtuRg==",
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.9.tgz",
+      "integrity": "sha512-yceMpm/xd4W2a85iqZyO09gTnHvXF6pyiWjD2jcOJs7hRoZtNNOO1eJlhHj1ixA+xip2hOyGn+LgcvLCMo5zXA==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -4891,11 +4891,11 @@
       }
     },
     "node_modules/xml-crypto": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.3.tgz",
-      "integrity": "sha512-MpXZwnn9JK0mNPZ5mnFIbNnQa+8lMGK4NtnX2FlJMfMWR60sJdFO9X72yO6ji068pxixzk53O7x0/iSKh6IhyQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.5.tgz",
+      "integrity": "sha512-xOSJmGFm+BTXmaPYk8pPV3duKo6hJuZ5niN4uMzoNcTlwYs0jAu/N3qY+ud9MhE4N7eMRuC1ayC7Yhmb7MmAWg==",
       "dependencies": {
-        "@xmldom/xmldom": "^0.7.0",
+        "@xmldom/xmldom": "^0.7.9",
         "xpath": "0.0.32"
       },
       "engines": {
@@ -5324,9 +5324,9 @@
       "dev": true
     },
     "@xmldom/xmldom": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.2.tgz",
-      "integrity": "sha512-t/Zqo0ewes3iq6zGqEqJNUWI27Acr3jkmSUNp6E3nl0Z2XbtqAG5XYqPNLdYonILmhcxANsIidh69tHzjXtuRg=="
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.9.tgz",
+      "integrity": "sha512-yceMpm/xd4W2a85iqZyO09gTnHvXF6pyiWjD2jcOJs7hRoZtNNOO1eJlhHj1ixA+xip2hOyGn+LgcvLCMo5zXA=="
     },
     "accepts": {
       "version": "1.3.7",
@@ -8856,11 +8856,11 @@
       }
     },
     "xml-crypto": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.3.tgz",
-      "integrity": "sha512-MpXZwnn9JK0mNPZ5mnFIbNnQa+8lMGK4NtnX2FlJMfMWR60sJdFO9X72yO6ji068pxixzk53O7x0/iSKh6IhyQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.5.tgz",
+      "integrity": "sha512-xOSJmGFm+BTXmaPYk8pPV3duKo6hJuZ5niN4uMzoNcTlwYs0jAu/N3qY+ud9MhE4N7eMRuC1ayC7Yhmb7MmAWg==",
       "requires": {
-        "@xmldom/xmldom": "^0.7.0",
+        "@xmldom/xmldom": "^0.7.9",
         "xpath": "0.0.32"
       }
     },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "strip-bom": "^3.0.0",
     "uuid": "^8.3.2",
     "whatwg-mimetype": "3.0.0",
-    "xml-crypto": "^2.1.3"
+    "xml-crypto": "^2.1.5"
   },
   "peerDependencies": {
     "axios": "^0.27.2"


### PR DESCRIPTION
fixing @xmldom/xmldom Improper Input Validation by updating xml-crypto package from 2.1.3  to 2.1.5

this PR doesn't introduce breaking changes of xml-crypto v3