### PR TITLE
Add missing closing bracket

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -915,6 +915,7 @@ WS-Security X509 Certificate support.
         existingPrefixes: {
             wsse: 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd',
         }
+     }
   }
   var wsSecurity = new soap.WSSecurityCert(privateKey, publicKey, password, options);
   client.setSecurity(wsSecurity);


### PR DESCRIPTION
There was a bracket missing in the documentation of web security example