### PR TITLE
add envelopeSoapUrl option

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -177,6 +177,7 @@ export class Client extends EventEmitter {
     this.overridePromiseSuffix = options.overridePromiseSuffix || 'Async';
     this.wsdl.options.attributesKey = options.attributesKey || 'attributes';
     this.wsdl.options.envelopeKey = options.envelopeKey || 'soap';
+    this.wsdl.options.envelopeSoapUrl = options.envelopeSoapUrl || 'http://schemas.xmlsoap.org/soap/envelope/';
     this.wsdl.options.preserveWhitespace = !!options.preserveWhitespace;
     const igNs = options.ignoredNamespaces;
     if (igNs !== undefined && typeof igNs === 'object') {
@@ -300,6 +301,7 @@ export class Client extends EventEmitter {
     const style = method.style;
     const defs = this.wsdl.definitions;
     const envelopeKey = this.wsdl.options.envelopeKey;
+    const envelopeSoapUrl = this.wsdl.options.envelopeSoapUrl;
     const ns: string = defs.$targetNamespace;
     let encoding = '';
     let message = '';
@@ -309,7 +311,7 @@ export class Client extends EventEmitter {
     let headers: any = {
       'Content-Type': 'text/xml; charset=utf-8',
     };
-    let xmlnsSoap = 'xmlns:' + envelopeKey + '="http://schemas.xmlsoap.org/soap/envelope/"';
+    let xmlnsSoap = 'xmlns:' + envelopeKey + '="'+ envelopeSoapUrl + '"';
 
     const finish = (obj, body, response) => {
       let result;

--- a/src/client.ts
+++ b/src/client.ts
@@ -311,7 +311,7 @@ export class Client extends EventEmitter {
     let headers: any = {
       'Content-Type': 'text/xml; charset=utf-8',
     };
-    let xmlnsSoap = 'xmlns:' + envelopeKey + '="'+ envelopeSoapUrl + '"';
+    let xmlnsSoap = 'xmlns:' + envelopeKey + '="' + envelopeSoapUrl + '"';
 
     const finish = (obj, body, response) => {
       let result;

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,6 +121,8 @@ export interface IOptions extends IWsdlBaseOptions {
   endpoint?: string;
   /** set specific key instead of <pre><soap:Body></soap:Body></pre>. */
   envelopeKey?: string;
+  /** set specific SOAP Schema Url; will not be used with forceSoap12Headers option */
+  envelopeSoapUrl?: string;
   /** provide your own http client that implements request(rurl, data, callback, exheaders, exoptions) */
   httpClient?: IHttpClient;
   /** override the request module. */

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -1470,6 +1470,18 @@ var fs = require('fs'),
           });
       });
 
+      it('should allow customization of envelope Soap Url', function (done) {
+        soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', Object.assign({ envelopeSoapUrl: 'http://example.com/v1' }, meta.options), function (err, client) {
+          assert.ok(client);
+          assert.ifError(err);
+  
+          client.MyOperation({}, function (err, result) {
+            assert.notEqual(client.lastRequest.indexOf('xmlns:soap=\"http://example.com/v1\"'), -1);
+            done();
+          });
+        });
+      });
+
       it('should add soap headers', function (done) {
         soap.createClientAsync(__dirname + '/wsdl/default_namespace.wsdl', meta.options)
           .then(function (client) {


### PR DESCRIPTION
This adds an option to change the URL in `xmlns:soap` attribute.

Some services require this Url to be changed. Until now, it was hardcoded.

Also requested on SO: https://stackoverflow.com/questions/68483250/node-soap-remove-xmlns-attribute-from-method