### PR TITLE
Try to make error messages useful when using SOAP 1.2

### DIFF
--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -512,6 +512,7 @@ export class WSDL {
           detail = detail || fault.detail;
           // SOAP 1.2
           code = code || fault.Code && `${fault.Code.Value}: ${fault.Code.Subcode && fault.Code.Subcode.Value}`;
+          string = string || fault.Reason && fault.Reason.Text.$value;
           string = string || fault.Reason && fault.Reason.Text;
           detail = detail || fault.Detail;
 

--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -502,13 +502,18 @@ export class WSDL {
       if (root.Envelope) {
         const body = root.Envelope.Body;
         if (body && body.Fault) {
-          let code = body.Fault.faultcode && body.Fault.faultcode.$value;
-          let string = body.Fault.faultstring && body.Fault.faultstring.$value;
-          let detail = body.Fault.detail && body.Fault.detail.$value;
+          const fault = body.Fault;
+          let code = fault.faultcode && fault.faultcode.$value;
+          let string = fault.faultstring && fault.faultstring.$value;
+          let detail = fault.detail && fault.detail.$value;
 
-          code = code || body.Fault.faultcode;
-          string = string || body.Fault.faultstring;
-          detail = detail || body.Fault.detail;
+          code = code || fault.faultcode;
+          string = string || fault.faultstring;
+          detail = detail || fault.detail;
+          // SOAP 1.2
+          code = code || fault.Code && `${fault.Code.Value}: ${fault.Code.Subcode && fault.Code.Subcode.Value}`;
+          string = string || fault.Reason && fault.Reason.Text;
+          detail = detail || fault.Detail;
 
           const error: any = new Error(code + ': ' + string + (detail ? ': ' + JSON.stringify(detail) : ''));
 

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -34,7 +34,7 @@ test.service = {
             Fault: {
               Code: {
                 Value: "soap:Sender",
-                Subcode: { value: "rpc:BadArguments" }
+                Subcode: { Value: "rpc:BadArguments" }
               },
               Reason: { Text: "Processing Error" }
             }
@@ -61,7 +61,7 @@ test.service = {
           Fault: {
             Code: {
               Value: "soap:Sender",
-              Subcode: { value: "rpc:BadArguments" }
+              Subcode: { Value: "rpc:BadArguments" }
             },
             Reason: { Text: "Processing Error" },
             statusCode: 500
@@ -454,7 +454,7 @@ describe('SOAP Server', function () {
       client.GetLastTradePrice({ tickerSymbol: 'SOAP Fault v1.2' }, function (err, response, body) {
         assert.ok(err);
         var fault = err.root.Envelope.Body.Fault;
-        assert.equal(err.message, fault.faultcode + ': ' + fault.faultstring);
+        assert.equal(err.message, fault.Code.Value + ': ' + fault.Code.Subcode.Value + ': ' + fault.Reason.Text);
         assert.equal(fault.Code.Value, "soap:Sender");
         assert.equal(fault.Reason.Text, "Processing Error");
         // Verify namespace on elements set according to fault spec 1.2
@@ -493,7 +493,7 @@ describe('SOAP Server', function () {
         Fault: {
           Code: {
             Value: "soap:Sender",
-            Subcode: { value: "rpc:BadArguments" }
+            Subcode: { Value: "rpc:BadArguments" }
           },
           Reason: { Text: "Processing Error" }
         }


### PR DESCRIPTION
When using SOAP 1.2 the Fault error messages were `Uncaught Error: undefined: undefined`.

They are now of the form `Uncaught Error: s:Sender: w:InternalError: The WS-Management service cannot process the request because the XML is invalid.: {"FaultDetail":"http://schemas.dmtf.org/wbem/wsman/1/wsman/faultDetail/Invalid","WSManFault":{"attributes":{"Code":"2150858819","Machine":"dell"},"Message":"WinRM cannot process the request because the input XML uses an undefined XML namespace."}}`, while verbose, it's actually useful.