### PR TITLE
fix harcoded namespace prefixes in parsing & add more tests

### DIFF
--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -22,6 +22,7 @@ import * as elements from './elements';
 const debug = debugBuilder('node-soap');
 
 const XSI_URI = 'http://www.w3.org/2001/XMLSchema-instance';
+const ENV_URI = 'http://schemas.xmlsoap.org/soap/envelope/';
 
 export function trim(text) {
   return text.trim();
@@ -215,6 +216,7 @@ export class WSDL {
     };
     const stack: any[] = [{ name: null, object: root, schema: schema }];
     const xsiPrefixes: Map<any, any> = new Map();
+    let envPrefix: string = "soap";
     const xmlns: any = {};
 
     const refs = {};
@@ -255,6 +257,9 @@ export class WSDL {
           if (value === XSI_URI) {
               xsiPrefixes.set(name, value);
           }
+          if (value === ENV_URI) {
+              envPrefix = name;
+          }
           continue;
         }
         hasNonXmlnsAttribute = true;
@@ -275,7 +280,7 @@ export class WSDL {
         obj[this.options.attributesKey] = elementAttributes;
       }
 
-      if (!objectName && (xmlns.soap || xmlns.soapenv || xmlns.S) && top.name === 'Body' && name !== 'Fault') {
+      if (!objectName && xmlns[envPrefix] && top.name === 'Body' && name !== 'Fault') {
         let message = this.definitions.messages[name];
         // Support RPC/literal messages where response body contains one element named
         // after the operation + 'Response'. See http://www.w3.org/TR/wsdl#_names

--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -216,7 +216,7 @@ export class WSDL {
     };
     const stack: any[] = [{ name: null, object: root, schema: schema }];
     const xsiPrefixes: Map<any, any> = new Map();
-    let envPrefix: string = "soap";
+    let envPrefix: string = 'soap';
     const xmlns: any = {};
 
     const refs = {};

--- a/test/request-response-samples/GET_ALL_STORE_NUMBERS__should_work_with_more_deeply_nested_XML_messages_and_security/request.json
+++ b/test/request-response-samples/GET_ALL_STORE_NUMBERS__should_work_with_more_deeply_nested_XML_messages_and_security/request.json
@@ -1,0 +1,3 @@
+{
+  "IV_REQUESTER": "REQUSER1"
+}

--- a/test/request-response-samples/GET_ALL_STORE_NUMBERS__should_work_with_more_deeply_nested_XML_messages_and_security/request.xml
+++ b/test/request-response-samples/GET_ALL_STORE_NUMBERS__should_work_with_more_deeply_nested_XML_messages_and_security/request.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+  <soap:Envelope
+    xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ns0="urn:company-com:document:company:rfc:functions"
+    xmlns:p1="urn:example:SYSTEM:RETAIL:StoreData"
+    xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+    <soap:Header>
+      <wsse:Security
+        xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+        xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+        <wsu:Timestamp wsu:Id="Timestamp-2014-10-12T01:02:03Z">
+          <wsu:Created>2014-10-12T01:02:03Z</wsu:Created>
+          <wsu:Expires>2014-10-12T01:12:03Z</wsu:Expires>
+        </wsu:Timestamp>
+        <wsse:UsernameToken
+          xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
+          wsu:Id="SecurityToken-2014-10-12T01:02:03Z">
+          <wsse:Username>basicuser</wsse:Username>
+          <wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText">basicpass</wsse:Password>
+          <wsu:Created>2014-10-12T01:02:03Z</wsu:Created>
+        </wsse:UsernameToken></wsse:Security>
+    </soap:Header>
+    <soap:Body>
+      <ns0:Z_STORE_TEMPLATE_GET_ALL xmlns:ns0="urn:company-com:document:company:rfc:functions">
+        <IV_REQUESTER>REQUSER1</IV_REQUESTER>
+      </ns0:Z_STORE_TEMPLATE_GET_ALL>
+    </soap:Body>
+</soap:Envelope>

--- a/test/request-response-samples/GET_ALL_STORE_NUMBERS__should_work_with_more_deeply_nested_XML_messages_and_security/response.json
+++ b/test/request-response-samples/GET_ALL_STORE_NUMBERS__should_work_with_more_deeply_nested_XML_messages_and_security/response.json
@@ -1,0 +1,18 @@
+{
+  "ET_ALL_STORES": {
+    "item": [
+      { "STORE_ID": "1001" },
+      { "STORE_ID": "1002" }
+    ]
+  },
+  "ET_RETURN": {
+    "item": [
+      {
+        "TYPE": "S",
+        "ID": "MSG001",
+        "NUMBER": "000",
+        "MESSAGE": "Request processed successfully"
+      }
+    ]
+  }
+}

--- a/test/request-response-samples/GET_ALL_STORE_NUMBERS__should_work_with_more_deeply_nested_XML_messages_and_security/response.xml
+++ b/test/request-response-samples/GET_ALL_STORE_NUMBERS__should_work_with_more_deeply_nested_XML_messages_and_security/response.xml
@@ -1,0 +1,24 @@
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+                  xmlns:urn="urn:company-com:document:company:rfc:functions">
+   <soapenv:Header/>
+   <soapenv:Body>
+      <urn:Z_STORE_TEMPLATE_GET_ALL.Response>
+         <ET_ALL_STORES>
+            <item>
+               <STORE_ID>1001</STORE_ID>
+            </item>
+            <item>
+               <STORE_ID>1002</STORE_ID>
+            </item>
+         </ET_ALL_STORES>
+         <ET_RETURN>
+            <item>
+               <TYPE>S</TYPE>
+               <ID>MSG001</ID>
+               <NUMBER>000</NUMBER>
+               <MESSAGE>Request processed successfully</MESSAGE>
+            </item>
+         </ET_RETURN>
+      </urn:Z_STORE_TEMPLATE_GET_ALL.Response>
+   </soapenv:Body>
+</soapenv:Envelope>

--- a/test/request-response-samples/GET_ALL_STORE_NUMBERS__should_work_with_more_deeply_nested_XML_messages_and_security/security.json
+++ b/test/request-response-samples/GET_ALL_STORE_NUMBERS__should_work_with_more_deeply_nested_XML_messages_and_security/security.json
@@ -1,0 +1,5 @@
+{
+  "type": "ws",
+  "username": "basicuser",
+  "password": "basicpass"
+}

--- a/test/request-response-samples/GET_ALL_STORE_NUMBERS__should_work_with_more_deeply_nested_XML_messages_and_security/soap.wsdl
+++ b/test/request-response-samples/GET_ALL_STORE_NUMBERS__should_work_with_more_deeply_nested_XML_messages_and_security/soap.wsdl
@@ -1,0 +1,523 @@
+<wsdl:definitions xmlns:ns0="urn:company-com:document:company:rfc:functions"
+    xmlns:p1="urn:example:SYSTEM:RETAIL:StoreData"
+    xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy"
+    xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
+    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" name="SI_O_SYSTEM_STOREDATA"
+    targetNamespace="urn:example:SYSTEM:RETAIL:StoreData">
+    <wsdl:documentation />
+    <wsp:UsingPolicy wsdl:required="true" />
+    <wsp:Policy wsu:Id="OP_GET_ALL_STORE_NUMBERS" />
+    <wsp:Policy wsu:Id="OP_GET_DATA" />
+    <wsdl:types>
+        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns="urn:company-com:document:company:rfc:functions"
+            targetNamespace="urn:company-com:document:company:rfc:functions">
+            <xsd:element name="Z_STORE_TEMPLATE_GET_DATA">
+                <xsd:complexType>
+                    <xsd:all>
+                        <xsd:element name="IT_STORE_NUMBERS" minOccurs="0">
+                            <xsd:complexType>
+                                <xsd:sequence>
+                                    <xsd:element name="item" type="ZSTORE_S_STORE_NUMBERS"
+                                        minOccurs="0" maxOccurs="unbounded" />
+                                </xsd:sequence>
+                            </xsd:complexType>
+                        </xsd:element>
+                        <xsd:element name="IV_REQUESTER" minOccurs="0">
+                            <xsd:simpleType>
+                                <xsd:restriction base="xsd:string">
+                                    <xsd:maxLength value="10" />
+                                </xsd:restriction>
+                            </xsd:simpleType>
+                        </xsd:element>
+                    </xsd:all>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="Z_STORE_TEMPLATE_GET_ALL.Response">
+                <xsd:complexType>
+                    <xsd:all>
+                        <xsd:element name="ET_ALL_STORES" minOccurs="0">
+                            <xsd:complexType>
+                                <xsd:sequence>
+                                    <xsd:element name="item" type="ZSTORE_S_STORE_NUMBERS"
+                                        minOccurs="0" maxOccurs="unbounded" />
+                                </xsd:sequence>
+                            </xsd:complexType>
+                        </xsd:element>
+                        <xsd:element name="ET_RETURN" minOccurs="0">
+                            <xsd:complexType>
+                                <xsd:sequence>
+                                    <xsd:element name="item" type="BAPIRET2" minOccurs="0"
+                                        maxOccurs="unbounded" />
+                                </xsd:sequence>
+                            </xsd:complexType>
+                        </xsd:element>
+                    </xsd:all>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="Z_STORE_TEMPLATE_GET_DATA.Response">
+                <xsd:complexType>
+                    <xsd:all>
+                        <xsd:element name="ET_STORE_DATA" minOccurs="0">
+                            <xsd:complexType>
+                                <xsd:sequence>
+                                    <xsd:element name="item" type="ZSTORE_S_STORE_DATA"
+                                        minOccurs="0"
+                                        maxOccurs="unbounded" />
+                                </xsd:sequence>
+                            </xsd:complexType>
+                        </xsd:element>
+                        <xsd:element name="ET_RETURN" minOccurs="0">
+                            <xsd:complexType>
+                                <xsd:sequence>
+                                    <xsd:element name="item" type="BAPIRET2" minOccurs="0"
+                                        maxOccurs="unbounded" />
+                                </xsd:sequence>
+                            </xsd:complexType>
+                        </xsd:element>
+                    </xsd:all>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="Z_STORE_TEMPLATE_GET_ALL">
+                <xsd:complexType>
+                    <xsd:all>
+                        <xsd:element name="IV_REQUESTER" minOccurs="0">
+                            <xsd:simpleType>
+                                <xsd:restriction base="xsd:string">
+                                    <xsd:maxLength value="10" />
+                                </xsd:restriction>
+                            </xsd:simpleType>
+                        </xsd:element>
+                    </xsd:all>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:simpleType name="genericDate">
+                <xsd:restriction base="xsd:string">
+                    <xsd:pattern value="....-..-.." />
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="date">
+                <xsd:union xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                    xmlns="urn:company-com:document:company:rfc:functions"
+                    memberTypes="xsd:date genericDate" />
+            </xsd:simpleType>
+            <xsd:complexType name="ZSTORE_S_STORE_SD_DATA">
+                <xsd:sequence>
+                    <xsd:element name="BRAND_CODE" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="4" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="CUSTOMER_GROUP" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="2" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="STORE_TYPE" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="2" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="IS_INACTIVE" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="1" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ZSTORE_S_STORE_DEPARTMENT_ASSIGN">
+                <xsd:sequence>
+                    <xsd:element name="DEPARTMENT" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="3" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ZSTORE_T_STORE_SALES_DATA">
+                <xsd:sequence>
+                    <xsd:element name="item" type="ZSTORE_S_STORE_SALES_DATA" minOccurs="0"
+                        maxOccurs="unbounded" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ZSTORE_T_STORE_DEPARTMENT_ASSIGN">
+                <xsd:sequence>
+                    <xsd:element name="item" type="ZSTORE_S_STORE_DEPARTMENT_ASSIGN" minOccurs="0"
+                        maxOccurs="unbounded" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ZSTORE_S_STORE_PLANNING_DATA">
+                <xsd:sequence>
+                    <xsd:element name="YEAR" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="4" />
+                                <xsd:pattern value="\d+" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="SEASON" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="1" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="STORE_GROUP" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="3" />
+                                <xsd:pattern value="\d+" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="STORE_FLAG" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="1" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="COMPETITIVE_FLAG" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="1" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ZSTORE_S_STORE_NUMBERS">
+                <xsd:sequence>
+                    <xsd:element name="STORE_ID" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="4" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ZSTORE_T_STORE_PLANNING_DATA">
+                <xsd:sequence>
+                    <xsd:element name="item" type="ZSTORE_S_STORE_PLANNING_DATA" minOccurs="0"
+                        maxOccurs="unbounded" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ZSTORE_S_STORE_SALES_DATA">
+                <xsd:sequence>
+                    <xsd:element name="SALES_ORG" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="4" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="DISTRIBUTION_CHANNEL" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="2" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="BAPIRET2">
+                <xsd:sequence>
+                    <xsd:element name="TYPE" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="1" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="ID" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="20" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="NUMBER" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="3" />
+                                <xsd:pattern value="\d+" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="MESSAGE" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="220" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="LOG_NO" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="20" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="LOG_MSG_NO" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="6" />
+                                <xsd:pattern value="\d+" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="MESSAGE_V1" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="50" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="MESSAGE_V2" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="50" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="MESSAGE_V3" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="50" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="MESSAGE_V4" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="50" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="PARAMETER" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="32" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="ROW" type="xsd:integer" minOccurs="0" />
+                    <xsd:element name="FIELD" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="30" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="SYSTEM" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="10" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ZSTORE_T_STORE_SD_DATA">
+                <xsd:sequence>
+                    <xsd:element name="item" type="ZSTORE_S_STORE_SD_DATA" minOccurs="0"
+                        maxOccurs="unbounded" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ZSTORE_S_STORE_DATA">
+                <xsd:sequence>
+                    <xsd:element name="STORE_ID" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="4" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="COMPANY_CODE" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="4" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="STORE_CUSTOMER_ID" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="8" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="NAME1" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="30" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="POSTAL_CODE" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="10" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="CITY" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="25" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="STREET" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="30" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="PHONE_NUMBER" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="30" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="OPENING_DATE" type="date" minOccurs="0" />
+                    <xsd:element name="LOCATION_CODE" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="4" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="CLOSING_DATE" type="date" minOccurs="0" />
+                    <xsd:element name="RENOVATION_DATE" type="date" minOccurs="0" />
+                    <xsd:element name="COUNTRY_CODE" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="2" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="PURCHASING_ORG" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="4" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="PURCHASING_GROUP" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="4" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="POS_SYSTEM" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="5" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="COUNTRY" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="3" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="DEPARTMENT_ASSIGNMENTS"
+                        type="ZSTORE_T_STORE_DEPARTMENT_ASSIGN"
+                        minOccurs="0" />
+                    <xsd:element name="PLANNING_DATA" type="ZSTORE_T_STORE_PLANNING_DATA"
+                        minOccurs="0" />
+                    <xsd:element name="SALES_AND_DISTRIBUTION_DATA" type="ZSTORE_T_STORE_SD_DATA"
+                        minOccurs="0" />
+                    <xsd:element name="SALES_DATA" type="ZSTORE_T_STORE_SALES_DATA" minOccurs="0" />
+                </xsd:sequence>
+            </xsd:complexType>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="ns0.Z_STORE_TEMPLATE_GET_ALL.Input">
+        <wsdl:documentation />
+        <wsdl:part name="parameters" element="ns0:Z_STORE_TEMPLATE_GET_ALL" />
+    </wsdl:message>
+    <wsdl:message name="ns0.Z_STORE_TEMPLATE_GET_ALL.Output">
+        <wsdl:documentation />
+        <wsdl:part name="parameters" element="ns0:Z_STORE_TEMPLATE_GET_ALL.Response" />
+    </wsdl:message>
+    <wsdl:message name="ns0.Z_STORE_TEMPLATE_GET_DATA.Input">
+        <wsdl:documentation />
+        <wsdl:part name="parameters" element="ns0:Z_STORE_TEMPLATE_GET_DATA" />
+    </wsdl:message>
+    <wsdl:message name="ns0.Z_STORE_TEMPLATE_GET_DATA.Output">
+        <wsdl:documentation />
+        <wsdl:part name="parameters" element="ns0:Z_STORE_TEMPLATE_GET_DATA.Response" />
+    </wsdl:message>
+    <wsdl:portType name="SI_O_SYSTEM_STOREDATA">
+        <wsdl:documentation />
+        <wsdl:operation name="GET_ALL_STORE_NUMBERS">
+            <wsdl:documentation />
+            <wsp:Policy>
+                <wsp:PolicyReference URI="#OP_GET_ALL_STORE_NUMBERS" />
+            </wsp:Policy>
+            <wsdl:input message="p1:ns0.Z_STORE_TEMPLATE_GET_ALL.Input" />
+            <wsdl:output message="p1:ns0.Z_STORE_TEMPLATE_GET_ALL.Output" />
+        </wsdl:operation>
+        <wsdl:operation name="GET_DATA">
+            <wsdl:documentation />
+            <wsp:Policy>
+                <wsp:PolicyReference URI="#OP_GET_DATA" />
+            </wsp:Policy>
+            <wsdl:input message="p1:ns0.Z_STORE_TEMPLATE_GET_DATA.Input" />
+            <wsdl:output message="p1:ns0.Z_STORE_TEMPLATE_GET_DATA.Output" />
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="SI_O_SYSTEM_STOREDATABinding" type="p1:SI_O_SYSTEM_STOREDATA">
+        <soap:binding xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" style="document"
+            transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="GET_ALL_STORE_NUMBERS">
+            <soap:operation xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                soapAction="http://example.com/xi/WebService/soap1.1" />
+            <wsdl:input>
+                <soap:body xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GET_DATA">
+            <soap:operation xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                soapAction="http://example.com/xi/WebService/soap1.1" />
+            <wsdl:input>
+                <soap:body xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="SI_O_SYSTEM_STOREDATAService">
+        <wsdl:port name="HTTP_Port" binding="p1:SI_O_SYSTEM_STOREDATABinding">
+            <soap:address xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                location="http://example-server.company.com:8080/SOAPAdapter/MessageServlet?senderParty=&amp;senderService=INTEGRATION_ENGINE&amp;receiverParty=&amp;receiverService=&amp;interface=SI_O_SYSTEM_STOREDATA&amp;interfaceNamespace=urn%3Aexample%3ASYSTEM%3ARETAIL%3AStoreData" />
+        </wsdl:port>
+        <wsdl:port name="HTTPS_Port" binding="p1:SI_O_SYSTEM_STOREDATABinding">
+            <soap:address xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                location="https://example-server.company.com:8443/SOAPAdapter/MessageServlet?senderParty=&amp;senderService=INTEGRATION_ENGINE&amp;receiverParty=&amp;receiverService=&amp;interface=SI_O_SYSTEM_STOREDATA&amp;interfaceNamespace=urn%3Aexample%3ASYSTEM%3ARETAIL%3AStoreData" />
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/test/request-response-samples/GET_ALL_STORE_NUMBERS__should_work_with_more_deeply_nested_XML_messages_and_security/wsdl_options.js
+++ b/test/request-response-samples/GET_ALL_STORE_NUMBERS__should_work_with_more_deeply_nested_XML_messages_and_security/wsdl_options.js
@@ -1,0 +1,3 @@
+'use strict';
+
+exports.ignoreBaseNameSpaces = false;

--- a/test/request-response-samples/GET_DATA__should_work_with_more_deeply_nested_XML_messages_and_without_security/request.json
+++ b/test/request-response-samples/GET_DATA__should_work_with_more_deeply_nested_XML_messages_and_without_security/request.json
@@ -1,0 +1,9 @@
+{
+  "IT_STORE_NUMBERS": {
+    "item": [
+      { "STORE_ID": "1001" },
+      { "STORE_ID": "1002" }
+    ]
+  },
+  "IV_REQUESTER": "REQUSER1"
+}

--- a/test/request-response-samples/GET_DATA__should_work_with_more_deeply_nested_XML_messages_and_without_security/request.xml
+++ b/test/request-response-samples/GET_DATA__should_work_with_more_deeply_nested_XML_messages_and_without_security/request.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soapenv:Envelope
+   xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xmlns:ns0="urn:company-com:document:company:rfc:functions"
+   xmlns:p1="urn:example:SYSTEM:RETAIL:StoreData"
+   xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+   <soapenv:Body>
+      <xmlns:ns0:Z_STORE_TEMPLATE_GET_DATA xmlns:urn="urn:company-com:document:company:rfc:functions">
+         <IT_STORE_NUMBERS>
+            <item>
+               <STORE_ID>1001</STORE_ID>
+            </item>
+            <item>
+               <STORE_ID>1002</STORE_ID>
+            </item>
+         </IT_STORE_NUMBERS>
+         <IV_REQUESTER>REQUSER1</IV_REQUESTER>
+      </xmlns:ns0:Z_STORE_TEMPLATE_GET_DATA>
+   </soapenv:Body>
+</soapenv:Envelope>

--- a/test/request-response-samples/GET_DATA__should_work_with_more_deeply_nested_XML_messages_and_without_security/response.json
+++ b/test/request-response-samples/GET_DATA__should_work_with_more_deeply_nested_XML_messages_and_without_security/response.json
@@ -1,0 +1,40 @@
+{
+  "ET_STORE_DATA": {
+    "item": [
+      {
+        "STORE_ID": "1001",
+        "COMPANY_CODE": "C001",
+        "STORE_CUSTOMER_ID": "CUST1234",
+        "NAME1": "Downtown Store",
+        "POSTAL_CODE": "12345",
+        "CITY": "Metropolis",
+        "STREET": "Main St 1",
+        "PHONE_NUMBER": "+1-555-1111",
+        "OPENING_DATE": "2020-01-01",
+        "COUNTRY_CODE": "US"
+      },
+      {
+        "STORE_ID": "1002",
+        "COMPANY_CODE": "C002",
+        "STORE_CUSTOMER_ID": "CUST5678",
+        "NAME1": "Uptown Store",
+        "POSTAL_CODE": "67890",
+        "CITY": "Gotham",
+        "STREET": "High St 99",
+        "PHONE_NUMBER": "+1-555-2222",
+        "OPENING_DATE": "2021-06-15",
+        "COUNTRY_CODE": "US"
+      }
+    ]
+  },
+  "ET_RETURN": {
+    "item": [
+      {
+        "TYPE": "S",
+        "ID": "MSG001",
+        "NUMBER": "000",
+        "MESSAGE": "Data retrieved successfully"
+      }
+    ]
+  }
+}

--- a/test/request-response-samples/GET_DATA__should_work_with_more_deeply_nested_XML_messages_and_without_security/response.xml
+++ b/test/request-response-samples/GET_DATA__should_work_with_more_deeply_nested_XML_messages_and_without_security/response.xml
@@ -1,7 +1,7 @@
-<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
-                  xmlns:urn="urn:company-com:document:company:rfc:functions">
-   <soapenv:Header/>
-   <soapenv:Body>
+<SOAP:Envelope xmlns:SOAP="http://schemas.xmlsoap.org/soap/envelope/"
+               xmlns:urn="urn:company-com:document:company:rfc:functions">
+   <SOAP:Header/>
+   <SOAP:Body>
       <urn:Z_STORE_TEMPLATE_GET_DATA.Response>
          <ET_STORE_DATA>
             <item>
@@ -38,5 +38,5 @@
             </item>
          </ET_RETURN>
       </urn:Z_STORE_TEMPLATE_GET_DATA.Response>
-   </soapenv:Body>
-</soapenv:Envelope>
+   </SOAP:Body>
+</SOAP:Envelope>

--- a/test/request-response-samples/GET_DATA__should_work_with_more_deeply_nested_XML_messages_and_without_security/response.xml
+++ b/test/request-response-samples/GET_DATA__should_work_with_more_deeply_nested_XML_messages_and_without_security/response.xml
@@ -1,0 +1,42 @@
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+                  xmlns:urn="urn:company-com:document:company:rfc:functions">
+   <soapenv:Header/>
+   <soapenv:Body>
+      <urn:Z_STORE_TEMPLATE_GET_DATA.Response>
+         <ET_STORE_DATA>
+            <item>
+               <STORE_ID>1001</STORE_ID>
+               <COMPANY_CODE>C001</COMPANY_CODE>
+               <STORE_CUSTOMER_ID>CUST1234</STORE_CUSTOMER_ID>
+               <NAME1>Downtown Store</NAME1>
+               <POSTAL_CODE>12345</POSTAL_CODE>
+               <CITY>Metropolis</CITY>
+               <STREET>Main St 1</STREET>
+               <PHONE_NUMBER>+1-555-1111</PHONE_NUMBER>
+               <OPENING_DATE>2020-01-01</OPENING_DATE>
+               <COUNTRY_CODE>US</COUNTRY_CODE>
+            </item>
+            <item>
+               <STORE_ID>1002</STORE_ID>
+               <COMPANY_CODE>C002</COMPANY_CODE>
+               <STORE_CUSTOMER_ID>CUST5678</STORE_CUSTOMER_ID>
+               <NAME1>Uptown Store</NAME1>
+               <POSTAL_CODE>67890</POSTAL_CODE>
+               <CITY>Gotham</CITY>
+               <STREET>High St 99</STREET>
+               <PHONE_NUMBER>+1-555-2222</PHONE_NUMBER>
+               <OPENING_DATE>2021-06-15</OPENING_DATE>
+               <COUNTRY_CODE>US</COUNTRY_CODE>
+            </item>
+         </ET_STORE_DATA>
+         <ET_RETURN>
+            <item>
+               <TYPE>S</TYPE>
+               <ID>MSG001</ID>
+               <NUMBER>000</NUMBER>
+               <MESSAGE>Data retrieved successfully</MESSAGE>
+            </item>
+         </ET_RETURN>
+      </urn:Z_STORE_TEMPLATE_GET_DATA.Response>
+   </soapenv:Body>
+</soapenv:Envelope>

--- a/test/request-response-samples/GET_DATA__should_work_with_more_deeply_nested_XML_messages_and_without_security/soap.wsdl
+++ b/test/request-response-samples/GET_DATA__should_work_with_more_deeply_nested_XML_messages_and_without_security/soap.wsdl
@@ -1,0 +1,523 @@
+<wsdl:definitions xmlns:ns0="urn:company-com:document:company:rfc:functions"
+    xmlns:p1="urn:example:SYSTEM:RETAIL:StoreData"
+    xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy"
+    xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
+    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" name="SI_O_SYSTEM_STOREDATA"
+    targetNamespace="urn:example:SYSTEM:RETAIL:StoreData">
+    <wsdl:documentation />
+    <wsp:UsingPolicy wsdl:required="true" />
+    <wsp:Policy wsu:Id="OP_GET_ALL_STORE_NUMBERS" />
+    <wsp:Policy wsu:Id="OP_GET_DATA" />
+    <wsdl:types>
+        <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns="urn:company-com:document:company:rfc:functions"
+            targetNamespace="urn:company-com:document:company:rfc:functions">
+            <xsd:element name="Z_STORE_TEMPLATE_GET_DATA">
+                <xsd:complexType>
+                    <xsd:all>
+                        <xsd:element name="IT_STORE_NUMBERS" minOccurs="0">
+                            <xsd:complexType>
+                                <xsd:sequence>
+                                    <xsd:element name="item" type="ZSTORE_S_STORE_NUMBERS"
+                                        minOccurs="0" maxOccurs="unbounded" />
+                                </xsd:sequence>
+                            </xsd:complexType>
+                        </xsd:element>
+                        <xsd:element name="IV_REQUESTER" minOccurs="0">
+                            <xsd:simpleType>
+                                <xsd:restriction base="xsd:string">
+                                    <xsd:maxLength value="10" />
+                                </xsd:restriction>
+                            </xsd:simpleType>
+                        </xsd:element>
+                    </xsd:all>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="Z_STORE_TEMPLATE_GET_ALL.Response">
+                <xsd:complexType>
+                    <xsd:all>
+                        <xsd:element name="ET_ALL_STORES" minOccurs="0">
+                            <xsd:complexType>
+                                <xsd:sequence>
+                                    <xsd:element name="item" type="ZSTORE_S_STORE_NUMBERS"
+                                        minOccurs="0" maxOccurs="unbounded" />
+                                </xsd:sequence>
+                            </xsd:complexType>
+                        </xsd:element>
+                        <xsd:element name="ET_RETURN" minOccurs="0">
+                            <xsd:complexType>
+                                <xsd:sequence>
+                                    <xsd:element name="item" type="BAPIRET2" minOccurs="0"
+                                        maxOccurs="unbounded" />
+                                </xsd:sequence>
+                            </xsd:complexType>
+                        </xsd:element>
+                    </xsd:all>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="Z_STORE_TEMPLATE_GET_DATA.Response">
+                <xsd:complexType>
+                    <xsd:all>
+                        <xsd:element name="ET_STORE_DATA" minOccurs="0">
+                            <xsd:complexType>
+                                <xsd:sequence>
+                                    <xsd:element name="item" type="ZSTORE_S_STORE_DATA"
+                                        minOccurs="0"
+                                        maxOccurs="unbounded" />
+                                </xsd:sequence>
+                            </xsd:complexType>
+                        </xsd:element>
+                        <xsd:element name="ET_RETURN" minOccurs="0">
+                            <xsd:complexType>
+                                <xsd:sequence>
+                                    <xsd:element name="item" type="BAPIRET2" minOccurs="0"
+                                        maxOccurs="unbounded" />
+                                </xsd:sequence>
+                            </xsd:complexType>
+                        </xsd:element>
+                    </xsd:all>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="Z_STORE_TEMPLATE_GET_ALL">
+                <xsd:complexType>
+                    <xsd:all>
+                        <xsd:element name="IV_REQUESTER" minOccurs="0">
+                            <xsd:simpleType>
+                                <xsd:restriction base="xsd:string">
+                                    <xsd:maxLength value="10" />
+                                </xsd:restriction>
+                            </xsd:simpleType>
+                        </xsd:element>
+                    </xsd:all>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:simpleType name="genericDate">
+                <xsd:restriction base="xsd:string">
+                    <xsd:pattern value="....-..-.." />
+                </xsd:restriction>
+            </xsd:simpleType>
+            <xsd:simpleType name="date">
+                <xsd:union xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                    xmlns="urn:company-com:document:company:rfc:functions"
+                    memberTypes="xsd:date genericDate" />
+            </xsd:simpleType>
+            <xsd:complexType name="ZSTORE_S_STORE_SD_DATA">
+                <xsd:sequence>
+                    <xsd:element name="BRAND_CODE" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="4" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="CUSTOMER_GROUP" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="2" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="STORE_TYPE" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="2" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="IS_INACTIVE" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="1" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ZSTORE_S_STORE_DEPARTMENT_ASSIGN">
+                <xsd:sequence>
+                    <xsd:element name="DEPARTMENT" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="3" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ZSTORE_T_STORE_SALES_DATA">
+                <xsd:sequence>
+                    <xsd:element name="item" type="ZSTORE_S_STORE_SALES_DATA" minOccurs="0"
+                        maxOccurs="unbounded" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ZSTORE_T_STORE_DEPARTMENT_ASSIGN">
+                <xsd:sequence>
+                    <xsd:element name="item" type="ZSTORE_S_STORE_DEPARTMENT_ASSIGN" minOccurs="0"
+                        maxOccurs="unbounded" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ZSTORE_S_STORE_PLANNING_DATA">
+                <xsd:sequence>
+                    <xsd:element name="YEAR" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="4" />
+                                <xsd:pattern value="\d+" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="SEASON" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="1" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="STORE_GROUP" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="3" />
+                                <xsd:pattern value="\d+" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="STORE_FLAG" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="1" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="COMPETITIVE_FLAG" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="1" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ZSTORE_S_STORE_NUMBERS">
+                <xsd:sequence>
+                    <xsd:element name="STORE_ID" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="4" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ZSTORE_T_STORE_PLANNING_DATA">
+                <xsd:sequence>
+                    <xsd:element name="item" type="ZSTORE_S_STORE_PLANNING_DATA" minOccurs="0"
+                        maxOccurs="unbounded" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ZSTORE_S_STORE_SALES_DATA">
+                <xsd:sequence>
+                    <xsd:element name="SALES_ORG" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="4" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="DISTRIBUTION_CHANNEL" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="2" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="BAPIRET2">
+                <xsd:sequence>
+                    <xsd:element name="TYPE" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="1" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="ID" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="20" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="NUMBER" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="3" />
+                                <xsd:pattern value="\d+" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="MESSAGE" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="220" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="LOG_NO" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="20" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="LOG_MSG_NO" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="6" />
+                                <xsd:pattern value="\d+" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="MESSAGE_V1" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="50" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="MESSAGE_V2" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="50" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="MESSAGE_V3" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="50" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="MESSAGE_V4" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="50" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="PARAMETER" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="32" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="ROW" type="xsd:integer" minOccurs="0" />
+                    <xsd:element name="FIELD" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="30" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="SYSTEM" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="10" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ZSTORE_T_STORE_SD_DATA">
+                <xsd:sequence>
+                    <xsd:element name="item" type="ZSTORE_S_STORE_SD_DATA" minOccurs="0"
+                        maxOccurs="unbounded" />
+                </xsd:sequence>
+            </xsd:complexType>
+            <xsd:complexType name="ZSTORE_S_STORE_DATA">
+                <xsd:sequence>
+                    <xsd:element name="STORE_ID" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="4" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="COMPANY_CODE" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="4" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="STORE_CUSTOMER_ID" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="8" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="NAME1" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="30" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="POSTAL_CODE" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="10" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="CITY" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="25" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="STREET" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="30" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="PHONE_NUMBER" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="30" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="OPENING_DATE" type="date" minOccurs="0" />
+                    <xsd:element name="LOCATION_CODE" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="4" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="CLOSING_DATE" type="date" minOccurs="0" />
+                    <xsd:element name="RENOVATION_DATE" type="date" minOccurs="0" />
+                    <xsd:element name="COUNTRY_CODE" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="2" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="PURCHASING_ORG" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="4" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="PURCHASING_GROUP" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="4" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="POS_SYSTEM" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="5" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="COUNTRY" minOccurs="0">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:string">
+                                <xsd:maxLength value="3" />
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:element>
+                    <xsd:element name="DEPARTMENT_ASSIGNMENTS"
+                        type="ZSTORE_T_STORE_DEPARTMENT_ASSIGN"
+                        minOccurs="0" />
+                    <xsd:element name="PLANNING_DATA" type="ZSTORE_T_STORE_PLANNING_DATA"
+                        minOccurs="0" />
+                    <xsd:element name="SALES_AND_DISTRIBUTION_DATA" type="ZSTORE_T_STORE_SD_DATA"
+                        minOccurs="0" />
+                    <xsd:element name="SALES_DATA" type="ZSTORE_T_STORE_SALES_DATA" minOccurs="0" />
+                </xsd:sequence>
+            </xsd:complexType>
+        </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="ns0.Z_STORE_TEMPLATE_GET_ALL.Input">
+        <wsdl:documentation />
+        <wsdl:part name="parameters" element="ns0:Z_STORE_TEMPLATE_GET_ALL" />
+    </wsdl:message>
+    <wsdl:message name="ns0.Z_STORE_TEMPLATE_GET_ALL.Output">
+        <wsdl:documentation />
+        <wsdl:part name="parameters" element="ns0:Z_STORE_TEMPLATE_GET_ALL.Response" />
+    </wsdl:message>
+    <wsdl:message name="ns0.Z_STORE_TEMPLATE_GET_DATA.Input">
+        <wsdl:documentation />
+        <wsdl:part name="parameters" element="ns0:Z_STORE_TEMPLATE_GET_DATA" />
+    </wsdl:message>
+    <wsdl:message name="ns0.Z_STORE_TEMPLATE_GET_DATA.Output">
+        <wsdl:documentation />
+        <wsdl:part name="parameters" element="ns0:Z_STORE_TEMPLATE_GET_DATA.Response" />
+    </wsdl:message>
+    <wsdl:portType name="SI_O_SYSTEM_STOREDATA">
+        <wsdl:documentation />
+        <wsdl:operation name="GET_ALL_STORE_NUMBERS">
+            <wsdl:documentation />
+            <wsp:Policy>
+                <wsp:PolicyReference URI="#OP_GET_ALL_STORE_NUMBERS" />
+            </wsp:Policy>
+            <wsdl:input message="p1:ns0.Z_STORE_TEMPLATE_GET_ALL.Input" />
+            <wsdl:output message="p1:ns0.Z_STORE_TEMPLATE_GET_ALL.Output" />
+        </wsdl:operation>
+        <wsdl:operation name="GET_DATA">
+            <wsdl:documentation />
+            <wsp:Policy>
+                <wsp:PolicyReference URI="#OP_GET_DATA" />
+            </wsp:Policy>
+            <wsdl:input message="p1:ns0.Z_STORE_TEMPLATE_GET_DATA.Input" />
+            <wsdl:output message="p1:ns0.Z_STORE_TEMPLATE_GET_DATA.Output" />
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="SI_O_SYSTEM_STOREDATABinding" type="p1:SI_O_SYSTEM_STOREDATA">
+        <soap:binding xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" style="document"
+            transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="GET_ALL_STORE_NUMBERS">
+            <soap:operation xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                soapAction="http://example.com/xi/WebService/soap1.1" />
+            <wsdl:input>
+                <soap:body xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GET_DATA">
+            <soap:operation xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                soapAction="http://example.com/xi/WebService/soap1.1" />
+            <wsdl:input>
+                <soap:body xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="SI_O_SYSTEM_STOREDATAService">
+        <wsdl:port name="HTTP_Port" binding="p1:SI_O_SYSTEM_STOREDATABinding">
+            <soap:address xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                location="http://example-server.company.com:8080/SOAPAdapter/MessageServlet?senderParty=&amp;senderService=INTEGRATION_ENGINE&amp;receiverParty=&amp;receiverService=&amp;interface=SI_O_SYSTEM_STOREDATA&amp;interfaceNamespace=urn%3Aexample%3ASYSTEM%3ARETAIL%3AStoreData" />
+        </wsdl:port>
+        <wsdl:port name="HTTPS_Port" binding="p1:SI_O_SYSTEM_STOREDATABinding">
+            <soap:address xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                location="https://example-server.company.com:8443/SOAPAdapter/MessageServlet?senderParty=&amp;senderService=INTEGRATION_ENGINE&amp;receiverParty=&amp;receiverService=&amp;interface=SI_O_SYSTEM_STOREDATA&amp;interfaceNamespace=urn%3Aexample%3ASYSTEM%3ARETAIL%3AStoreData" />
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/test/request-response-samples/GET_DATA__should_work_with_more_deeply_nested_XML_messages_and_without_security/wsdl_options.js
+++ b/test/request-response-samples/GET_DATA__should_work_with_more_deeply_nested_XML_messages_and_without_security/wsdl_options.js
@@ -1,0 +1,17 @@
+'use strict';
+
+exports.ignoreBaseNameSpaces = true;
+exports.envelopeKey = "soapenv";
+
+exports.ignoredNamespaces = {
+    "namespaces": ["targetNamespace", "typedNamespace"],
+    "override": "true"
+  };
+
+exports.overrideRootElement = {
+    "namespace": "xmlns:ns0",
+    "xmlnsAttributes": [{
+      "name": "xmlns:urn",
+      "value": "urn:company-com:document:company:rfc:functions"
+    }]
+  };


### PR DESCRIPTION
- Closes #1346 

This PR simply creates two new request-response sample regression tests based on the WSDL from #1346. I test with various options and with and without security. The tests pass with the current branch tip. However, the OP would need to confirm if the samples are representative enough of the data they see.

@w666 -- over to you to make any adjutments as needed