### PR TITLE
Speed up WSDL parsing

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -40,7 +40,7 @@ export function splitQName<T>(nsName: T) {
     };
   }
 
-  const [topLevelName] = nsName.split('|');
+  const [topLevelName] = nsName.split('|', 1);
 
   const prefixOffset = topLevelName.indexOf(':');
 

--- a/src/wsdl/elements.ts
+++ b/src/wsdl/elements.ts
@@ -65,6 +65,7 @@ export class Element {
   public $targetNamespace?;
   public children: Element[] = [];
   public ignoredNamespaces;
+  public strict: boolean;
   public name?: string;
   public nsName?;
   public prefix?: string;
@@ -124,7 +125,10 @@ export class Element {
       return;
     }
 
-    const ChildClass = this.allowedChildren[splitQName(nsName).name];
+    let ChildClass = this.allowedChildren[splitQName(nsName).name];
+    if (ChildClass == null && !this.strict) {
+      ChildClass = UnexpectedElement;
+    }
     if (ChildClass) {
       const child = new ChildClass(nsName, attrs, options, schemaXmlns);
       child.init();
@@ -171,11 +175,21 @@ export class Element {
       this.valueKey = options.valueKey || '$value';
       this.xmlKey = options.xmlKey || '$xml';
       this.ignoredNamespaces = options.ignoredNamespaces || [];
+      this.strict = options.strict || false;
     } else {
       this.valueKey = '$value';
       this.xmlKey = '$xml';
       this.ignoredNamespaces = [];
+      this.strict = false;
     }
+  }
+}
+
+export class UnexpectedElement extends Element {
+  public startElement(stack: Element[], nsName: string, attrs, options: IWsdlBaseOptions, schemaXmlns) {
+    const child = new UnexpectedElement(nsName, attrs, options, schemaXmlns);
+    child.init();
+    stack.push(child);
   }
 }
 

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -500,7 +500,7 @@ var fs = require('fs'),
             assert.ok(result);
             assert.ok(client.lastResponse);
             assert.ok(client.lastResponseHeaders);
-            assert.ok(client.lastElapsedTime);
+            assert.ok(client.lastElapsedTime !== undefined);
 
             done();
           }, { time: true }, { 'test-header': 'test' });


### PR DESCRIPTION
We were running into performance issues while generating a SOAP client. I profiled the client generation and identified two bottlenecks in parsing WSDL files:
- When visiting an unexpected node an error got constructed that was discarded later on in non-strict mode. Constructing an error is pretty expensive because Node needs to capture the stack.
- splitQName split the entire nsName string even though it's only interested in the first element