### PR TITLE
Adding attributes parsing

### DIFF
--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -4,7 +4,8 @@ var fs = require('fs'),
     soap = require('..'),
     WSDL = require('../lib/wsdl').WSDL,
     assert = require('assert'),
-    sinon = require('sinon');
+    sinon = require('sinon'),
+    elements = require('../lib/wsdl/elements');
 
 describe('WSDL Parser (strict)', () => {
 
@@ -347,6 +348,25 @@ describe('WSDL Parser (non-strict)', () => {
   it('Should create client even if the some of message definitions are missing', function (done) {
     soap.createClient(__dirname+'/wsdl/missing_message_definition.wsdl', function(err, client) {
       assert.equal(err, null);
+      done();
+    });
+  });
+
+  it('Should describe return correct result for attributes in complexTypeElement', function(done) {
+    soap.createClient(__dirname+ '/wsdl/wsdl_with_attributes.wsdl', function(err,client){
+      assert.ifError(err);
+      var description = client.describe();
+
+      assert.deepEqual(description.StockQuoteService.StockQuotePort.GetLastTradePrice.input[elements.AttributeElement.Symbol], {
+        AttributeInOne: { type: "s:boolean", required: false },
+        AttributeInTwo: { type: "s:boolean", required: true },
+      });
+      assert.deepEqual(description.StockQuoteService.StockQuotePort.GetLastTradePrice.output[elements.AttributeElement.Symbol], {
+        AttributeOut: { type: "s:boolean", required: true },
+      });
+
+      assert.deepEqual(Object.keys(description.StockQuoteService.StockQuotePort.GetLastTradePrice.input), ['tickerSymbol']);
+      assert.deepEqual(Object.keys(description.StockQuoteService.StockQuotePort.GetLastTradePrice.output), []);
       done();
     });
   });

--- a/test/wsdl/wsdl_with_attributes.wsdl
+++ b/test/wsdl/wsdl_with_attributes.wsdl
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<definitions name="StockQuote"
+             targetNamespace="http://example.com/stockquote.wsdl"
+             xmlns:tns="http://example.com/stockquote.wsdl"
+             xmlns:xsd1="http://example.com/stockquote.xsd"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns="http://schemas.xmlsoap.org/wsdl/">
+    <types>
+        <schema targetNamespace="http://example.com/stockquote.xsd"
+                xmlns="http://www.w3.org/2000/10/XMLSchema">
+            <element name="TradePriceRequest">
+                <complexType>
+                    <s:attribute name="AttributeInOne" type="s:boolean" />
+                    <all>
+                        <element name="tickerSymbol" type="string"/>
+                    </all>
+                    <s:attribute name="AttributeInTwo" type="s:boolean" use="required" />
+                </complexType>
+            </element>
+            <element name="TradePrice">
+                <complexType>
+                    <element name="price" type="float"/>
+                    <s:attribute name="AttributeOut" type="s:boolean" use="required" />
+                </complexType>
+            </element>
+        </schema>
+    </types>
+
+    <message name="GetLastTradePriceInput">
+        <part name="body" element="xsd1:TradePriceRequest"/>
+    </message>
+
+    <message name="GetLastTradePriceOutput">
+        <part name="body" element="xsd1:TradePrice"/>
+    </message>
+
+    <portType name="StockQuotePortType">
+        <operation name="GetLastTradePrice">
+            <input message="tns:GetLastTradePriceInput"/>
+            <output message="tns:GetLastTradePriceOutput"/>
+        </operation>
+    </portType>
+
+    <binding name="StockQuoteSoapBinding" type="tns:StockQuotePortType">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <operation name="GetLastTradePrice">
+            <soap:operation soapAction="http://example.com/GetLastTradePrice"/>
+            <input>
+                <soap:body use="literal"/>
+            </input>
+            <output>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+    </binding>
+
+    <service name="StockQuoteService">
+        <documentation>My first service</documentation>
+        <port name="StockQuotePort" binding="tns:StockQuoteSoapBinding">
+            <soap:address location="http://example.com/stockquote"/>
+        </port>
+    </service>
+
+</definitions>


### PR DESCRIPTION
Hi! 

# Problem

There is typescript [generator](https://github.com/dderevjanik/wsdl-tsclient) based on `node-soap`. Out of the box it parses wsdl using node-soap wsdl class.

For example for such wsdl:

```
<s:element name="SpellError">
  <s:complexType>
    <s:sequence>
      <s:element minOccurs="1" maxOccurs="1" name="word" type="s:string"/>
      <s:element minOccurs="1" maxOccurs="1" name="text" type="s:string"/>
     </s:sequence>
     <s:attribute name="text" type="s:string" use="required"/>
     <s:attribute name="pos" type="s:int" use="required"/>
  </s:complexType>
</s:element>
```

[generator](https://github.com/dderevjanik/wsdl-tsclient) creates such code where it ignores attributes :

```
interface SpellError {
  word?: string;
  text?: string; 
}
```

Generator ignores attributes because for parsing wsdl it uses `WSDL` class  from `node-soap` which don't parse attributes.

More about problem [here](https://github.com/dderevjanik/wsdl-tsclient/issues/63) and [here](https://github.com/dderevjanik/wsdl-tsclient/issues/20)

# Solution

This PR resuscitates old PR - https://github.com/vpulim/node-soap/pull/1013 - in which the problem has already been solved. 