### PR TITLE
Adjust xmlEscape to escape \n, \r, and \t

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -199,15 +199,11 @@ export function xmlEscape(obj) {
     if (obj.substr(0, 9) === '<![CDATA[' && obj.substr(-3) === ']]>') {
       return obj;
     }
-    return obj.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&apos;');
+    // https://github.com/vpulim/node-soap/issues/1510
+    return obj.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&apos;').replace(/\t/g, '&#x9;').replace(/\r/g, '&#xD;').replace(/\n/g, '&#xA;');
   }
 
   return obj;
-}
-
-// https://github.com/vpulim/node-soap/issues/1510
-export function xmlEscapeAttr(obj) {
-  return xmlEscape(obj).replace(/\t/g, '&#x9;').replace(/\r/g, '&#xD;').replace(/\n/g, '&#xA;');
 }
 
 export function parseMTOMResp(payload: Buffer, boundary: string, callback: (err?: Error, resp?: IMTOMAttachments) => void) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -205,6 +205,11 @@ export function xmlEscape(obj) {
   return obj;
 }
 
+// https://github.com/vpulim/node-soap/issues/1510
+export function xmlEscapeAttr(obj) {
+  return xmlEscape(obj).replace(/\t/g, '&#x9;').replace(/\r/g, '&#xD;').replace(/\n/g, '&#xA;');
+}
+
 export function parseMTOMResp(payload: Buffer, boundary: string, callback: (err?: Error, resp?: IMTOMAttachments) => void) {
   return import('formidable')
     .then(({ MultipartParser }) => {

--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -14,7 +14,7 @@ import * as sax from 'sax';
 import { HttpClient } from '../http';
 import { NamespaceContext } from '../nscontext';
 import { IOptions } from '../types';
-import { findPrefix, splitQName, stripBom, TNS_PREFIX, xmlEscape, xmlEscapeAttr } from '../utils';
+import { findPrefix, splitQName, stripBom, TNS_PREFIX, xmlEscape } from '../utils';
 import * as elements from './elements';
 
 const debug = debugBuilder('node-soap');
@@ -1016,7 +1016,7 @@ export class WSDL {
         }
       } else {
         // https://github.com/vpulim/node-soap/issues/1510
-        attr += ` ${k}="${xmlEscapeAttr(v)}"`;
+        attr += ` ${k}="${xmlEscape(v)}"`;
       }
     });
 

--- a/src/wsdl/index.ts
+++ b/src/wsdl/index.ts
@@ -14,7 +14,7 @@ import * as sax from 'sax';
 import { HttpClient } from '../http';
 import { NamespaceContext } from '../nscontext';
 import { IOptions } from '../types';
-import { findPrefix, splitQName, stripBom, TNS_PREFIX, xmlEscape } from '../utils';
+import { findPrefix, splitQName, stripBom, TNS_PREFIX, xmlEscape, xmlEscapeAttr } from '../utils';
 import * as elements from './elements';
 
 const debug = debugBuilder('node-soap');
@@ -1015,7 +1015,8 @@ export class WSDL {
           attr += ` xmlns:${v.prefix}="${v.xmlns}"`;
         }
       } else {
-        attr += ` ${k}="${xmlEscape(v)}"`;
+        // https://github.com/vpulim/node-soap/issues/1510
+        attr += ` ${k}="${xmlEscapeAttr(v)}"`;
       }
     });
 


### PR DESCRIPTION
- Closes #1510

This PR proposes a change to add  \n, \r, and \t parsing in `objectToXML()` specifically for attributes only. <s>Creating this as draft because 6 tests below begin to fail. @w666 feel free to suggest next steps.

