### PR TITLE
Not set Header.Connection if forever option is falsy

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -61,7 +61,7 @@ export class HttpClient implements IHttpClient {
       'Accept': 'text/html,application/xhtml+xml,application/xml,text/xml;q=0.9,*/*;q=0.8',
       'Accept-Encoding': 'none',
       'Accept-Charset': 'utf-8',
-      ...(exoptions.forever && { 'Connection': 'keep-alive' }),
+      ...(exoptions.forever && { Connection: 'keep-alive' }),
       'Host': host + (isNaN(port) ? '' : ':' + port),
     };
     const mergeOptions = ['headers'];

--- a/src/http.ts
+++ b/src/http.ts
@@ -61,7 +61,7 @@ export class HttpClient implements IHttpClient {
       'Accept': 'text/html,application/xhtml+xml,application/xml,text/xml;q=0.9,*/*;q=0.8',
       'Accept-Encoding': 'none',
       'Accept-Charset': 'utf-8',
-      'Connection': exoptions.forever ? 'keep-alive' : null,
+      ...(exoptions.forever && { 'Connection': 'keep-alive' }),
       'Host': host + (isNaN(port) ? '' : ':' + port),
     };
     const mergeOptions = ['headers'];

--- a/src/http.ts
+++ b/src/http.ts
@@ -61,7 +61,7 @@ export class HttpClient implements IHttpClient {
       'Accept': 'text/html,application/xhtml+xml,application/xml,text/xml;q=0.9,*/*;q=0.8',
       'Accept-Encoding': 'none',
       'Accept-Charset': 'utf-8',
-      'Connection': exoptions.forever ? 'keep-alive' : 'close',
+      'Connection': exoptions.forever ? 'keep-alive' : null,
       'Host': host + (isNaN(port) ? '' : ':' + port),
     };
     const mergeOptions = ['headers'];

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -1833,3 +1833,58 @@ describe('Client posting complex body', () => {
     }, baseUrl);
   });
 });
+
+describe('Connection header', () => {
+  var server = null;
+  var hostname = '127.0.0.1';
+  var port = 15099;
+  var baseUrl = 'http://' + hostname + ':' + port;
+
+  before(function (done) {
+    server = http.createServer(function (req, res) {
+      res.statusCode = 200;
+      res.write(JSON.stringify({ tempResponse: 'temp' }), 'utf8');
+      res.end();
+    }).listen(port, hostname, done);
+  });
+
+  after(function (done) {
+    server.close();
+    server = null;
+    done();
+  });
+
+  it('should set Connection header to keep-alive when forever option is true', function (done) {
+    soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', function (err, client) {
+      assert.ok(client);
+      assert.ifError(err);
+      client.MyOperation({}, { forever: true }, function () {
+        assert.strictEqual(client.lastRequestHeaders.Connection, 'keep-alive');
+        done();
+      }, null, null);
+    }, baseUrl);
+  });
+
+  it('should not set Connection header when forever option is false', function (done) {
+    soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', function (err, client) {
+      assert.ok(client);
+      assert.ifError(err);
+      client.MyOperation({}, { forever: false }, function () {
+        assert.strictEqual(client.lastRequestHeaders.Connection, undefined);
+        done();
+      }, null, null);
+    }, baseUrl);
+  });
+
+  it('should not set Connection header when forever option is not set', function (done) {
+    soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', function (err, client) {
+      assert.ok(client);
+      assert.ifError(err);
+
+      client.MyOperation({}, function () {
+        assert.strictEqual(client.lastRequestHeaders.Connection, undefined);
+        done();
+      }, null, null);
+    }, baseUrl);
+  });
+});


### PR DESCRIPTION
Not set Header.Connection if forever option is falsy

axios hang up

![image](https://github.com/user-attachments/assets/a5549081-15d7-48c7-90b7-0f70e9029968)

I tried simple codes
```ts
import axios from 'axios'
import http from 'node:http'
import { createClientAsync, HttpClient } from 'soap'

const address = 'http://cs.ssis.go.kr/indiv/cwoa/ws/interfaces/ERPII589SSI639W20042'
const methodName = 'WbOrg'
const content = {
  [methodName]: {
    item: {
      foo: 'bar',
    },
  },
}

async function main() {
  const axiosInstance = axios.create({
    httpAgent: new http.Agent(),
  })
  const httpClient = new HttpClient({
    request: axiosInstance,
  })
  const soapClient = await createClientAsync(`${address}?wsdl`, {
    // it works if toggle under
    // ref, server is broken. 500 is ok
    httpClient,
  })

  await soapClient.receiveAsync(
    {
      AuthInfo: {
        ComCode: 'C0000006260',
        Password: '3799232',
      },
      Contents: JSON.stringify(content),
    },
    // createClientAsync cannot set forever
    // {
    //   forever: true,
    // },
  )
}

main()
```

I found connection 'close' can be problematic

current:
- request GET wsdl
- response GET
- request POST
- hang up (axios throw error, not excute http request)

pr:
- request GET wsdl
- response GET
- request POST
- response POST


