### PR TITLE
Improvement when there is no explicit Body in the request (take 2)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -515,6 +515,7 @@ export class Server extends EventEmitter {
         return methodName;
       }
     }
+    return null;
   }
 
   private _executeMethod(options: IExecuteMethodOptions, req: Request, res: Response, callback: (result: any, statusCode?: number) => any, includeTimestamp?) {


### PR DESCRIPTION
- Closes #1196 

This PR simply reformats the OG PR using prettier and sync's with master to make it legible. There is no test, but the existing test pass. Not sure about the motivation. The author, @aurelmegn, says to "have improved the input request parsing when there is no explicit body in the initial request Xml." Perhaps they could clarify what changes. Not sure what to test for here either.

@w666 -- leaving up to you to decide what to do next -- merge this one, add a test, or simply close both...