### PR TITLE
Bump axios-ntlm version to solve vulnerability issue with axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "author": "Vinay Pulim <v@pulim.com>",
   "dependencies": {
-    "axios-ntlm": "^1.2.0",
+    "axios-ntlm": "^1.4.2",
     "debug": "^4.3.2",
     "formidable": "^3.2.4",
     "get-stream": "^6.0.1",


### PR DESCRIPTION
Explanation from sonatype:

The axios package @1.5.0 is vulnerable to Prototype Pollution. The functions and files listed below, when parsing form data, fail to validate or reject keys that contain the __proto__ accessor. An attacker can exploit this vulnerability by submitting a crafted payload to corrupt the original JavaScript Object prototype and cause application crashes, data corruption, and other security violations.

In the image below you can see axios@1.5.0 is part of axios-ntlm.  
![image](https://github.com/vpulim/node-soap/assets/2647564/76d6fd18-0e20-4bee-a6e7-989e7ff40e1f)

Bumping the version of axios-ntlm to 1.4.2 is expected to update axios to 1.6.7 if i'm not mistaken