### PR TITLE
overrideImportLocation try/catch

### DIFF
--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -1209,14 +1209,18 @@ export class WSDL {
       includePath = url.resolve(this.uri || '', include.location);
     }
 
-    if (this.options.wsdl_options !== undefined && typeof this.options.wsdl_options.overrideImportLocation === 'function') {
-      includePath = this.options.wsdl_options.overrideImportLocation(includePath);
-    }
-
     const options = Object.assign({}, this.options);
     // follow supplied ignoredNamespaces option
     options.ignoredNamespaces = this._originalIgnoredNamespaces || this.options.ignoredNamespaces;
     options.WSDL_CACHE = this.WSDL_CACHE;
+
+    if (this.options.wsdl_options !== undefined && typeof this.options.wsdl_options.overrideImportLocation === 'function') {
+      try {
+        includePath = this.options.wsdl_options.overrideImportLocation(includePath, this.uri, include.location, options);
+      } catch (e) {
+        return callback(e);
+      }
+    }
 
     open_wsdl_recursive(includePath, options, (err, wsdl) => {
       if (err) {

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -75,6 +75,28 @@ describe('WSDL Parser (strict)', () => {
     });
   });
 
+  it('should catch error on overrideImportLocation option', (done) => {
+    const options = {
+      strict: true,
+      wsdl_options: {
+        overrideImportLocation: (location, parent, include, options) => {
+          assert.equal(location, __dirname+'/wsdl/wsdlImport/sub.wsdl');
+          assert.equal(parent, __dirname+'/wsdl/wsdlImport/main.wsdl');
+          assert.equal(include, 'sub.wsdl')
+          assert.notEqual(options, null);
+          throw new Error(`user error`);
+        }
+      },
+      disableCache: true,
+    };
+
+    soap.createClient(__dirname+'/wsdl/wsdlImport/main.wsdl', options, function(err, client){
+      assert.notEqual(err, null);
+      assert.equal(err.message, 'user error');
+      done();
+    });
+  });
+
   it('should get the parent namespace when parent namespace is empty string', (done) => {
     soap.createClient(__dirname+'/wsdl/marketo.wsdl', {strict: true}, function(err, client){
       assert.ifError(err);


### PR DESCRIPTION
Hi!

# Problem:

The node-soap library allows overriding the import location of WSDL files by defining an `overrideImportLocation` function in the options object. However, if the code within this function throws an error, the entire application crashes. This is because `overrideImportLocation` is invoked in the `process.nextTick` queue, and the `createClient` callback is not invoked.

Furthermore, in our project, we require complex logic to determine the import location. This necessitates the ability to throw user-defined exceptions within the `overrideImportLocation` function. It would be highly beneficial if these exceptions were returned by the client callback function.

# Proposed solution:

To address these issues, we propose the following:

1. Wrap `overrideImportLocation` in a try-catch block: This will ensure that any errors thrown within the function are caught and handled gracefully.

2. Extend `overrideImportLocation` arguments: instead of returning only the location (for backward compatibility), it should also return the URI, include path, and options. This extended set of arguments facilitates the implementation of complex logic to determine the sub-WSDL location. The options parameter can be used to redefine specific parameters for the sub-WSDL.
