### PR TITLE
Add option for digest algorithm

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -981,6 +981,7 @@ The `options` object is optional and can contain the following properties:
 * `hasTimeStamp`: Includes Timestamp tags (default: `true`)
 * `signatureTransformations`: sets the Reference Transforms Algorithm (default ['http://www.w3.org/2000/09/xmldsig#enveloped-signature', 'http://www.w3.org/2001/10/xml-exc-c14n#']). Type is a string array
 * `signatureAlgorithm`: set to `http://www.w3.org/2001/04/xmldsig-more#rsa-sha256` to use sha256
+* `digestAlgorithm`: set to `http://www.w3.org/2000/09/xmldsig#sha1` to use sha1 (default `http://www.w3.org/2001/04/xmlenc#sha256`)
 * `additionalReferences` : (optional) Array of Soap headers that need to be signed.  This need to be added using `client.addSoapHeader('header')`
 * `signerOptions`: (optional) passes options to the XML Signer package - from (https://github.com/yaronn/xml-crypto)
   * `existingPrefixes`: (optional) A hash of prefixes and namespaces prefix: namespace that shouldn't be in the signature because they already exist in the xml (default: `{ 'wsse': 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd' }`)

--- a/src/security/WSSecurityCert.ts
+++ b/src/security/WSSecurityCert.ts
@@ -74,11 +74,10 @@ export class WSSecurityCert implements ISecurity {
 
     this.signer = new SignedXml({
       idMode: options?.signerOptions?.idMode,
-      signatureAlgorithm: options?.signatureAlgorithm });
-    if (options.digestAlgorithm) {
-      this.signer.digestAlgorithm = options.digestAlgorithm;
-    }
+      signatureAlgorithm: options?.signatureAlgorithm,
+    });
 
+    this.signer.digestAlgorithm = options.digestAlgorithm ?? 'http://www.w3.org/2001/04/xmlenc#sha256';
     if (options.signatureAlgorithm === 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256') {
       this.signer.signatureAlgorithm = options.signatureAlgorithm;
       this.signer.addReference({

--- a/src/security/WSSecurityCert.ts
+++ b/src/security/WSSecurityCert.ts
@@ -43,6 +43,7 @@ export interface IWSSecurityCertOptions {
   hasTimeStamp?: boolean;
   signatureTransformations?: string[];
   signatureAlgorithm?: string;
+  digestAlgorithm?: string;
   additionalReferences?: string[];
   signerOptions?: IXmlSignerOptions;
 }
@@ -74,6 +75,9 @@ export class WSSecurityCert implements ISecurity {
     this.signer = new SignedXml({
       idMode: options?.signerOptions?.idMode,
       signatureAlgorithm: options?.signatureAlgorithm });
+    if (options.digestAlgorithm) {
+      this.signer.digestAlgorithm = options.digestAlgorithm;
+    }
 
     if (options.signatureAlgorithm === 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256') {
       this.signer.signatureAlgorithm = options.signatureAlgorithm;
@@ -180,19 +184,19 @@ export class WSSecurityCert implements ISecurity {
     resolvePlaceholderInReferences(this.signer.references, bodyXpath);
 
     if (!(this.signer.references.filter((ref: { xpath: string; }) => (ref.xpath === bodyXpath)).length > 0)) {
-      this.signer.addReference({ xpath: bodyXpath, transforms: references, digestAlgorithm: 'http://www.w3.org/2001/04/xmlenc#sha256' });
+      this.signer.addReference({ xpath: bodyXpath, transforms: references, digestAlgorithm: this.signer.digestAlgorithm });
     }
 
     for (const name of this.additionalReferences) {
       const xpath = `//*[name(.)='${name}']`;
       if (!(this.signer.references.filter((ref: { xpath: string; }) => (ref.xpath === xpath)).length > 0)) {
-        this.signer.addReference({ xpath: xpath, transforms: references, digestAlgorithm: 'http://www.w3.org/2001/04/xmlenc#sha256' });
+        this.signer.addReference({ xpath: xpath, transforms: references, digestAlgorithm: this.signer.digestAlgorithm });
       }
     }
 
     const timestampXpath = `//*[name(.)='wsse:Security']/*[local-name(.)='Timestamp']`;
     if (this.hasTimeStamp && !(this.signer.references.filter((ref: { xpath: string; }) => (ref.xpath === timestampXpath)).length > 0)) {
-      this.signer.addReference({ xpath: timestampXpath, transforms: references, digestAlgorithm: 'http://www.w3.org/2001/04/xmlenc#sha256' });
+      this.signer.addReference({ xpath: timestampXpath, transforms: references, digestAlgorithm: this.signer.digestAlgorithm });
     }
 
     this.signer.computeSignature(xmlWithSec, this.signerOptions);

--- a/test/security/WSSecurityCert.js
+++ b/test/security/WSSecurityCert.js
@@ -256,4 +256,14 @@ describe('WSSecurityCert', function () {
       var xml = instance.postProcess('<soap:Envelope><soap:Header></soap:Header><soap:Body><Body></Body></soap:Body></soap:Envelope>', 'soap');
       xml.should.containEql('SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha512"');
   });
+
+  it('should use digest method when the digestAlgorithm option is set on WSSecurityCert', function () {
+    var instance = new WSSecurityCert(key, cert, '', {
+      hasTimeStamp: false,
+      digestAlgorithm: 'http://www.w3.org/2000/09/xmldsig#sha1'
+    });
+    var xml = instance.postProcess('<soap:Envelope><soap:Header></soap:Header><soap:Body><Body></Body></soap:Body></soap:Envelope>', 'soap');
+    xml.should.containEql('DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"');
+  });
+
 });


### PR DESCRIPTION
Currently, the digest algorithm is hard coded to sha256 even when passing a different signature algorithm like sha1. However, some web services require differnt digest algorithms. This change adds a new option for passing the digest algorithm:

  client.setSecurity(new soap.WSSecurityCert(
    privateKey,
    publicKey,
    '',
    {
      signatureAlgorithm: 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
      **digestAlgorithm**   : 'http://www.w3.org/2000/09/xmldsig#sha1',
    }
  ));