### PR TITLE
Speed up parsing with many namespaces

### DIFF
--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -214,6 +214,7 @@ export class WSDL {
       },
     };
     const stack: any[] = [{ name: null, object: root, schema: schema }];
+    const xsiPrefixes: Map<any, any> = new Map();
     const xmlns: any = {};
 
     const refs = {};
@@ -247,12 +248,17 @@ export class WSDL {
 
       // Handle element attributes
       for (attributeName in attrs) {
+        const value = attrs[attributeName];
         if (/^xmlns:|^xmlns$/.test(attributeName)) {
-          xmlns[splitQName(attributeName).name] = attrs[attributeName];
+          const name = splitQName(attributeName).name;
+          xmlns[name] = value;
+          if (value === XSI_URI) {
+              xsiPrefixes.set(name, value);
+          }
           continue;
         }
         hasNonXmlnsAttribute = true;
-        elementAttributes[attributeName] = attrs[attributeName];
+        elementAttributes[attributeName] = value;
       }
 
       for (attributeName in elementAttributes) {
@@ -316,8 +322,8 @@ export class WSDL {
       let xsiTypeSchema;
       let xsiType;
 
-      for (const prefix in xmlns) {
-        if (xmlns[prefix] === XSI_URI && (`${prefix}:type` in elementAttributes)) {
+      for (const prefix of xsiPrefixes.keys()) {
+        if (`${prefix}:type` in elementAttributes) {
           xsiType = elementAttributes[`${prefix}:type`];
           break;
         }


### PR DESCRIPTION
The XML schema instance handling of the parsing code behaves linearly with regards to the amount of namespaces. If there are many namespaces in the response (in our case it was over 200, almost all of them unused) this causes large slowdowns, which are especially problematic when parsing large amounts of XML in resource constrained environments.

For every attribute, the code iterated through all namespaces to figure out whether one of them was relevant for XSI. This is information that can easily be precomputed when the namespace definitions are encountered.

By doing this, the parsing is sped up by more than 5x in our case.

Our XML was 4MB of XML containing about 10000 attributes (most tags do not have any attributes) and over 200 namespace definitions in the response.

For this use case, this change resulted in very significant speedups:

```
Benchmark 1: node perf.js lib-baseline
  Time (mean ± σ):     12.666 s ±  0.134 s    [User: 12.876 s, System: 0.106 s]
  Range (min … max):   12.503 s … 12.972 s    10 runs

Benchmark 2: node perf.js
  Time (mean ± σ):      2.177 s ±  0.036 s    [User: 2.417 s, System: 0.054 s]
  Range (min … max):    2.130 s …  2.246 s    10 runs

Summary
  node perf.js ran
    5.82 ± 0.11 times faster than node perf.js lib-baseline
```

This data was generated using `hyperfine` with the `perf.js` script containing

```js
const {WSDL} = require(`./${process.argv[2] ?? "lib"}/wsdl`);
const fs = require("node:fs");

const uri = "/path/to.wsdl";
const def = fs.readFileSync(uri, "utf-8");
const x = new WSDL(def, uri, {});

x.onReady((w) => {
  if (w) {
    console.log(w);
    return;
  }
  const xml = fs.readFileSync("/path/to.xml", "utf-8");
  for (let i = 0; i < 10; i++) {
    const o = x.xmlToObject(xml);
  }
});
```

Results were measured on a Mac M3 Pro.