### PR TITLE
Pass the error object to log

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -225,7 +225,7 @@ export class Server extends EventEmitter {
         error = err.stack ? (this.suppressStack === true ? err.message : err.stack) : err;
         this._sendHttpResponse(res, /* statusCode */ 500, error);
         if (typeof this.log === 'function') {
-          this.log('error', error, req);
+          this.log('error', err, req);
         }
       }
     }

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -463,9 +463,6 @@ describe('SOAP Server', function () {
         assert.ok(err);
         assert.strictEqual(err.response, response);
         assert.strictEqual(err.body, body);
-        // console.log(test.logMessages);
-        // assert.strictEqual(test.logMessages.length, 1);
-        // assert.notStrictEqual(test.logMessages[0].tyoe, {});
         done();
       });
     });


### PR DESCRIPTION
The current code uses `suppressStack` to determine what is logged, while I think `suppressStack` was only intended to control whether we expose internals to the caller.

It would be preferable if the logging mechanism could see the original error for what it is, since then it could use the appropriate logging mechanism in the code base; for example, pass the error object to Sentry, or log it in a structured way (name and stack separately) [for Datadog to consume](https://docs.datadoghq.com/standard-attributes/), etc.