### PR TITLE
Add option to exclude specific elements (e.g., Body, Timestamp) from SOAP message signing

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -983,6 +983,7 @@ The `options` object is optional and can contain the following properties:
 * `signatureAlgorithm`: set to `http://www.w3.org/2001/04/xmldsig-more#rsa-sha256` to use sha256
 * `digestAlgorithm`: set to `http://www.w3.org/2000/09/xmldsig#sha1` to use sha1 (default `http://www.w3.org/2001/04/xmlenc#sha256`)
 * `additionalReferences` : (optional) Array of Soap headers that need to be signed.  This need to be added using `client.addSoapHeader('header')`
+* `excludeReferencesFromSigning`: (Optional) An array of SOAP element names to exclude from signing (e.g., `Body`, `Timestamp`, `To`, `Action`).
 * `signerOptions`: (optional) passes options to the XML Signer package - from (https://github.com/yaronn/xml-crypto)
   * `existingPrefixes`: (optional) A hash of prefixes and namespaces prefix: namespace that shouldn't be in the signature because they already exist in the xml (default: `{ 'wsse': 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd' }`)
   * `prefix`: (optional) Adds this value as a prefix for the generated signature tags.

--- a/src/security/WSSecurityCert.ts
+++ b/src/security/WSSecurityCert.ts
@@ -46,7 +46,7 @@ export interface IWSSecurityCertOptions {
   digestAlgorithm?: string;
   additionalReferences?: string[];
   signerOptions?: IXmlSignerOptions;
-  excludedReferences?: string[];
+  excludeReferencesFromSigning?: string[];
 }
 
 export interface IXmlSignerOptions {
@@ -66,7 +66,7 @@ export class WSSecurityCert implements ISecurity {
   private created: string;
   private expires: string;
   private additionalReferences: string[] = [];
-  private excludedReferences: string[] = [];
+  private excludeReferencesFromSigning: string[] = [];
 
   constructor(privatePEM: any, publicP12PEM: any, password: any, options: IWSSecurityCertOptions = {}) {
     this.publicP12PEM = publicP12PEM.toString()
@@ -99,8 +99,8 @@ export class WSSecurityCert implements ISecurity {
       this.additionalReferences = options.additionalReferences;
     }
 
-    if (options.excludedReferences && options.excludedReferences.length > 0) {
-      this.excludedReferences = options.excludedReferences;
+    if (options.excludeReferencesFromSigning && options.excludeReferencesFromSigning.length > 0) {
+      this.excludeReferencesFromSigning = options.excludeReferencesFromSigning;
     }
 
     if (options.signerOptions) {
@@ -188,19 +188,19 @@ export class WSSecurityCert implements ISecurity {
     const bodyXpath = `//*[name(.)='${envelopeKey}:Body']`;
     resolvePlaceholderInReferences(this.signer.references, bodyXpath);
 
