### PR TITLE
Bump `strip-bom` and `get-stream`

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,7 @@ jobs:
       # Don't fail all elements of the matrix if one fails
       fail-fast: false
       matrix:
-        node-version: ['20.x', '22.x', '24.x', '20.9.0', '20.10.0', '20.11.0', '20.12.0', '20.13.0', '20.14.0', '20.15.0', '20.16.0', '20.17.0', '20.18.0', '20.19.0']
+        node-version: ['20.x', '22.x', '24.x']
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "typescript-eslint": "^8.46.1"
       },
       "engines": {
-        "node": ">=20.9.0"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.6.3",
   "description": "A minimal node SOAP client",
   "engines": {
-    "node": ">=20.9.0"
+    "node": ">=20.19.0"
   },
   "author": "Vinay Pulim <v@pulim.com>",
   "dependencies": {


### PR DESCRIPTION
These dependencies are now compatible with `node-soap`.

- Bump strip-bom from 3.0.0 to 5.0.0
- Bump get-stream from 6.0.1 to 9.0.1
- Bump min node version to 20.19.0
- Don't fast-fail the test matrix

Helps #1281 