### PR TITLE
Add `*.ts` to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,10 @@ insert_final_newline = false
 indent_style = space
 indent_size = 2
 
+[*.ts]
+indent_style = space
+indent_size = 2
+
 [*.json]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
Most files in this project are now TypeScript, so the indentation configuration in the `.editorconfig` is important for that too.

My editor (WebStorm) wasn't correctly picking it up before and defaulting to 4 spaces, which made editing annoying.