### PR TITLE
Do not extend IExpressApp from http.Server, add optional address prop

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,8 @@ import { WSDL } from './wsdl';
 import { BindingElement, IPort } from './wsdl/elements';
 import zlib from 'zlib';
 
-interface IExpressApp extends http.Server {
+interface IExpressApp {
+  address?: () => { address: string; port: number; family: string } | string;
   route;
   use;
 }


### PR DESCRIPTION
This is required to fix TS warnings when express.Router is passed to soap.listener

Close #1503