### PR TITLE
Call method using apply to enable access to it through "this" context

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,7 @@
 import { EventEmitter } from 'events';
 import * as http from 'http';
 import * as url from 'url';
-import { IOneWayOptions, IServerOptions, IServicePort, IServices, ISoapFault, ISoapServiceMethod } from './types';
+import { IOneWayOptions, IServerOptions, IServices, ISoapFault, ISoapServiceMethod } from './types';
 import { findPrefix } from './utils';
 import { WSDL } from './wsdl';
 import { BindingElement, IPort } from './wsdl/elements';
@@ -489,7 +489,6 @@ export class Server extends EventEmitter {
     includeTimestamp?,
   ) {
     options = options || {};
-    let port: IServicePort;
     let method: ISoapServiceMethod;
     let body;
     let headers;
@@ -513,7 +512,6 @@ export class Server extends EventEmitter {
 
     try {
       method = this.services[serviceName][portName][methodName];
-      port = this.services[serviceName][portName];
     } catch (error) {
       return callback(this._envelope('', headers, includeTimestamp));
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,7 @@
 import { EventEmitter } from 'events';
 import * as http from 'http';
 import * as url from 'url';
-import { IOneWayOptions, ISecurity, IServerOptions, IServices, ISoapFault, ISoapServiceMethod } from './types';
+import { IOneWayOptions, IServerOptions, IServicePort, IServices, ISoapFault, ISoapServiceMethod } from './types';
 import { findPrefix } from './utils';
 import { WSDL } from './wsdl';
 import { BindingElement, IPort } from './wsdl/elements';
@@ -489,6 +489,7 @@ export class Server extends EventEmitter {
     includeTimestamp?,
   ) {
     options = options || {};
+    let port: IServicePort;
     let method: ISoapServiceMethod;
     let body;
     let headers;
@@ -512,6 +513,7 @@ export class Server extends EventEmitter {
 
     try {
       method = this.services[serviceName][portName][methodName];
+      port = this.services[serviceName][portName];
     } catch (error) {
       return callback(this._envelope('', headers, includeTimestamp));
     }
@@ -580,7 +582,7 @@ export class Server extends EventEmitter {
       handleResult(error, result);
     };
 
-    const result = method(args, methodCallback, options.headers, req, res, this);
+    const result = method.apply(this, [args, methodCallback, options.headers, req, res]);
     if (typeof result !== 'undefined') {
       if (isPromiseLike<any>(result)) {
         result.then((value) => {


### PR DESCRIPTION
Closes #1115 

This PR simply restores a branch off #1115 's deleted fork and resolves merge conflicts after a git rebase. From @bruno-brant

> Method is "applied" instead of being called directly, which enables access to "this". The owning object for the method is the port, therefore, that's what is being passed as "this".
> Author:    Bruno Brant <1890900+bruno-brant@users.noreply.github.com>