### PR TITLE
Fix WSSecurityCert header placement when no SOAP headers exist

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -444,7 +444,7 @@ export class Client extends EventEmitter {
       encoding +
       this.wsdl.xmlnsInEnvelope +
       '>' +
-      (decodedHeaders || (this.security && this.security.toXML())
+      (decodedHeaders || (this.security && (this.security.toXML() || this.security.postProcess))
         ? '<' +
           envelopeKey +
           ':Header' +

--- a/test/security/WSSecurityCert.js
+++ b/test/security/WSSecurityCert.js
@@ -330,25 +330,38 @@ describe('WSSecurityCert', function () {
     xml.should.containEql(instance.signer.getSignatureXml());
   });
 
-  it('can handle undefined toXML in WSSecurity', async function () {
+  it('should produce valid XML with WSSecurityCert when no SOAP headers are added', async function () {
     const baseUrl = 'http://localhost:80';
+    const client = await soap.createClientAsync(__dirname + '/../wsdl/default_namespace.wsdl', {}, baseUrl);
 
-    try {
-      const client = await soap.createClientAsync(__dirname + '/../wsdl/default_namespace.wsdl', {}, baseUrl);
+    const security = new soap.WSSecurityCert(key, cert, '', {
+      hasTimeStamp: true,
+      signatureTransformations: ['http://www.w3.org/2001/10/xml-exc-c14n#'],
+    });
 
-      const security = new soap.WSSecurityCert(key, cert, '', {
-        hasTimeStamp: true,
-        signatureAlgorithm: 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
-        digestAlgorithm: 'http://www.w3.org/2000/09/xmldsig#sha1',
-        signatureTransformations: ['http://www.w3.org/2001/10/xml-exc-c14n#'],
-      });
+    client.setSecurity(security);
 
-      client.setSecurity(security);
+    let requestXml;
+    client.on('request', function (xml) {
+      requestXml = xml;
+    });
 
-      client.MyOperation(function () {});
-      assert.fail('must fail');
-    } catch (err) {
-      assert.ok(err.message?.includes('the following xpath cannot be signed'));
-    }
+    client.MyOperation({}, function () {});
+
+    assert.ok(requestXml, 'request XML should have been captured');
+    assert.ok(requestXml.indexOf('<soap:Header>') !== -1, 'XML must contain <soap:Header>');
+    assert.ok(requestXml.indexOf('</soap:Header>') !== -1, 'XML must contain </soap:Header>');
+    assert.ok(requestXml.indexOf('<wsse:Security') !== -1, 'XML must contain <wsse:Security');
+
+    const headerStart = requestXml.indexOf('<soap:Header>');
+    const headerEnd = requestXml.indexOf('</soap:Header>');
+    const securityStart = requestXml.indexOf('<wsse:Security');
+    assert.ok(securityStart > headerStart, 'wsse:Security must appear after <soap:Header>');
+    assert.ok(securityStart < headerEnd, 'wsse:Security must appear before </soap:Header>');
+
+    assert.ok(requestXml.endsWith('</soap:Envelope>'), 'XML must end with </soap:Envelope>');
+
+    const envelopeCloseIdx = requestXml.indexOf('</soap:Envelope>');
+    assert.strictEqual(envelopeCloseIdx + '</soap:Envelope>'.length, requestXml.length, 'No content should appear after </soap:Envelope>');
   });
 });


### PR DESCRIPTION
Fixes #1487

When using `WSSecurityCert` without additional SOAP headers, the generated security header could be placed outside the SOAP `Envelope`, resulting in invalid XML structure.

This change ensures the security header is always inserted inside the SOAP `Envelope`, regardless of whether other SOAP headers are present.

Includes a test covering the scenario where no additional SOAP headers exist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SOAP security header generation with improved fallback handling to support edge cases.

* **Tests**
  * Added test coverage verifying correct security header insertion in SOAP requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->