```
  625 passing (3s)
  2 pending
  6 failing

  1) Request Response Sampling
       should not fail without children:
     Uncaught TypeError: Cannot read properties of undefined (reading 'getAvailability')
      at /home/user/node-soap/test/request-response-samples-test.js:197:26
      at /home/user/node-soap/lib/soap.js:5:10271
      at WSDL.callback (lib/soap.js:5:8257)
      at /home/user/node-soap/lib/wsdl/index.js:7:1266
      at WSDL.callback (lib/wsdl/index.js:94:925)
      at /home/user/node-soap/lib/wsdl/index.js:9:156
      at WSDL._processNextInclude (lib/wsdl/index.js:93:997)
      at WSDL.processIncludes (lib/wsdl/index.js:9:801)
      at /home/user/node-soap/lib/wsdl/index.js:7:1112
      at process.processTicksAndRejections (node:internal/process/task_queues:77:11)

  2) Request Response Sampling
       correct ns context:
     Uncaught TypeError: Cannot read properties of undefined (reading 'UpdateProfile')
      at /home/user/node-soap/test/request-response-samples-test.js:197:26
      at /home/user/node-soap/lib/soap.js:5:10271
      at WSDL.callback (lib/soap.js:5:8257)
      at /home/user/node-soap/lib/wsdl/index.js:7:1266
      at /home/user/node-soap/lib/wsdl/index.js:94:1691
      at WSDL.callback (lib/wsdl/index.js:94:925)
      at /home/user/node-soap/lib/wsdl/index.js:9:156
      at /home/user/node-soap/lib/wsdl/index.js:94:1691
      at WSDL._processNextInclude (lib/wsdl/index.js:93:997)
      at WSDL.<anonymous> (lib/wsdl/index.js:94:1605)
      at open_wsdl_recursive (lib/wsdl/index.js:102:1196)
      at WSDL._processNextInclude (lib/wsdl/index.js:94:751)
      at WSDL.processIncludes (lib/wsdl/index.js:9:801)
      at /home/user/node-soap/lib/wsdl/index.js:7:1112
      at process.processTicksAndRejections (node:internal/process/task_queues:77:11)

  3) Request Response Sampling
       correct namespaces other prefixes:
     Uncaught TypeError: Cannot read properties of undefined (reading 'UpdateProfile')
      at /home/user/node-soap/test/request-response-samples-test.js:197:26
      at /home/user/node-soap/lib/soap.js:5:10271
      at WSDL.callback (lib/soap.js:5:8257)
      at /home/user/node-soap/lib/wsdl/index.js:7:1266
      at /home/user/node-soap/lib/wsdl/index.js:94:1691
      at WSDL.callback (lib/wsdl/index.js:94:925)
      at /home/user/node-soap/lib/wsdl/index.js:9:156
      at /home/user/node-soap/lib/wsdl/index.js:94:1691
      at WSDL._processNextInclude (lib/wsdl/index.js:93:997)
      at WSDL.<anonymous> (lib/wsdl/index.js:94:1605)
      at open_wsdl_recursive (lib/wsdl/index.js:102:1196)
      at WSDL._processNextInclude (lib/wsdl/index.js:94:751)
      at WSDL.processIncludes (lib/wsdl/index.js:9:801)
      at /home/user/node-soap/lib/wsdl/index.js:7:1112
      at process.processTicksAndRejections (node:internal/process/task_queues:77:11)

  4) Request Response Sampling
       correct namespaces in sequence with imports:
     Uncaught TypeError: Cannot read properties of undefined (reading 'UpdateProfile')
      at /home/user/node-soap/test/request-response-samples-test.js:197:26
      at /home/user/node-soap/lib/soap.js:5:10271
      at WSDL.callback (lib/soap.js:5:8257)
      at /home/user/node-soap/lib/wsdl/index.js:7:1266
      at /home/user/node-soap/lib/wsdl/index.js:94:1691
      at WSDL.callback (lib/wsdl/index.js:94:925)
      at /home/user/node-soap/lib/wsdl/index.js:9:156
      at /home/user/node-soap/lib/wsdl/index.js:94:1691
      at WSDL._processNextInclude (lib/wsdl/index.js:93:997)
      at WSDL.<anonymous> (lib/wsdl/index.js:94:1605)
      at open_wsdl_recursive (lib/wsdl/index.js:102:1196)
      at WSDL._processNextInclude (lib/wsdl/index.js:94:751)
      at WSDL.processIncludes (lib/wsdl/index.js:9:801)
      at /home/user/node-soap/lib/wsdl/index.js:7:1112
      at process.processTicksAndRejections (node:internal/process/task_queues:77:11)

  5) Request Response Sampling
       correct namespaces for elements with base ignorednamespaces:
     Uncaught TypeError: Cannot read properties of undefined (reading 'UpdateProfile')
      at /home/user/node-soap/test/request-response-samples-test.js:197:26
      at /home/user/node-soap/lib/soap.js:5:10271
      at WSDL.callback (lib/soap.js:5:8257)
      at /home/user/node-soap/lib/wsdl/index.js:7:1266
      at /home/user/node-soap/lib/wsdl/index.js:94:1691
      at WSDL.callback (lib/wsdl/index.js:94:925)
      at /home/user/node-soap/lib/wsdl/index.js:9:156
      at /home/user/node-soap/lib/wsdl/index.js:94:1691
      at WSDL._processNextInclude (lib/wsdl/index.js:93:997)
      at WSDL.<anonymous> (lib/wsdl/index.js:94:1605)
      at open_wsdl_recursive (lib/wsdl/index.js:102:1196)
      at WSDL._processNextInclude (lib/wsdl/index.js:94:751)
      at WSDL.processIncludes (lib/wsdl/index.js:9:801)
      at /home/user/node-soap/lib/wsdl/index.js:7:1112
      at process.processTicksAndRejections (node:internal/process/task_queues:77:11)

  6) Request Response Sampling
       correct namespaces for elements with base:
     Uncaught TypeError: Cannot read properties of undefined (reading 'UpdateProfile')
      at /home/user/node-soap/test/request-response-samples-test.js:197:26
      at /home/user/node-soap/lib/soap.js:5:10271
      at WSDL.callback (lib/soap.js:5:8257)
      at /home/user/node-soap/lib/wsdl/index.js:7:1266
      at /home/user/node-soap/lib/wsdl/index.js:94:1691
      at WSDL.callback (lib/wsdl/index.js:94:925)
      at /home/user/node-soap/lib/wsdl/index.js:9:156
      at /home/user/node-soap/lib/wsdl/index.js:94:1691
      at WSDL._processNextInclude (lib/wsdl/index.js:93:997)
      at WSDL.<anonymous> (lib/wsdl/index.js:94:1605)
      at open_wsdl_recursive (lib/wsdl/index.js:102:1196)
      at WSDL._processNextInclude (lib/wsdl/index.js:94:751)
      at WSDL.processIncludes (lib/wsdl/index.js:9:801)
      at /home/user/node-soap/lib/wsdl/index.js:7:1112
      at process.processTicksAndRejections (node:internal/process/task_queues:77:11)

```</s>