### PR TITLE
Improve trim speed during XML parsing.

### DIFF
--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -23,11 +23,8 @@ const debug = debugBuilder('node-soap');
 
 const XSI_URI = 'http://www.w3.org/2001/XMLSchema-instance';
 
-const trimLeft = /^[\s\xA0]+/;
-const trimRight = /[\s\xA0]+$/;
-
-function trim(text) {
-  return text.replace(trimLeft, '').replace(trimRight, '');
+export function trim(text) {
+  return text.trim();
 }
 
 function deepMerge<A, B>(destination: A, source: B): A & B {

--- a/test/trim-test.js
+++ b/test/trim-test.js
@@ -1,0 +1,30 @@
+trim = require('../lib/wsdl/index.js').trim
+var assert = require('assert');
+
+it('should trim correctly', async () => {
+    describe('removes whitespace', async () => {
+        const input = ' \n <> \n  ';
+        const expected = '<>';
+        
+        verify(input, expected);
+    })
+
+    describe('removes non breaking space', async () => {
+        const input = '\xA0<>';
+        const expected = '<>';
+
+        verify(input, expected);
+    });
+
+    describe('removes all', async () => {
+        const input = '\xA0\n \t<\n\t\xA0>\t \n \xA0';
+        const expected = '<\n\t\xA0>';
+
+        verify(input, expected);
+    });
+})
+
+function verify(input, expected) {
+    const actual = trim(input);
+    assert(actual === expected, `${actual} != ${expected}`);
+}


### PR DESCRIPTION
* Use native string.trim instead of regex replace for performance.
* Add tests surrounding trim function used in wsdl parsing.

## Issue with parsing large XML responses
I recently noticed an issue with slow parsing of large (1-2mb+) responses.
I narrowed the issue down to the trim(text) method in wdsl/index.ts
This uses regex to remove whitespace characters at the start and end of a string.
This has performance implications when the string is very long, as I believe the trimRight regex needs to scan the entire content before reaching the end and then backtrack.

This issue was so bad it was causing requests to timeout after (10+ minutes).

## Solution
I couldn't see any other tests testing the whitespace removal, so I added some.
I validated that it was extremely slow before the change (I gave up waiting after around 5 minutes).
I validated that after the change it was fast (~10ms).
And that the expected output is the same.