### PR TITLE
Run MR pipeline against supported node.js runtimes 20, 22 and 24

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,11 +4,14 @@ jobs:
   code-quality:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    strategy:
+      matrix:
+        node-version: ['20.x', '22.x', '24.x']
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm run build
       - run: npm run lint


### PR DESCRIPTION
Close #1406