-    if (!this.excludedReferences.some((ref) => ref === 'Body') && !(this.signer.references.filter((ref: { xpath: string; }) => (ref.xpath === bodyXpath)).length > 0)) {
-      this.signer.addReference({ xpath: bodyXpath, transforms: references, digestAlgorithm: this.signer.digestAlgorithm });
+    if (!this.excludeReferencesFromSigning.some((ref) => ref === 'Body') && !(this.signer.references.filter((ref: { xpath: string; }) => (ref.xpath === bodyXpath)).length > 0)) {
+        this.signer.addReference({ xpath: bodyXpath, transforms: references, digestAlgorithm: this.signer.digestAlgorithm });
     }
 
     for (const name of this.additionalReferences) {
       const xpath = `//*[name(.)='${name}']`;
-      if (!this.excludedReferences.some((ref) => ref === name) && !(this.signer.references.filter((ref: { xpath: string; }) => (ref.xpath === xpath)).length > 0)) {
+      if (!this.excludeReferencesFromSigning.some((ref) => ref === name) && !(this.signer.references.filter((ref: { xpath: string; }) => (ref.xpath === xpath)).length > 0)) {
         this.signer.addReference({ xpath: xpath, transforms: references, digestAlgorithm: this.signer.digestAlgorithm });
       }
     }
 
     const timestampXpath = `//*[name(.)='wsse:Security']/*[local-name(.)='Timestamp']`;
-    if (!this.excludedReferences.some((ref) => ref === 'Timestamp') && this.hasTimeStamp && !(this.signer.references.filter((ref: { xpath: string; }) => (ref.xpath === timestampXpath)).length > 0)) {
+    if (!this.excludeReferencesFromSigning.some((ref) => ref === 'Timestamp') && this.hasTimeStamp && !(this.signer.references.filter((ref: { xpath: string; }) => (ref.xpath === timestampXpath)).length > 0)) {
       this.signer.addReference({ xpath: timestampXpath, transforms: references, digestAlgorithm: this.signer.digestAlgorithm });
     }
 

--- a/src/security/WSSecurityCert.ts
+++ b/src/security/WSSecurityCert.ts
@@ -46,6 +46,7 @@ export interface IWSSecurityCertOptions {
   digestAlgorithm?: string;
   additionalReferences?: string[];
   signerOptions?: IXmlSignerOptions;
+  excludedReferences?: string[];
 }
 
 export interface IXmlSignerOptions {
@@ -65,6 +66,7 @@ export class WSSecurityCert implements ISecurity {
   private created: string;
   private expires: string;
   private additionalReferences: string[] = [];
+  private excludedReferences: string[] = [];
 
   constructor(privatePEM: any, publicP12PEM: any, password: any, options: IWSSecurityCertOptions = {}) {
     this.publicP12PEM = publicP12PEM.toString()
@@ -95,6 +97,10 @@ export class WSSecurityCert implements ISecurity {
 
     if (options.additionalReferences && options.additionalReferences.length > 0) {
       this.additionalReferences = options.additionalReferences;
+    }
+
+    if (options.excludedReferences && options.excludedReferences.length > 0) {
+      this.excludedReferences = options.excludedReferences;
     }
 
     if (options.signerOptions) {
@@ -182,19 +188,19 @@ export class WSSecurityCert implements ISecurity {
     const bodyXpath = `//*[name(.)='${envelopeKey}:Body']`;
     resolvePlaceholderInReferences(this.signer.references, bodyXpath);
 
-    if (!(this.signer.references.filter((ref: { xpath: string; }) => (ref.xpath === bodyXpath)).length > 0)) {
+    if (!this.excludedReferences.some((ref) => ref === 'Body') && !(this.signer.references.filter((ref: { xpath: string; }) => (ref.xpath === bodyXpath)).length > 0)) {
       this.signer.addReference({ xpath: bodyXpath, transforms: references, digestAlgorithm: this.signer.digestAlgorithm });
     }
 
     for (const name of this.additionalReferences) {
       const xpath = `//*[name(.)='${name}']`;
-      if (!(this.signer.references.filter((ref: { xpath: string; }) => (ref.xpath === xpath)).length > 0)) {
+      if (!this.excludedReferences.some((ref) => ref === name) && !(this.signer.references.filter((ref: { xpath: string; }) => (ref.xpath === xpath)).length > 0)) {
         this.signer.addReference({ xpath: xpath, transforms: references, digestAlgorithm: this.signer.digestAlgorithm });
       }
     }
 
     const timestampXpath = `//*[name(.)='wsse:Security']/*[local-name(.)='Timestamp']`;
-    if (this.hasTimeStamp && !(this.signer.references.filter((ref: { xpath: string; }) => (ref.xpath === timestampXpath)).length > 0)) {
+    if (!this.excludedReferences.some((ref) => ref === 'Timestamp') && this.hasTimeStamp && !(this.signer.references.filter((ref: { xpath: string; }) => (ref.xpath === timestampXpath)).length > 0)) {
       this.signer.addReference({ xpath: timestampXpath, transforms: references, digestAlgorithm: this.signer.digestAlgorithm });
     }
 

--- a/test/security/WSSecurityCert.js
+++ b/test/security/WSSecurityCert.js
@@ -110,6 +110,18 @@ describe('WSSecurityCert', function () {
     xml.match(/<Reference URI="#/g).should.have.length(2);
   });
 
+  it('should not only add Body Reference elements, for Soap inside wsse:Security element if Body is excluded from references', function () {
+    var instance = new WSSecurityCert(key, cert, '', {excludedReferences: ['Body']});
+    var xml = instance.postProcess('<soap:Envelope><soap:Header></soap:Header><soap:Body><Body></Body><Timestamp></Timestamp></soap:Body></soap:Envelope>', 'soap');
+    xml.match(/<Reference URI="#/g).should.have.length(1);
+  });
+
+  it('should not only add Timestamp Reference elements, for Soap inside wsse:Security element if Timestamp is excluded from references', function () {
+    var instance = new WSSecurityCert(key, cert, '',{excludedReferences: ['Timestamp']});
+    var xml = instance.postProcess('<soap:Envelope><soap:Header></soap:Header><soap:Body><Body></Body><Timestamp></Timestamp></soap:Body></soap:Envelope>', 'soap');
+    xml.match(/<Reference URI="#/g).should.have.length(1);
+  });
+
   it('should only add one Reference elements, for Soap Body wsse:Security element when addTimestamp is false', function () {
     var instance = new WSSecurityCert(key, cert, '', { hasTimeStamp: false });
     var xml = instance.postProcess('<soap:Envelope><soap:Header></soap:Header><soap:Body><Body></Body><Timestamp></Timestamp></soap:Body></soap:Envelope>', 'soap');
@@ -238,7 +250,7 @@ describe('WSSecurityCert', function () {
     }
     should(xml).not.be.ok();
   });
-   
+
   it('should use rsa-sha1 signature method when the signatureAlgorithm option is set to WSSecurityCert', function () {
       var instance = new WSSecurityCert(key, cert, '', {
          hasTimeStamp: false,


### PR DESCRIPTION
Description:

In some scenarios, it is necessary **not to sign certain elements** such as the <Body> or <Timestamp> in the SOAP request. To support this flexibility, this PR introduces a new property that allows users to **exclude specific references** from the signature process.

- Added a configurable option to exclude one or more elements (e.g., Body, Timestamp) from being signed.
- This helps in use cases where signing those elements causes compatibility issues or is not required.
- The implementation is backward compatible — by default, all elements are signed unless explicitly excluded.
- Updated relevant tests to cover this.

This enhancement improves the configurability of SOAP message security and supports broader integration scenarios.