### PR TITLE
Fix handling default ports from URL

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -23,11 +23,34 @@ export interface IAttachment {
   body: NodeJS.ReadableStream;
 }
 
-function getPortFromUrl(url: URL): string {
-  if (url.port) return url.port;
-  if (url.protocol.toLowerCase() === 'https:') return '443';
-  if (url.protocol.toLowerCase() === 'http:') return '80';
-  return '';
+// The URL API normalizes away default ports (:80 on http, :443 on https),
+// so parse the port from the raw URL string to preserve ports.
+function getPortFromUrl(url: string): string {
+  // Capture the authority section (everything between :// and the first /?#)
+  const authorityMatch = /^[a-z][a-z0-9+.-]*:\/\/([^/?#]+)/i.exec(url);
+  if (!authorityMatch) {
+    return '';
+  }
+
+  const hostPort = authorityMatch[1];
+
+  // IPv6 address: [::1] or [::1]:port
+  if (hostPort.startsWith('[')) {
+    const bracketEnd = hostPort.indexOf(']');
+    if (bracketEnd !== -1 && hostPort[bracketEnd + 1] === ':') {
+      const port = hostPort.slice(bracketEnd + 2);
+      return /^\d+$/.test(port) ? port : '';
+    }
+    return '';
+  }
+
+  // IPv4 / hostname: host or host:port
+  const colonIndex = hostPort.lastIndexOf(':');
+  if (colonIndex === -1) {
+    return '';
+  }
+  const port = hostPort.slice(colonIndex + 1);
+  return /^\d+$/.test(port) ? port : '';
 }
 
 /**
@@ -59,16 +82,15 @@ export class HttpClient implements IHttpClient {
     const curl = new URL(rurl);
     const method = data ? 'POST' : 'GET';
 
-    const host = curl.hostname;
-
-    const port = getPortFromUrl(curl);
+    const port = getPortFromUrl(rurl);
+    const host = port ? `${curl.hostname}:${port}` : curl.host || curl.hostname;
     const headers: IHeaders = {
       'User-Agent': 'node-soap/' + version,
       'Accept': 'text/html,application/xhtml+xml,application/xml,text/xml;q=0.9,*/*;q=0.8',
       'Accept-Encoding': 'none',
       'Accept-Charset': 'utf-8',
       ...(exoptions.forever && { Connection: 'keep-alive' }),
-      'Host': host + (port ? ':' + port : ''),
+      'Host': host,
     };
     const mergeOptions = ['headers'];
 

--- a/test/client-customHttp-test.js
+++ b/test/client-customHttp-test.js
@@ -116,3 +116,16 @@ it('should allow customization of httpClient and the wsdl file download should p
     done();
   });
 });
+
+it('should not append default ports to Host header', function () {
+  var client = new httpClient();
+
+  var httpsReq = client.buildRequest('https://example.com/service?wsdl', null);
+  assert.equal(httpsReq.headers.Host, 'example.com');
+
+  var httpReq = client.buildRequest('http://example.com/service?wsdl', null);
+  assert.equal(httpReq.headers.Host, 'example.com');
+
+  var explicitPortReq = client.buildRequest('https://example.com:8443/service?wsdl', null);
+  assert.equal(explicitPortReq.headers.Host, 'example.com:8443');
+});


### PR DESCRIPTION
 Close #1488

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP client to exclude default ports (80 for HTTP, 443 for HTTPS) from Host headers when not explicitly specified in URLs
  * Explicit port numbers are properly preserved in Host headers when included

* **Tests**
  * Added test coverage for Host header formatting behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->