### PR TITLE
 Handle Missing Message Definitions in WSDL for SOAP Client Creation

### DIFF
--- a/src/wsdl/elements.ts
+++ b/src/wsdl/elements.ts
@@ -872,14 +872,16 @@ export class OperationElement extends Element {
       }
       const messageName = splitQName(child.$message).name;
       const message = definitions.messages[messageName];
-      message.postProcess(definitions);
-      if (message.element) {
-        definitions.messages[message.element.$name] = message;
-        this[child.name] = message.element;
-      } else {
-        this[child.name] = message;
+      if (message) {
+        message.postProcess(definitions);
+        if (message.element) {
+          definitions.messages[message.element.$name] = message;
+          this[child.name] = message.element;
+        } else {
+          this[child.name] = message;
+        }
+        children.splice(i--, 1);
       }
-      children.splice(i--, 1);
     }
     this.deleteFixedAttrs();
   }

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -330,4 +330,12 @@ describe('WSDL Parser (non-strict)', () => {
       done();
     });
   });
+
+
+  it('Should create client even if the some of message definitions are missing', function (done) {
+    soap.createClient(__dirname+'/wsdl/missing_message_definition.wsdl', function(err, client) {
+      assert.equal(err, null);
+      done();
+    });
+  });
 });

--- a/test/wsdl/missing_message_definition.wsdl
+++ b/test/wsdl/missing_message_definition.wsdl
@@ -1,0 +1,57 @@
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns:tns="http://example.com/weather"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+             name="WeatherService"
+             targetNamespace="http://example.com/weather">
+
+    <types>
+        <xsd:schema targetNamespace="http://example.com/weather">
+            <xsd:element name="GetWeatherRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="City" type="xsd:string"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="GetWeatherResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="Temperature" type="xsd:float"/>
+                        <xsd:element name="Conditions" type="xsd:string"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </types>
+
+    <message name="GetWeatherRequest">
+        <part name="parameters" element="tns:GetWeatherRequest"/>
+    </message>
+
+    <portType name="WeatherPortType">
+        <operation name="GetWeather">
+            <input message="tns:GetWeatherRequest"/>
+            <output message="tns:GetWeatherResponse"/>
+        </operation>
+    </portType>
+
+    <binding name="WeatherBinding" type="tns:WeatherPortType">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <operation name="GetWeather">
+            <soap:operation soapAction="http://example.com/weather/GetWeather"/>
+            <input>
+                <soap:body use="literal"/>
+            </input>
+            <output>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+    </binding>
+
+    <service name="WeatherService">
+        <port name="WeatherPort" binding="tns:WeatherBinding">
+            <soap:address location="http://example.com/weather"/>
+        </port>
+    </service>
+</definitions>


### PR DESCRIPTION
This pull request addresses an issue in the SOAP npm library where the client creation fails if the WSDL response XML contains an operation with a missing message definition.

#### Problem:
When the WSDL response XML has an operation whose message definition is missing, the library throws an error and fails to create the client. Specifically, the error stack trace indicates that the `postProcess` method attempts to access properties of an undefined object, leading to a runtime error.

Error stack trace:
```
Cannot read properties of undefined (reading 'postProcess')
    at OperationElement.postProcess (/path/to/soap/src/wsdl/elements.ts:875:15)
    at PortTypeElement.postProcess (/path/to/soap/src/wsdl/elements.ts:915:13)
    at BindingElement.postProcess (/path/to/soap/src/wsdl/elements.ts:969:16)
    at ServiceElement.postProcess (/path/to/soap/src/wsdl/elements.ts:1043:19)
    at /path/to/soap/src/wsdl/index.ts:112:30
    at WSDL._processNextInclude (/path/to/soap/src/wsdl/index.ts:1189:14)
    at WSDL.processIncludes (/path/to/soap/src/wsdl/index.ts:173:10)
    at /path/to/soap/src/wsdl/index.ts:101:12
    at /path/to/async-listener/glue.js:188:31
    at processTicksAndRejections (node:internal/process/task_queues:77:11)
```

#### Solution:
The proposed fix involves adding checks to ensure that message definitions exist before invoking the `postProcess` method. This prevents the runtime error and allows the client to be created successfully even when some message definitions are missing.

#### Changes:
- Added conditional checks in `OperationElement.postProcess` to verify the existence of message definitions.
- Updated related test cases to cover scenarios with missing message definitions.

#### Testing:
- Verified that client creation succeeds with WSDL containing missing message definitions.
- Ran existing unit tests to ensure no regressions.
- Added new test cases to validate the fix.

#### References:
- WSDL example causing the issue:

```
<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
             xmlns:tns="http://example.com/weather"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             name="WeatherService"
             targetNamespace="http://example.com/weather">

    <types>
        <xsd:schema targetNamespace="http://example.com/weather">
            <xsd:element name="GetWeatherRequest">
                <xsd:complexType>
                    <xsd:sequence>
                        <xsd:element name="City" type="xsd:string"/>
                    </xsd:sequence>
                </xsd:complexType>
            </xsd:element>
            <xsd:element name="GetWeatherResponse">
                <xsd:complexType>
                    <xsd:sequence>
                        <xsd:element name="Temperature" type="xsd:float"/>
                        <xsd:element name="Conditions" type="xsd:string"/>
                    </xsd:sequence>
                </xsd:complexType>
            </xsd:element>
        </xsd:schema>
    </types>

    <message name="GetWeatherRequest">
        <part name="parameters" element="tns:GetWeatherRequest"/>
    </message>

    <portType name="WeatherPortType">
        <operation name="GetWeather">
            <input message="tns:GetWeatherRequest"/>
            <output message="tns:GetWeatherResponse"/>
        </operation>
    </portType>

    <binding name="WeatherBinding" type="tns:WeatherPortType">
        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
        <operation name="GetWeather">
            <soap:operation soapAction="http://example.com/weather/GetWeather"/>
            <input>
                <soap:body use="literal"/>
            </input>
            <output>
                <soap:body use="literal"/>
            </output>
        </operation>
    </binding>

    <service name="WeatherService">
        <port name="WeatherPort" binding="tns:WeatherBinding">
            <soap:address location="http://example.com/weather"/>
        </port>
    </service>
</definitions>
```

This pull request ensures robust client creation in the presence of incomplete WSDL definitions, enhancing the stability and reliability of the SOAP library.