### PR TITLE
feature (xml key): allow in first level for rpc

### DIFF
--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -604,17 +604,21 @@ export class WSDL {
       }
       if (key !== nsAttrName) {
         const value = params[key];
-        const prefixedKey = (isParts ? '' : nsPrefix) + key;
-        const attributes = [];
-        if (typeof value === 'object' && value.hasOwnProperty(this.options.attributesKey)) {
-          const attrs = value[this.options.attributesKey];
-          for (const n in attrs) {
-            attributes.push(' ' + n + '=' + '"' + attrs[n] + '"');
+        if (key === this.options.xmlKey) {
+          parts.push(this.objectToXML({[key]: value}, null, nsPrefix, nsURI));
+        } else {
+          const prefixedKey = (isParts ? '' : nsPrefix) + key;
+          const attributes = [];
+          if (typeof value === 'object' && value.hasOwnProperty(this.options.attributesKey)) {
+            const attrs = value[this.options.attributesKey];
+            for (const n in attrs) {
+              attributes.push(' ' + n + '=' + '"' + attrs[n] + '"');
+            }
           }
+          parts.push(['<', prefixedKey].concat(attributes).concat('>').join(''));
+          parts.push((typeof value === 'object') ? this.objectToXML(value, key, nsPrefix, nsURI) : xmlEscape(value));
+          parts.push(['</', prefixedKey, '>'].join(''));
         }
-        parts.push(['<', prefixedKey].concat(attributes).concat('>').join(''));
-        parts.push((typeof value === 'object') ? this.objectToXML(value, key, nsPrefix, nsURI) : xmlEscape(value));
-        parts.push(['</', prefixedKey, '>'].join(''));
       }
     }
     parts.push(['</', nsPrefix, name, '>'].join(''));

--- a/test/request-response-samples/Dummy__should_use_defined_xml_key_in_first_level_for_rpc/common.xsd
+++ b/test/request-response-samples/Dummy__should_use_defined_xml_key_in_first_level_for_rpc/common.xsd
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:tns="http://www.Dummy.com/Common/Types" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.Dummy.com/Common/Types" elementFormDefault="qualified" attributeFormDefault="unqualified">
+    <xs:complexType name="DummyResult">
+        <xs:sequence>
+            <xs:element name="DummyList" type="tns:DummyList" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="code" type="xs:string" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="Dummy">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="language" type="xs:language" use="optional"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="DummyList">
+        <xs:sequence>
+            <xs:element name="DummyElement" type="tns:Dummy" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/test/request-response-samples/Dummy__should_use_defined_xml_key_in_first_level_for_rpc/name.xsd
+++ b/test/request-response-samples/Dummy__should_use_defined_xml_key_in_first_level_for_rpc/name.xsd
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:tns="http://www.Dummy.com/Name/Types" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.Dummy.com/Name/Types" elementFormDefault="qualified"
+           attributeFormDefault="unqualified" xmlns:c="http://www.Dummy.com/Common/Types">
+    <xs:import namespace="common.xsd" schemaLocation="common.xsd"/>
+    <xs:element name="DummyRequest">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="DummyXML" type="xs:string" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="DummyResponse">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="DummyResult" type="c:DummyResult"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/test/request-response-samples/Dummy__should_use_defined_xml_key_in_first_level_for_rpc/request.json
+++ b/test/request-response-samples/Dummy__should_use_defined_xml_key_in_first_level_for_rpc/request.json
@@ -1,0 +1,3 @@
+{
+  "$xml": "<tns:DummyXML><myObject attr='myAttr'></myObject></tns:DummyXML>"
+}

--- a/test/request-response-samples/Dummy__should_use_defined_xml_key_in_first_level_for_rpc/request.xml
+++ b/test/request-response-samples/Dummy__should_use_defined_xml_key_in_first_level_for_rpc/request.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns:tns="http://www.Dummy.com" xmlns:n="http://www.Dummy.com/Name/Types"><soap:Body><tns:Dummy><tns:DummyXML><myObject attr='myAttr'></myObject></tns:DummyXML></tns:Dummy></soap:Body></soap:Envelope>

--- a/test/request-response-samples/Dummy__should_use_defined_xml_key_in_first_level_for_rpc/response.json
+++ b/test/request-response-samples/Dummy__should_use_defined_xml_key_in_first_level_for_rpc/response.json
@@ -1,0 +1,12 @@
+{
+  "DummyResult": {
+    "DummyList": {
+      "DummyElement": {
+        "attributes": {
+          "language": "en-US"
+        },
+        "$value": "Dummy Element Entry"
+      }
+    }
+  }
+}

--- a/test/request-response-samples/Dummy__should_use_defined_xml_key_in_first_level_for_rpc/response.xml
+++ b/test/request-response-samples/Dummy__should_use_defined_xml_key_in_first_level_for_rpc/response.xml
@@ -1,0 +1,14 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:tns="http://www.Dummy.com" xmlns:n="http://www.Dummy.com/Name/Types">
+    <soap:Header></soap:Header>
+    <soap:Body>
+        <n:DummyResponse>
+            <n:DummyResult>
+                <c:DummyList xmlns:c="http://www.Dummy.com/Common/Types">
+                    <c:DummyElement language="en-US">
+                        Dummy Element Entry
+                    </c:DummyElement>
+                </c:DummyList>
+            </n:DummyResult>
+        </n:DummyResponse>
+    </soap:Body>
+</soap:Envelope>

--- a/test/request-response-samples/Dummy__should_use_defined_xml_key_in_first_level_for_rpc/soap.wsdl
+++ b/test/request-response-samples/Dummy__should_use_defined_xml_key_in_first_level_for_rpc/soap.wsdl
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                  xmlns:tns="http://www.Dummy.com"  xmlns:n="http://www.Dummy.com/Name/Types"  xmlns:ns="http://schemas.xmlsoap.org/soap/encoding/" targetNamespace="http://www.Dummy.com">
+    <wsdl:types>
+        <xs:schema>
+            <xs:import namespace="http://www.Dummy.com/Common/Types" schemaLocation="common.xsd"/>
+            <xs:import namespace="http://www.Dummy.com/Name/Types" schemaLocation="name.xsd"/>
+        </xs:schema>
+    </wsdl:types>
+    <wsdl:message name="DummyRequest">
+        <wsdl:part name="DummyRequest" element="n:DummyRequest"/>
+    </wsdl:message>
+    <wsdl:message name="DummyResponse">
+        <wsdl:part name="DummyResponse" element="n:DummyResponse"/>
+    </wsdl:message>
+    <wsdl:portType name="DummyPortType">
+        <wsdl:operation name="Dummy">
+              <soap12:operation soapAction="" style="rpc"/>
+            <wsdl:input message="tns:DummyRequest"/>
+            <wsdl:output message="tns:DummyResponse"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="DummyBinding" type="tns:DummyPortType">
+        <soap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="Dummy">
+            <soap:operation soapAction="http://www.Dummy.com#Dummy" style="rpc"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="DummyService">
+        <wsdl:port name="DummyPortType" binding="tns:DummyBinding">
+            <soap:address location="http://www.Dummy.com/"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
* allow xmlKey in first level for rpc

# Problem
Using xmlKey ('$xml') in the first level of args

```js
var soap = require('soap');
  var url = 'http://example.com/wsdl?wsdl';
  var args = {$xml: '<action>1</action>'};

  soap.createClient(url, {}, function(err, client) {
      client.MyFunction(args, function(err, result) {
          ...
      });
  });
```

Request includes "$xml" tag instead of unescaped text

```xml
...<soap:body><MyFunction><$xml>&lt;tns:action&gt;&lt;...&lt;tns:/action&gt;&lt;</$xml></MyFunction></soap:body>...
```

# New Request 

```xml
...<soap:body><MyFunction><action>1</action></MyFunction></soap:body>...
```

