### PR TITLE
preserve whitespace for space only text node: <text> </text>

### DIFF
--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -356,7 +356,9 @@ export class WSDL {
       const name = splitQName(nsName).name;
 
       if (typeof cur.schema === 'string' && (cur.schema === 'string' || cur.schema.split(':')[1] === 'string')) {
-        if (typeof obj === 'object' && Object.keys(obj).length === 0) { obj = cur.object = ''; }
+        if (typeof obj === 'object' && Object.keys(obj).length === 0) {
+          obj = cur.object = (this.options.preserveWhitespace ? cur.text || '' : '');
+        }
       }
 
       if (cur.nil === true) {
@@ -423,13 +425,17 @@ export class WSDL {
     };
 
     p.ontext = (text) => {
+      const top = stack[stack.length - 1];
+
       const originalText = text;
       text = trim(text);
       if (!text.length) {
+        if (this.options.preserveWhitespace) {
+          top.text = (top.text || '') + originalText;
+        }
         return;
       }
 
-      const top = stack[stack.length - 1];
       const name = splitQName(top.schema).name;
       let value;
 

--- a/test/response-preserve-whitespace-test.js
+++ b/test/response-preserve-whitespace-test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+var request = require('request');
+var assert = require('assert');
+var http = require('http');
+var soap = require('../');
+var server;
+var port;
+
+describe('Preverse whitespace', function() {
+  var wsdl = __dirname + '/wsdl/hello.wsdl';
+  var xml = require('fs').readFileSync(wsdl, 'utf8');
+
+  before(function(done) {
+    server = http.createServer(function(req, res) {
+      res.statusCode = 200;
+      res.end('"<?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\"  xmlns:tns=\"http://www.examples.com/wsdl/HelloService.wsdl\"><soap:Body><tns:sayHelloResponse><tns:greeting> </tns:greeting></tns:sayHelloResponse></soap:Body></soap:Envelope>"');
+    }).listen(51515, done);
+  });
+
+  after(function() {
+    server.close();
+  });
+
+  it('preserves leading and trailing whitespace when preserveWhitespace option is true',
+    function(done) {
+      var url = 'http://' + server.address().address + ':' + server.address().port;
+
+      if (server.address().address === '0.0.0.0' || server.address().address === '::') {
+        url = 'http://127.0.0.1:' + server.address().port;
+      }
+
+      soap.createClient(
+        wsdl,
+        {
+          endpoint: url,
+          preserveWhitespace: true
+        },
+        function(err, client) {
+          if (err) {
+            console.log(err);
+            throw err;
+          }
+
+          client.sayHello(
+            {
+              firstName: 'hello world'
+            },
+            function(err, result, rawResponse, soapHeader, rawRequest) {
+              if (err) {
+                console.log(err);
+                throw err;
+              }
+              assert.equal(' ', result.greeting);
+              done();
+            }
+          );
+        }
+      );
+    });
+
+});

--- a/test/response-preserve-whitespace-test.js
+++ b/test/response-preserve-whitespace-test.js
@@ -9,7 +9,6 @@ var port;
 
 describe('Preverse whitespace', function() {
   var wsdl = __dirname + '/wsdl/hello.wsdl';
-  var xml = require('fs').readFileSync(wsdl, 'utf8');
 
   before(function(done) {
     server = http.createServer(function(req, res) {
@@ -34,6 +33,7 @@ describe('Preverse whitespace', function() {
         wsdl,
         {
           endpoint: url,
+          disableCache: true, // disable wsdl cache, otherwise 'mocha test/client-response-options-test.js test/response-preserve-whitespace-test.js' will fail.
           preserveWhitespace: true
         },
         function(err, client) {


### PR DESCRIPTION
when preverseWhitespace = true option is specified, the space in the text node should be preversed.
but if the text node's content is all white space, these space is not preserved. 
example: <text> </text>
expect: result.text = ' ' (<- one space)
actual: result.text = ''  (empty string)
