### PR TITLE
keep track of effective xmlns for each element

### DIFF
--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -407,4 +407,16 @@ describe('WSDL Parser (non-strict)', () => {
       done();
     });
   });
+
+  it('should describe correct service input/output when imports have different tns namespaces', function(done) {
+    soap.createClient(__dirname + '/wsdl/tnsImportConflict/root.wsdl', function(err, client) {
+      assert.ifError(err);
+      var description = client.describe();
+      assert.deepStrictEqual(description.TestService.TestPort.Test, {
+        input: { val: 'xsd:string' },
+        output: { val: 'xsd:string' },
+      });
+      done();
+    });
+  });
 });

--- a/test/wsdl/tnsImportConflict/bar.wsdl
+++ b/test/wsdl/tnsImportConflict/bar.wsdl
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions
+    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:tns="bar"
+    targetNamespace="bar">
+</wsdl:definitions>

--- a/test/wsdl/tnsImportConflict/foo.wsdl
+++ b/test/wsdl/tnsImportConflict/foo.wsdl
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions
+    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+    xmlns:tns="foo"
+    targetNamespace="foo">
+
+  <wsdl:types>
+    <xsd:schema targetNamespace="foo" elementFormDefault="qualified">
+      <xsd:element name="TestElement">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="val" type="xsd:string" minOccurs="0"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:schema>
+  </wsdl:types>
+
+  <wsdl:message name="TestInputMessage">
+    <wsdl:part name="params" element="tns:TestElement"/>
+  </wsdl:message>
+
+  <wsdl:message name="TestOutputMessage">
+    <wsdl:part name="params" element="tns:TestElement"/>
+  </wsdl:message>
+
+  <wsdl:portType name="TestPortType">
+    <wsdl:operation name="Test">
+      <wsdl:input message="tns:TestInputMessage"/>
+      <wsdl:output message="tns:TestOutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+
+  <wsdl:binding name="TestBinding" type="tns:TestPortType">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+    <wsdl:operation name="Test">
+      <soap:operation soapAction="foo/Test"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+
+</wsdl:definitions>

--- a/test/wsdl/tnsImportConflict/root.wsdl
+++ b/test/wsdl/tnsImportConflict/root.wsdl
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions
+    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+    xmlns:tns="http://tempuri.org"
+    name="TestService"
+    targetNamespace="http://tempuri.org">
+
+  <wsdl:import namespace="foo" location="foo.wsdl"/>
+  <wsdl:import namespace="bar" location="bar.wsdl"/>
+
+  <wsdl:service name="TestService">
+    <wsdl:port name="TestPort" binding="tns:TestBinding">
+      <soap:address location="http://example.com/TestService"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
This is an attempt at fixing #1276. It adds a new `effectiveXmlns` property to each `Element` type which keeps track of the namespace mapping at the time the element was defined.

I'm pretty confident that we need to track the xmlns mapping separately, but I'm not sure if this is the best way to do it. However, people often say that the correct solution becomes obvious once you see an incorrect one, so I'm sharing it anyway.

**edit:**

Another approach I considered was giving each `Element` a reference the `WSDL` instance it was declared in. Implemented here: https://github.com/vpulim/node-soap/pull/1279
