### PR TITLE
Handle different namespace prefix for the same namespace

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -116,9 +116,10 @@ Paid support can be provided as well, please contact one of the active maintaine
   - `stream` (_boolean_): Use streams to parse the XML SOAP responses. (**Default:** `false`)
   - `returnSaxStream` (_boolean_): Return the SAX stream, transferring responsibility of parsing XML to the end user. Only valid when the _stream_ option is set to `true`. (**Default:** `false`)
   - `parseReponseAttachments` (_boolean_): Treat response as multipart/related response with MTOM attachment. Reach attachments on the `lastResponseAttachments` property of SoapClient. (**Default:** `false`)
-  - `encoding` (_string_): response data enconding, used with `parseReponseAttachments`. (**Default:** `utf8`)
+  - `encoding` (_string_): Response data enconding, used with `parseReponseAttachments`. (**Default:** `utf8`)
+  - `forceUseSchemaXmlns` (_boolean_): Force to use schema xmlns when schema prefix not found, this is needed when schema prefix is different for the same namespace in different files, for example wsdl and in imported xsd file fir complex types (**Default** `false`)
 - `callback` (_Function_):
-  - `err` (_Error_ | _<AggregateError>_)
+  - `err` (_Error_ | _\<AggregateError\>_)
   - `result` (_Any_)
 - Returns: `Client`
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -181,6 +181,8 @@ export class Client extends EventEmitter {
     this.wsdl.options.envelopeKey = options.envelopeKey || 'soap';
     this.wsdl.options.envelopeSoapUrl = options.envelopeSoapUrl || 'http://schemas.xmlsoap.org/soap/envelope/';
     this.wsdl.options.preserveWhitespace = !!options.preserveWhitespace;
+    this.wsdl.options.forceUseSchemaXmlns = !!options.forceUseSchemaXmlns;
+
     const igNs = options.ignoredNamespaces;
     if (igNs !== undefined && typeof igNs === 'object') {
       if ('override' in igNs) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,6 +107,8 @@ export interface IWsdlBaseOptions {
   wsdl_options?: { [key: string]: any };
   /** set proper headers for SOAP v1.2. */
   forceSoap12Headers?: boolean;
+  /** Force to use schema xmlns when schema prefix not found, this is needed when schema prefix is different for the same namespace in different files, for example wsdl and in imported xsd file fir complex types*/
+  forceUseSchemaXmlns?: boolean;
 }
 
 /** @deprecated use IOptions */

--- a/src/wsdl/elements.ts
+++ b/src/wsdl/elements.ts
@@ -73,6 +73,7 @@ export class Element {
   public valueKey: string;
   public xmlKey;
   public xmlns?: IXmlNs;
+  public forceUseSchemaXmlns?: boolean;
 
   constructor(nsName: string, attrs, options?: IWsdlBaseOptions, schemaAttrs?) {
     const parts = splitQName(nsName);
@@ -180,11 +181,13 @@ export class Element {
       this.xmlKey = options.xmlKey || '$xml';
       this.ignoredNamespaces = options.ignoredNamespaces || [];
       this.strict = options.strict || false;
+      this.forceUseSchemaXmlns = options.forceUseSchemaXmlns || false;
     } else {
       this.valueKey = '$value';
       this.xmlKey = '$xml';
       this.ignoredNamespaces = [];
       this.strict = false;
+      this.forceUseSchemaXmlns = false;
     }
   }
 }
@@ -241,7 +244,7 @@ export class ElementElement extends Element {
     if (type) {
       type = splitQName(type);
       const typeName: string = type.name;
-      const useSchemaXmlns = !!findNs(type.prefix, this.definitionsXmlns, definitions.xmlns) || !!findNs(this.targetNSAlias, this.definitionsXmlns, definitions.xmlns);
+      const useSchemaXmlns = !!findNs(type.prefix, this.definitionsXmlns, definitions.xmlns) || !!findNs(this.targetNSAlias, this.definitionsXmlns, definitions.xmlns) || this.forceUseSchemaXmlns;
       const ns = findNs(type.prefix, xmlns, this.xmlns, useSchemaXmlns ? this.schemaXmlns : undefined, this.definitionsXmlns, definitions.xmlns);
       const schema = definitions.schemas[ns];
       const typeElement = schema && (this.$type ? schema.complexTypes[typeName] || schema.types[typeName] : schema.elements[typeName]);

--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -1181,6 +1181,7 @@ export class WSDL {
     // Works only in client
     this.options.forceSoap12Headers = options.forceSoap12Headers;
     this.options.customDeserializer = options.customDeserializer;
+    this.options.forceUseSchemaXmlns = options.forceUseSchemaXmlns;
 
     if (options.overrideElementKey !== undefined) {
       this.options.overrideElementKey = options.overrideElementKey;

--- a/test/request-response-samples/getMessage__does_not_use_schema_xmlns/dto10.xsd
+++ b/test/request-response-samples/getMessage__does_not_use_schema_xmlns/dto10.xsd
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xsd:schema
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:beadto10="urn:de:brak:bea:application:dto:soap:dto10" attributeFormDefault="qualified"
+	elementFormDefault="qualified" targetNamespace="urn:de:brak:bea:application:dto:soap:dto10">
+	<xsd:complexType name="MessageResponseSoapDTO">
+		<xsd:sequence>
+			<xsd:element name="exported" type="xsd:boolean">
+				<xsd:annotation>
+					<xsd:documentation>Die Nachricht wurde als "exportiert" markiert.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:schema>

--- a/test/request-response-samples/getMessage__does_not_use_schema_xmlns/request.json
+++ b/test/request-response-samples/getMessage__does_not_use_schema_xmlns/request.json
@@ -1,0 +1,10 @@
+{
+  "Body": {
+    "getMessageRequest": {
+      "message": {
+        "sessionId": "123",
+        "markAsExport": false
+      }
+    }
+  }
+}

--- a/test/request-response-samples/getMessage__does_not_use_schema_xmlns/request.xml
+++ b/test/request-response-samples/getMessage__does_not_use_schema_xmlns/request.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:dto10="urn:de:brak:bea:application:dto:soap:dto10"
+    xmlns:beatns="urn:de:brak:bea:application:dto:soap:types10">
+    <soap:Body>
+        <getMessageRequest xmlns="urn:de:brak:bea:application:dto:soap:types10">
+            <Body>
+                <getMessageRequest>
+                    <message>
+                        <sessionId>123</sessionId>
+                        <markAsExport>false</markAsExport>
+                    </message>
+                </getMessageRequest>
+            </Body>
+        </getMessageRequest>
+    </soap:Body>
+</soap:Envelope>

--- a/test/request-response-samples/getMessage__does_not_use_schema_xmlns/response.json
+++ b/test/request-response-samples/getMessage__does_not_use_schema_xmlns/response.json
@@ -1,0 +1,1 @@
+{ "message": { "exported": "false" } }

--- a/test/request-response-samples/getMessage__does_not_use_schema_xmlns/response.xml
+++ b/test/request-response-samples/getMessage__does_not_use_schema_xmlns/response.xml
@@ -1,0 +1,12 @@
+<soap:Envelope
+    xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+    <soap:Body>
+        <getMessageResponse
+            xmlns="urn:de:brak:bea:application:dto:soap:types10"
+            xmlns:ns2="urn:de:brak:bea:application:dto:soap:dto10">
+            <message>
+                <ns2:exported>false</ns2:exported>
+            </message>
+        </getMessageResponse>
+    </soap:Body>
+</soap:Envelope>

--- a/test/request-response-samples/getMessage__does_not_use_schema_xmlns/soap.wsdl
+++ b/test/request-response-samples/getMessage__does_not_use_schema_xmlns/soap.wsdl
@@ -1,0 +1,52 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<wsdl:definitions
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+	xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+	xmlns:dto10="urn:de:brak:bea:application:dto:soap:dto10"
+	xmlns:beatns="urn:de:brak:bea:application:dto:soap:types10"
+	xmlns="urn:de:brak:bea:application:dto:soap:types10" name="beA"
+	targetNamespace="urn:de:brak:bea:application:dto:soap:types10">
+	<wsdl:types>
+		<xsd:schema
+			xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+			xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+			xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+			xmlns:dto10="urn:de:brak:bea:application:dto:soap:dto10"
+			xmlns:beatns="urn:de:brak:bea:application:dto:soap:types10"
+			xmlns="urn:de:brak:bea:application:dto:soap:types10">
+			<xsd:import namespace="urn:de:brak:bea:application:dto:soap:types10"
+				schemaLocation="types10.xsd" />
+		</xsd:schema>
+	</wsdl:types>
+	<wsdl:message name="getMessageResponse">
+		<wsdl:part element="getMessageResponse" name="parameters"></wsdl:part>
+	</wsdl:message>
+	<wsdl:message name="getMessageRequest">
+		<wsdl:part element="getMessageRequest" name="parameters"></wsdl:part>
+	</wsdl:message>
+
+	<wsdl:portType name="beAServicePortType">
+		<wsdl:operation name="getMessage">
+			<wsdl:input message="getMessageRequest"></wsdl:input>
+			<wsdl:output message="getMessageResponse"></wsdl:output>
+		</wsdl:operation>
+	</wsdl:portType>
+	<wsdl:binding name="beAServiceHttpBinding" type="beAServicePortType">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="getMessage">
+			<soap:operation soapAction="getMessage" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:service name="BeAPortType">
+		<wsdl:port binding="beAServiceHttpBinding" name="BeAServiceV10">
+			<soap:address location="https://schulung-ksw.bea-brak.de/bea/BeAPortType/BeAServiceV10" />
+		</wsdl:port>
+	</wsdl:service>
+</wsdl:definitions>

--- a/test/request-response-samples/getMessage__does_not_use_schema_xmlns/types10.xsd
+++ b/test/request-response-samples/getMessage__does_not_use_schema_xmlns/types10.xsd
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xsd:schema
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:beadto10="urn:de:brak:bea:application:dto:soap:dto10" attributeFormDefault="qualified"
+	elementFormDefault="qualified" targetNamespace="urn:de:brak:bea:application:dto:soap:types10">
+	<xsd:import namespace="urn:de:brak:bea:application:dto:soap:dto10" schemaLocation="dto10.xsd" />
+	<xsd:element name="getMessageRequest">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="sessionId" type="xsd:string">
+				</xsd:element>
+				<xsd:element name="markAsExport" type="xsd:boolean">
+				</xsd:element>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="getMessageResponse">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="message" type="beadto10:MessageResponseSoapDTO">
+				</xsd:element>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+</xsd:schema>

--- a/test/request-response-samples/getMessage__force_use_schema_xmlns/dto10.xsd
+++ b/test/request-response-samples/getMessage__force_use_schema_xmlns/dto10.xsd
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xsd:schema
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:beadto10="urn:de:brak:bea:application:dto:soap:dto10" attributeFormDefault="qualified"
+	elementFormDefault="qualified" targetNamespace="urn:de:brak:bea:application:dto:soap:dto10">
+	<xsd:complexType name="MessageResponseSoapDTO">
+		<xsd:sequence>
+			<xsd:element name="exported" type="xsd:boolean">
+				<xsd:annotation>
+					<xsd:documentation>Die Nachricht wurde als "exportiert" markiert.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:schema>

--- a/test/request-response-samples/getMessage__force_use_schema_xmlns/request.json
+++ b/test/request-response-samples/getMessage__force_use_schema_xmlns/request.json
@@ -1,0 +1,10 @@
+{
+  "Body": {
+    "getMessageRequest": {
+      "message": {
+        "sessionId": "123",
+        "markAsExport": false
+      }
+    }
+  }
+}

--- a/test/request-response-samples/getMessage__force_use_schema_xmlns/request.xml
+++ b/test/request-response-samples/getMessage__force_use_schema_xmlns/request.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:dto10="urn:de:brak:bea:application:dto:soap:dto10"
+    xmlns:beatns="urn:de:brak:bea:application:dto:soap:types10">
+    <soap:Body>
+        <getMessageRequest xmlns="urn:de:brak:bea:application:dto:soap:types10">
+            <Body>
+                <getMessageRequest>
+                    <message>
+                        <sessionId>123</sessionId>
+                        <markAsExport>false</markAsExport>
+                    </message>
+                </getMessageRequest>
+            </Body>
+        </getMessageRequest>
+    </soap:Body>
+</soap:Envelope>

--- a/test/request-response-samples/getMessage__force_use_schema_xmlns/response.json
+++ b/test/request-response-samples/getMessage__force_use_schema_xmlns/response.json
@@ -1,0 +1,1 @@
+{ "message": { "exported": false } }

--- a/test/request-response-samples/getMessage__force_use_schema_xmlns/response.xml
+++ b/test/request-response-samples/getMessage__force_use_schema_xmlns/response.xml
@@ -1,0 +1,12 @@
+<soap:Envelope
+    xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+    <soap:Body>
+        <getMessageResponse
+            xmlns="urn:de:brak:bea:application:dto:soap:types10"
+            xmlns:ns2="urn:de:brak:bea:application:dto:soap:dto10">
+            <message>
+                <ns2:exported>false</ns2:exported>
+            </message>
+        </getMessageResponse>
+    </soap:Body>
+</soap:Envelope>

--- a/test/request-response-samples/getMessage__force_use_schema_xmlns/soap.wsdl
+++ b/test/request-response-samples/getMessage__force_use_schema_xmlns/soap.wsdl
@@ -1,0 +1,52 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<wsdl:definitions
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+	xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+	xmlns:dto10="urn:de:brak:bea:application:dto:soap:dto10"
+	xmlns:beatns="urn:de:brak:bea:application:dto:soap:types10"
+	xmlns="urn:de:brak:bea:application:dto:soap:types10" name="beA"
+	targetNamespace="urn:de:brak:bea:application:dto:soap:types10">
+	<wsdl:types>
+		<xsd:schema
+			xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+			xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+			xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+			xmlns:dto10="urn:de:brak:bea:application:dto:soap:dto10"
+			xmlns:beatns="urn:de:brak:bea:application:dto:soap:types10"
+			xmlns="urn:de:brak:bea:application:dto:soap:types10">
+			<xsd:import namespace="urn:de:brak:bea:application:dto:soap:types10"
+				schemaLocation="types10.xsd" />
+		</xsd:schema>
+	</wsdl:types>
+	<wsdl:message name="getMessageResponse">
+		<wsdl:part element="getMessageResponse" name="parameters"></wsdl:part>
+	</wsdl:message>
+	<wsdl:message name="getMessageRequest">
+		<wsdl:part element="getMessageRequest" name="parameters"></wsdl:part>
+	</wsdl:message>
+
+	<wsdl:portType name="beAServicePortType">
+		<wsdl:operation name="getMessage">
+			<wsdl:input message="getMessageRequest"></wsdl:input>
+			<wsdl:output message="getMessageResponse"></wsdl:output>
+		</wsdl:operation>
+	</wsdl:portType>
+	<wsdl:binding name="beAServiceHttpBinding" type="beAServicePortType">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+		<wsdl:operation name="getMessage">
+			<soap:operation soapAction="getMessage" />
+			<wsdl:input>
+				<soap:body use="literal" />
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal" />
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:service name="BeAPortType">
+		<wsdl:port binding="beAServiceHttpBinding" name="BeAServiceV10">
+			<soap:address location="https://schulung-ksw.bea-brak.de/bea/BeAPortType/BeAServiceV10" />
+		</wsdl:port>
+	</wsdl:service>
+</wsdl:definitions>

--- a/test/request-response-samples/getMessage__force_use_schema_xmlns/types10.xsd
+++ b/test/request-response-samples/getMessage__force_use_schema_xmlns/types10.xsd
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xsd:schema
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:beadto10="urn:de:brak:bea:application:dto:soap:dto10" attributeFormDefault="qualified"
+	elementFormDefault="qualified" targetNamespace="urn:de:brak:bea:application:dto:soap:types10">
+	<xsd:import namespace="urn:de:brak:bea:application:dto:soap:dto10" schemaLocation="dto10.xsd" />
+	<xsd:element name="getMessageRequest">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="sessionId" type="xsd:string">
+				</xsd:element>
+				<xsd:element name="markAsExport" type="xsd:boolean">
+				</xsd:element>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="getMessageResponse">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="message" type="beadto10:MessageResponseSoapDTO">
+				</xsd:element>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+</xsd:schema>

--- a/test/request-response-samples/getMessage__force_use_schema_xmlns/wsdl_options.js
+++ b/test/request-response-samples/getMessage__force_use_schema_xmlns/wsdl_options.js
@@ -1,0 +1,3 @@
+'use strict';
+
+exports.forceUseSchemaXmlns = true;


### PR DESCRIPTION
 - Add `forceUseSchemaXmlns` option to force to use schema xmlns, it contains all the prefixes defined in XSD files.
 - Add tests for both cases when `forceUseSchemaXmln=true` and not set.

 Close #1363