### PR TITLE
honor httpAgent/httpsAgent when setting ntlm flag

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -193,7 +193,9 @@ export class HttpClient implements IHttpClient {
         password: exoptions.password,
         workstation: exoptions.workstation || '',
         domain: exoptions.domain || '',
-      });
+      }, { httpAgent: exoptions.httpAgent,
+           httpsAgent: exoptions.httpsAgent
+         });
       req = ntlmReq(options);
     } else {
       if (this.options.parseReponseAttachments) {


### PR DESCRIPTION
Passing httpAgent/httpsAgent inside `wsdl_options` works until you add `ntlm: true` to the `wsdl_options`. This PR fixes this.