### PR TITLE
Workaround for wsdl:input message-part and namespace use wsdl:i…

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -414,7 +414,7 @@ export class Client extends EventEmitter {
       assert.ok(!style || style === 'document', 'invalid message definition for rpc style binding');
 
       let useName = input.$name;
-      let useNSAlias = input.targetNSAlias;
+      let useNSAlias: any = input.targetNSAlias;
 
       // [workaround-1] if <wsdl:input> element has part as children use it.
       if (input.children && input.children.length == 1 && input.children[0].nsName == "wsdl:part" && input.children[0]["$element"]) {


### PR DESCRIPTION
WSDL server had the following multiple-import with wsdl:input part

main.wsdl

```xml
<wsdl:definitions name="Report" targetNamespace="2012-04-20" xmlns:i0="Other" xmlns:tns="2012-04-20">
  <wsdl:import namespace="Other" location="other.wsdl" />
  <wsdl:message name="InputMessage">
    <wsdl:part name="parameters" element="tns:InputMessagePart" />
  </wsdl:message>

  <wsdl:message name="OutputMessage">
    <wsdl:part name="parameters" element="tns:OutputMessagePart" />
  </wsdl:message>

  <wsdl:portType name="Report">
    <wsdl:operation name="TestOperation">
      <wsdl:input wsaw:Action="ACTX" message="tns:InputMessage" />
      <wsdl:output wsaw:Action="ACTX" message="tns:OutputMessage" />
    </wsdl:operation>
  </wsdl:portType>
  <wsdl:service name="Report">
        <wsdl:port name="SecureEp" binding="i0:SecureEp">
            <soap:address location="https://server.tld/Report/2012-04-20/" />
        </wsdl:port>
        <wsdl:port name="NonSecureEp" binding="i0:NonSecureEp">
            <soap:address location="https://server.tld/Report/2012-04-20/" />
        </wsdl:port>
    </wsdl:service>    
</wsdl:definitions>
```

other.wsdl

```xml
<wsdl:definitions targetNamespace="Other" 
xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy"
 xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:i0="20212-04-20"  xmlns:tns="Other">

  <wsp:Policy wsu:Id="SecureSOAPEndpoint_policy"> <!-- ... --></wsp:Policy>

  <wsdl:import namespace="2012-04-20" location="main.wsdl" />

  <wsdl:binding name="SecureEp" type="i0:Report">
    <wsp:PolicyReference URI="#SecureEp_policy" />
    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" />
    <wsdl:operation name="TestOperation">
      <soap:operation soapAction="2012-04-20/Report/TestOperation" style="document" />
         <wsdl:input><soap:body use="literal" /></wsdl:input>
         <wsdl:output><soap:body use="literal" /></wsdl:output>
    </wsdl:operation>
  </wsdl:binding>

  <wsdl:binding name="NonSecureEp" type="i0:Report">
    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" />

    <wsdl:operation name="TestOperation">
      <soap:operation soapAction="2012-04-20/Report/TestOperation" style="document" />
         <wsdl:input><soap:body use="literal" /></wsdl:input>
         <wsdl:output><soap:body use="literal" /></wsdl:output>
    </wsdl:operation>
  </wsdl:binding>
</wsdl:definitions>
```

When making call to function: client.TestOperation(...)

Actual: Wraps with <InputMessage>
Expected: Should wrap with <i0:InputMessagePart ...>