### PR TITLE
WSSecurityCert KeyInfo tag wrapped around  SecurityTokenReference

### DIFF
--- a/src/security/WSSecurityCert.ts
+++ b/src/security/WSSecurityCert.ts
@@ -58,6 +58,7 @@ export class WSSecurityCert implements ISecurity {
   private publicP12PEM: string;
   private signer: any;
   private signerOptions: IXmlSignerOptions = {};
+  private keyInfoId: string;
   private x509Id: string;
   private hasTimeStamp: boolean;
   private signatureTransformations: string[];
@@ -111,15 +112,19 @@ export class WSSecurityCert implements ISecurity {
       key: privatePEM,
       passphrase: password,
     };
+    this.keyInfoId = `KI-${generateId()}`;
     this.x509Id = `x509-${generateId()}`;
     this.hasTimeStamp = typeof options.hasTimeStamp === 'undefined' ? true : !!options.hasTimeStamp;
     this.signatureTransformations = Array.isArray(options.signatureTransformations) ? options.signatureTransformations
       : ['http://www.w3.org/2000/09/xmldsig#enveloped-signature', 'http://www.w3.org/2001/10/xml-exc-c14n#'];
 
     this.signer.getKeyInfo = (key) => {
-      return `<wsse:SecurityTokenReference>` +
+      const prefix = !key || key === '' ? '' : `${key}:`;
+      return `<${prefix}KeyInfo Id="${this.keyInfoId}">` +
+        `<wsse:SecurityTokenReference>` +
         `<wsse:Reference URI="#${this.x509Id}" ValueType="${oasisBaseUri}/oasis-200401-wss-x509-token-profile-1.0#X509v3"/>` +
-        `</wsse:SecurityTokenReference>`;
+        `</wsse:SecurityTokenReference>` +
+        `</${prefix}KeyInfo>`;
     };
   }
 

--- a/src/security/WSSecurityCert.ts
+++ b/src/security/WSSecurityCert.ts
@@ -58,7 +58,6 @@ export class WSSecurityCert implements ISecurity {
   private publicP12PEM: string;
   private signer: any;
   private signerOptions: IXmlSignerOptions = {};
-  private keyInfoId: string;
   private x509Id: string;
   private hasTimeStamp: boolean;
   private signatureTransformations: string[];
@@ -112,19 +111,15 @@ export class WSSecurityCert implements ISecurity {
       key: privatePEM,
       passphrase: password,
     };
-    this.keyInfoId = `KI-${generateId()}`;
     this.x509Id = `x509-${generateId()}`;
     this.hasTimeStamp = typeof options.hasTimeStamp === 'undefined' ? true : !!options.hasTimeStamp;
     this.signatureTransformations = Array.isArray(options.signatureTransformations) ? options.signatureTransformations
       : ['http://www.w3.org/2000/09/xmldsig#enveloped-signature', 'http://www.w3.org/2001/10/xml-exc-c14n#'];
 
-    this.signer.getKeyInfo = (key) => {
-      const prefix = !key || key === '' ? '' : `${key}:`;
-      return `<${prefix}KeyInfo Id="${this.keyInfoId}">` +
-        `<wsse:SecurityTokenReference>` +
+    this.signer.getKeyInfoContent = (key) => {
+      return `<wsse:SecurityTokenReference>` +
         `<wsse:Reference URI="#${this.x509Id}" ValueType="${oasisBaseUri}/oasis-200401-wss-x509-token-profile-1.0#X509v3"/>` +
-        `</wsse:SecurityTokenReference>` +
-        `</${prefix}KeyInfo>`;
+        `</wsse:SecurityTokenReference>`;
     };
   }
 

--- a/test/security/WSSecurityCert.js
+++ b/test/security/WSSecurityCert.js
@@ -54,7 +54,8 @@ describe('WSSecurityCert', function () {
     xml.should.containEql('<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">');
     xml.should.containEql('<wsse:SecurityTokenReference');
     xml.should.containEql('<wsse:Reference URI="#' + instance.x509Id);
-    xml.should.containEql('<KeyInfo Id="' + instance.keyInfoId);
+    xml.should.containEql('<KeyInfo>');
+    xml.should.containEql('</KeyInfo>');
     xml.should.containEql('ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3"/>');
     xml.should.containEql(instance.publicP12PEM);
     xml.should.containEql(instance.signer.getSignatureXml());
@@ -187,6 +188,7 @@ describe('WSSecurityCert', function () {
     xml.should.containEql('<ds:DigestMethod');
     xml.should.containEql('<ds:DigestValue>');
     xml.should.containEql('</ds:DigestValue>');
+    xml.should.containEql('<ds:KeyInfo>');
     xml.should.containEql('</ds:KeyInfo>');
   });
 

--- a/test/security/WSSecurityCert.js
+++ b/test/security/WSSecurityCert.js
@@ -54,6 +54,7 @@ describe('WSSecurityCert', function () {
     xml.should.containEql('<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">');
     xml.should.containEql('<wsse:SecurityTokenReference');
     xml.should.containEql('<wsse:Reference URI="#' + instance.x509Id);
+    xml.should.containEql('<KeyInfo Id="' + instance.keyInfoId);
     xml.should.containEql('ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3"/>');
     xml.should.containEql(instance.publicP12PEM);
     xml.should.containEql(instance.signer.getSignatureXml());
@@ -186,6 +187,7 @@ describe('WSSecurityCert', function () {
     xml.should.containEql('<ds:DigestMethod');
     xml.should.containEql('<ds:DigestValue>');
     xml.should.containEql('</ds:DigestValue>');
+    xml.should.containEql('</ds:KeyInfo>');
   });
 
   it('should add attributes to the security tag', function () {


### PR DESCRIPTION
`WSSecurityCert` `<wsse:SecurityTokenReference>` tag should be wrapped inside `<KeyInfo>` tag.

reference: https://docs.oasis-open.org/wss/v1.1/wss-v1.1-spec-pr-x509TokenProfile-01.htm

```xml
<wsse:Security>
  <ds:Signature>
  
    <ds:SignedInfo>...</ds:SignedInfo>
    <ds:SignatureValue>...</ds:SignatureValue>

    <ds:KeyInfo Id="keyinfo"> <---------------------------- This tag was missing

       <wsse:SecurityTokenReference>...</wsse:SecurityTokenReference>
    </ds:KeyInfo>

  </ds:Signature>
</wsse:Security>
```